### PR TITLE
Make SubstVec*-helpers not to create unnecessary VO/VVO/VOCs

### DIFF
--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -341,17 +341,23 @@ fn functions_modifying_args(
             :ruleset {ruleset})"
     ));
 
-
     for vectypebase in ["VecOperandBase", "VecVecOperandBase"] {
         let fname_vec_base = func_name_fmt.replace("{}", vectypebase);
-        res.push(format!("(relation {fname_vec_base}-helper ({vectypebase} {aux_params_str} i64 {vectypebase}))"))
+        res.push(format!(
+            "(relation {fname_vec_base}-helper ({vectypebase} {aux_params_str} i64 {vectypebase}))"
+        ))
     }
 
     // Rules to compute on VecOperand
     for (vectype, vectypebase, ctor, eltype) in [
         ("VecOperand", "VecOperandBase", "VO", "Operand"),
         ("VecOperandCtx", "VecOperandBase", "VOC", "Operand"),
-        ("VecVecOperandCtx", "VecVecOperandBase", "VVO", "VecOperandCtx"),
+        (
+            "VecVecOperandCtx",
+            "VecVecOperandBase",
+            "VVO",
+            "VecOperandCtx",
+        ),
     ] {
         let fname_vec = func_name_fmt.replace("{}", vectype);
         let fname_vec_base = func_name_fmt.replace("{}", vectypebase);
@@ -359,52 +365,22 @@ fn functions_modifying_args(
         // rtjoa: TODO: implement by mapping internally so they're not O(n^2) time
         res.push(format!(
             "
-<<<<<<< HEAD
-            ;(function {fname_vec}-helper ({vectype} {aux_params_str} i64) {vectype})
-            ;(rewrite
-            ;    ({fname_vec} vec {aux_args_str})
-            ;    ({fname_vec}-helper vec {aux_args_str} 0)
-            ;    :ruleset {ruleset})
-            ;(rule
-            ;    ((= f ({fname_vec}-helper ({ctor} vec) {aux_args_str} i))
-            ;     (< i (vec-length vec)))
-            ;    ((union
-            ;        ({fname_vec}-helper ({ctor} vec) {aux_args_str} i)
-            ;        ({fname_vec}-helper
-            ;            ({ctor} (vec-set vec i ({fname_eltype} (vec-get vec i) {aux_args_str})))
-            ;            {aux_args_str} (+ i 1))))
-            ;    :ruleset {ruleset})
-            ;(rule
-            ;    ((= f ({fname_vec}-helper ({ctor} vec) {aux_args_str} i))
-            ;     (= i (vec-length vec)))
-            ;    ((union
-            ;        ({fname_vec}-helper ({ctor} vec) {aux_args_str} i)
-            ;        ({ctor} vec)))
-            ;    :ruleset {ruleset})
-
-            (rule ((= f ({fname_vec} ({ctor} vec) {aux_args_str}))) 
+            (rule (({fname_vec} ({ctor} vec) {aux_args_str})) 
                   (({fname_vec_base}-helper vec {aux_args_str} 0 vec)) :ruleset {ruleset})
 
-=======
-            (function {fname_vec}-helper ({vectype} {aux_params_str} i64) {vectype} :unextractable)
-            (rewrite
-                ({fname_vec} vec {aux_args_str})
-                ({fname_vec}-helper vec {aux_args_str} 0)
-                :ruleset {ruleset})
->>>>>>> main
             (rule
                 (({fname_vec_base}-helper vec {aux_args_str} i vec_out)
                  (< i (vec-length vec)))
-                (
-                    ({fname_vec_base}-helper
-                        vec {aux_args_str} (+ i 1) (vec-set vec_out i ({fname_eltype} (vec-get vec_out i) {aux_args_str}))) )
+                (({fname_vec_base}-helper
+                            vec {aux_args_str} (+ i 1) (vec-set vec_out i ({fname_eltype} (vec-get vec_out i) {aux_args_str}))) )
                 :ruleset {ruleset})
             (rule
-                ((= f ({fname_vec_base}-helper vec {aux_args_str} i vec_out))
-                 (= i (vec-length vec)))
+                (({fname_vec_base}-helper vec {aux_args_str} i vec_out)
+                 (= i (vec-length vec))
+                 ({fname_vec} ({ctor} vec) {aux_args_str}))
                 ((union
                     ({ctor} vec_out)
-                    ({ctor} vec)))
+                    ({fname_vec} ({ctor} vec) {aux_args_str})))
                 :ruleset {ruleset})"
         ));
     }

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use super::BRIL_OPS;
 
 /// "subst-beneath" rules support replacing a specific {Expr, Body, Operand,
@@ -339,36 +341,61 @@ fn functions_modifying_args(
             :ruleset {ruleset})"
     ));
 
+
+    for vectypebase in ["VecOperandBase", "VecVecOperandBase"] {
+        let fname_vec_base = func_name_fmt.replace("{}", vectypebase);
+        res.push(format!("(relation {fname_vec_base}-helper ({vectypebase} {aux_params_str} i64 {vectypebase}))"))
+    }
+
     // Rules to compute on VecOperand
-    for (vectype, ctor, eltype) in [
-        ("VecOperand", "VO", "Operand"),
-        ("VecOperandCtx", "VOC", "Operand"),
-        ("VecVecOperandCtx", "VVO", "VecOperandCtx"),
+    for (vectype, vectypebase, ctor, eltype) in [
+        ("VecOperand", "VecOperandBase", "VO", "Operand"),
+        ("VecOperandCtx", "VecOperandBase", "VOC", "Operand"),
+        ("VecVecOperandCtx", "VecVecOperandBase", "VVO", "VecOperandCtx"),
     ] {
         let fname_vec = func_name_fmt.replace("{}", vectype);
+        let fname_vec_base = func_name_fmt.replace("{}", vectypebase);
         let fname_eltype = func_name_fmt.replace("{}", eltype);
         // rtjoa: TODO: implement by mapping internally so they're not O(n^2) time
         res.push(format!(
             "
-            (function {fname_vec}-helper ({vectype} {aux_params_str} i64) {vectype})
-            (rewrite
-                ({fname_vec} vec {aux_args_str})
-                ({fname_vec}-helper vec {aux_args_str} 0)
-                :ruleset {ruleset})
+            ;(function {fname_vec}-helper ({vectype} {aux_params_str} i64) {vectype})
+            ;(rewrite
+            ;    ({fname_vec} vec {aux_args_str})
+            ;    ({fname_vec}-helper vec {aux_args_str} 0)
+            ;    :ruleset {ruleset})
+            ;(rule
+            ;    ((= f ({fname_vec}-helper ({ctor} vec) {aux_args_str} i))
+            ;     (< i (vec-length vec)))
+            ;    ((union
+            ;        ({fname_vec}-helper ({ctor} vec) {aux_args_str} i)
+            ;        ({fname_vec}-helper
+            ;            ({ctor} (vec-set vec i ({fname_eltype} (vec-get vec i) {aux_args_str})))
+            ;            {aux_args_str} (+ i 1))))
+            ;    :ruleset {ruleset})
+            ;(rule
+            ;    ((= f ({fname_vec}-helper ({ctor} vec) {aux_args_str} i))
+            ;     (= i (vec-length vec)))
+            ;    ((union
+            ;        ({fname_vec}-helper ({ctor} vec) {aux_args_str} i)
+            ;        ({ctor} vec)))
+            ;    :ruleset {ruleset})
+
+            (rule ((= f ({fname_vec} ({ctor} vec) {aux_args_str}))) 
+                  (({fname_vec_base}-helper vec {aux_args_str} 0 vec)) :ruleset {ruleset})
+
             (rule
-                ((= f ({fname_vec}-helper ({ctor} vec) {aux_args_str} i))
+                (({fname_vec_base}-helper vec {aux_args_str} i vec_out)
                  (< i (vec-length vec)))
-                ((union
-                    ({fname_vec}-helper ({ctor} vec) {aux_args_str} i)
-                    ({fname_vec}-helper
-                        ({ctor} (vec-set vec i ({fname_eltype} (vec-get vec i) {aux_args_str})))
-                        {aux_args_str} (+ i 1))))
+                (
+                    ({fname_vec_base}-helper
+                        vec {aux_args_str} (+ i 1) (vec-set vec_out i ({fname_eltype} (vec-get vec_out i) {aux_args_str}))) )
                 :ruleset {ruleset})
             (rule
-                ((= f ({fname_vec}-helper ({ctor} vec) {aux_args_str} i))
+                ((= f ({fname_vec_base}-helper vec {aux_args_str} i vec_out))
                  (= i (vec-length vec)))
                 ((union
-                    ({fname_vec}-helper ({ctor} vec) {aux_args_str} i)
+                    ({ctor} vec_out)
                     ({ctor} vec)))
                 :ruleset {ruleset})"
         ));

--- a/tests/snapshots/files__range_check-rvsdg-optimize.snap
+++ b/tests/snapshots/files__range_check-rvsdg-optimize.snap
@@ -7,8 +7,8 @@ expression: visualization.result
   v4: int = id v2;
   jmp .__6__;
 .__27__:
-  v28: int = const 1;
-  v31: int = add v28 v4;
+  v29: int = const 1;
+  v31: int = add v4 v29;
   v34: int = const 6;
   v36: bool = lt v4 v34;
   v4: int = id v31;

--- a/tests/snapshots/files__range_splitting-rvsdg-optimize.snap
+++ b/tests/snapshots/files__range_splitting-rvsdg-optimize.snap
@@ -10,7 +10,7 @@ expression: visualization.result
 .__9__:
   v8: int = const 1;
   print v8;
-  v14: int = add v8 v6;
+  v14: int = add v6 v8;
   v17: int = const 5;
   v19: bool = lt v14 v17;
   v6: int = id v14;


### PR DESCRIPTION
Last Tuesday in hackathon we found that VecOperand-get table's rules are firing too many times in some cases, which implies too many VOs are created. A possible cause is subst's helper methods are creating VO/VVOs every iteration. This PR changes the helper only creating new VOBases in iterations. 

actually it reduces test time by about 1s on my computer.
<img width="134" alt="image" src="https://github.com/egraphs-good/eggcc/assets/93016614/68bcb927-e98d-42c7-a0a7-a4f4690fb3b8">
<img width="155" alt="image" src="https://github.com/egraphs-good/eggcc/assets/93016614/cae6494c-4f40-4d25-842c-4c3fa5ff597b">


and it makes the (repeat 1000 subst) in mod.rs line 78 able to saturate, though IDK if it's good idea to make it saturate.