### PR TITLE
Unique args switch rewrites

### DIFF
--- a/uniqueargs/src/deep_copy.egg
+++ b/uniqueargs/src/deep_copy.egg
@@ -19,7 +19,8 @@
 ;;     DeepCopy vectors
 (rewrite (DeepCopy (EVec (vec-of)) id) (EVec (vec-of)) :ruleset repairs)
 (rule
-  ((= lhs (DeepCopy (EVec vec) id)))
+  ((= lhs (DeepCopy (EVec vec) id))
+   (> (vec-length vec) 0))
   ((let last (vec-get vec (- (vec-length vec) 1)))
    (let rest (vec-pop vec))
    (union lhs

--- a/uniqueargs/src/deep_copy.egg
+++ b/uniqueargs/src/deep_copy.egg
@@ -1,23 +1,23 @@
 ;; Rename all arguments under the input Expr to have a new Id
 ;; preserves all equalities, and propogates them in the future.
-(function DeepCopy (Expr Id) Expr)
+(function DeepCopy (Expr Id) Expr :unextractable)
 
 ;; leaves get the new id
-(rewrite (DeepCopy (Arg id i) newid) (Arg newid i))
-(rewrite (DeepCopy (Num id num) newid) (Num newid num))
-(rewrite (DeepCopy (Bool id b) newid) (Bool newid b))
+(rewrite (DeepCopy (Arg id i)  newid) (Arg newid i)  :ruleset repairs)
+(rewrite (DeepCopy (Num id n)  newid) (Num newid n)  :ruleset repairs)
+(rewrite (DeepCopy (Bool id b) newid) (Bool newid b) :ruleset repairs)
 
-(rewrite (DeepCopy (badd a b) id) (badd (DeepCopy a id) (DeepCopy b id)))
-(rewrite (DeepCopy (bsub a b) id) (bsub (DeepCopy a id) (DeepCopy b id)))
-(rewrite (DeepCopy (bmul a b) id) (bmul (DeepCopy a id) (DeepCopy b id)))
-(rewrite (DeepCopy (blt a b) id) (blt (DeepCopy a id) (DeepCopy b id)))
-(rewrite (DeepCopy (band a b) id) (band (DeepCopy a id) (DeepCopy b id)))
-(rewrite (DeepCopy (bor a b) id) (bor (DeepCopy a id) (DeepCopy b id)))
+(rewrite (DeepCopy (badd a b) id) (badd (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
+(rewrite (DeepCopy (bsub a b) id) (bsub (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
+(rewrite (DeepCopy (bmul a b) id) (bmul (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
+(rewrite (DeepCopy (blt  a b) id) (blt  (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
+(rewrite (DeepCopy (band a b) id) (band (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
+(rewrite (DeepCopy (bor  a b) id) (bor  (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
 
-(rewrite (DeepCopy (PRINT a b) id) (PRINT (DeepCopy a id) (DeepCopy b id)))
+(rewrite (DeepCopy (PRINT a b) id) (PRINT (DeepCopy a id) (DeepCopy b id)) :ruleset repairs)
 
 ;;     DeepCopy vectors
-(rewrite (DeepCopy (EVec (vec-of)) id) (EVec (vec-of)))
+(rewrite (DeepCopy (EVec (vec-of)) id) (EVec (vec-of)) :ruleset repairs)
 (rule
   ((= lhs (DeepCopy (EVec vec) id)))
   ((let last (vec-get vec (- (vec-length vec) 1)))
@@ -25,7 +25,8 @@
    (union lhs
      (VecPush
        (DeepCopy (EVec rest) id)
-       (DeepCopy last id)))))
+       (DeepCopy last id))))
+  :ruleset repairs)
 
 ;; Deepcopy regions
 ;; do nothing if the new id is the old
@@ -37,7 +38,8 @@
     (Loop inner-id
       (DeepCopy pred inner-id)
       (DeepCopy inputs outer-id)
-      (DeepCopy outputs inner-id)))))
+      (DeepCopy outputs inner-id))))
+ :ruleset repairs)
 (rule
  ((= lhs (DeepCopy (Switch id pred inputs outputs) outer-id)))
  ((let inner-id (id (i64-fresh!)))
@@ -45,4 +47,5 @@
     (Switch inner-id
       (DeepCopy pred outer-id)
       (DeepCopy inputs outer-id)
-      (DeepCopy outputs inner-id)))))
+      (DeepCopy outputs inner-id))))
+ :ruleset repairs)

--- a/uniqueargs/src/deep_copy.egg
+++ b/uniqueargs/src/deep_copy.egg
@@ -1,7 +1,3 @@
-;; Delayed vec-push utility
-(function VecPush (Expr Expr) Expr :unextractable)
-(rewrite (VecPush (EVec vec) last) (EVec (vec-push vec last)))
-
 ;; Rename all arguments under the input Expr to have a new Id
 ;; preserves all equalities, and propogates them in the future.
 (function DeepCopy (Expr Id) Expr)

--- a/uniqueargs/src/main.rs
+++ b/uniqueargs/src/main.rs
@@ -1,23 +1,31 @@
-use egglog::EGraph;
+// Rust test modules
+// If you don't put your Rust file here it won't get compiled!
+mod switch_rewrites;
 
-fn main() {
-    let program = vec![
-        // headers
-        include_str!("schema.egg"),
-        include_str!("util.egg"),
-        include_str!("deep_copy.egg"),
-        // analyses
-        // optimizations
-        include_str!("switch_rewrites.egg"),
-        // execution
+pub type Result = std::result::Result<(), egglog::Error>;
+
+pub fn run_test(a: &str, b: &str) -> Result {
+    let program = format!(
+        "
+        {}
+        (let test_a {a})
+        (let test_b {b})
+        {}
+        (check (= test_a test_b))",
+        vec![
+            include_str!("schema.egg"),
+            // analyses
+            // repairs
+            include_str!("util.egg"),
+            include_str!("deep_copy.egg"),
+            // optimizations
+            include_str!("switch_rewrites.egg"),
+        ]
+        .join("\n"),
         include_str!("schedule.egg"),
-        include_str!("tests.egg"),
-    ]
-    .join("\n");
+    );
 
-    let mut egraph = EGraph::default();
-    match egraph.parse_and_run_program(&program) {
-        Ok(_) => println!("Success!"),
-        Err(e) => println!("Error: {}", e),
-    }
+    egglog::EGraph::default()
+        .parse_and_run_program(&program)
+        .map(|_| ())
 }

--- a/uniqueargs/src/main.rs
+++ b/uniqueargs/src/main.rs
@@ -6,6 +6,7 @@ fn main() {
         include_str!("schema.egg"),
         include_str!("util.egg"),
         include_str!("deep_copy.egg"),
+        // analyses
         // optimizations
         include_str!("switch_rewrites.egg"),
         // execution

--- a/uniqueargs/src/main.rs
+++ b/uniqueargs/src/main.rs
@@ -4,14 +4,9 @@ mod switch_rewrites;
 
 pub type Result = std::result::Result<(), egglog::Error>;
 
-pub fn run_test(a: &str, b: &str) -> Result {
+pub fn run_test(build: &str, check: &str) -> Result {
     let program = format!(
-        "
-        {}
-        (let test_a {a})
-        (let test_b {b})
-        {}
-        (check (= test_a test_b))",
+        "{}\n{build}\n{}\n{check}\n",
         vec![
             include_str!("schema.egg"),
             // analyses

--- a/uniqueargs/src/main.rs
+++ b/uniqueargs/src/main.rs
@@ -4,6 +4,7 @@ fn main() {
     let program = vec![
         // header
         include_str!("schema.egg"),
+        include_str!("util.egg"),
         include_str!("deep_copy.egg"),
         // optimizations
         include_str!("switch_rewrites.egg"),

--- a/uniqueargs/src/main.rs
+++ b/uniqueargs/src/main.rs
@@ -2,7 +2,7 @@ use egglog::EGraph;
 
 fn main() {
     let program = vec![
-        // header
+        // headers
         include_str!("schema.egg"),
         include_str!("util.egg"),
         include_str!("deep_copy.egg"),

--- a/uniqueargs/src/schedule.egg
+++ b/uniqueargs/src/schedule.egg
@@ -1,3 +1,7 @@
 ; The main (run) statement for the egglog program
 
-(run 5)
+(run-schedule
+  (repeat 5
+    (saturate analyses)
+    (run)
+    (saturate repairs)))

--- a/uniqueargs/src/schema.egg
+++ b/uniqueargs/src/schema.egg
@@ -29,6 +29,10 @@
 (function Switch (Id Expr Expr Expr) Expr)
 ;; Name and a outputs: EVec
 (function Func (Id String Expr) Expr)
+
 ;; Arguments
 ;; Take the id of the region it is in, and an index for which argument to return
 (function Arg (Id i64) Expr)
+;; Projects
+;; Take a specific output of an Expr with multiple outputs
+(function Project (Expr i64) Expr)

--- a/uniqueargs/src/schema.egg
+++ b/uniqueargs/src/schema.egg
@@ -36,3 +36,7 @@
 ;; Projects
 ;; Take a specific output of an Expr with multiple outputs
 (function Project (Expr i64) Expr)
+
+;; Rulesets
+(ruleset analyses)
+(ruleset repairs)

--- a/uniqueargs/src/schema.egg
+++ b/uniqueargs/src/schema.egg
@@ -5,6 +5,8 @@
 
 ;; Every region gets a unique id
 (datatype Id (id i64))
+;; The id of the outermost region (used for tests)
+(let global-id (id (i64-fresh!)))
 
 ;; Pure expressions
 ;; Leaf nodes need ids to be unique for the region they 

--- a/uniqueargs/src/switch_rewrites.egg
+++ b/uniqueargs/src/switch_rewrites.egg
@@ -23,7 +23,7 @@
                           (PassThroughArgs inner-id args)
                           (EVec (vec-of (EVec B) (EVec A)))))
        (let outer (Switch outer-id
-                          (DeepCopy a inner-id)
+                          (DeepCopy a outer-id)
                           (EVec (vec-push inputs b)) ; pass b as an extra argument
                           (EVec (vec-of (EVec B)
                                         (ExprToEVec rets inner)))))
@@ -41,4 +41,20 @@
 ;;          A
 ;;      else:
 ;;          B
-
+(rule ((= switch (Switch id (bor a b) (EVec inputs) (EVec outputs)))
+       (= (vec-length outputs) 2)
+       (= (vec-get outputs 1) (EVec A))
+       (= (vec-get outputs 0) (EVec B))
+       (= (vec-length inputs) args)
+       (= (vec-length A)      rets))
+      ((let inner-id (id (i64-fresh!)))
+       (let outer-id (id (i64-fresh!)))
+       (let inner (Switch inner-id
+                          (Arg inner-id args) ; we pass b as an extra argument to the outer gamma
+                          (PassThroughArgs inner-id args)
+                          (EVec (vec-of (EVec B) (EVec A)))))
+       (let outer (Switch outer-id
+                          (DeepCopy a outer-id)
+                          (EVec (vec-push inputs b)) ; pass b as an extra argument
+                          (EVec (vec-of (ExprToEVec rets inner) (EVec A)))))
+       (union switch outer)))

--- a/uniqueargs/src/switch_rewrites.egg
+++ b/uniqueargs/src/switch_rewrites.egg
@@ -19,13 +19,13 @@
       ((let inner-id (id (i64-fresh!)))
        (let outer-id (id (i64-fresh!)))
        (let inner (Switch inner-id
-                          (Arg inner-id args) ; we pass b as an extra argument to the outer gamma
-                          (PassThroughArgs inner-id args)
-                          (EVec (vec-of (EVec B) (EVec A)))))
+                          (Arg outer-id args) ; we pass b as an extra argument to the outer gamma
+                          (PassThroughArgs outer-id args)
+                          (EVec (vec-of (DeepCopy (EVec B) inner-id) (DeepCopy (EVec A) inner-id)))))
        (let outer (Switch outer-id
-                          (DeepCopy a outer-id)
+                          a
                           (EVec (vec-push inputs b)) ; pass b as an extra argument
-                          (EVec (vec-of (EVec B)
+                          (EVec (vec-of (DeepCopy (EVec B) outer-id)
                                         (ExprToEVec rets inner)))))
        (union switch outer)))
 
@@ -50,11 +50,12 @@
       ((let inner-id (id (i64-fresh!)))
        (let outer-id (id (i64-fresh!)))
        (let inner (Switch inner-id
-                          (Arg inner-id args) ; we pass b as an extra argument to the outer gamma
-                          (PassThroughArgs inner-id args)
-                          (EVec (vec-of (EVec B) (EVec A)))))
+                          (Arg outer-id args) ; we pass b as an extra argument to the outer gamma
+                          (PassThroughArgs outer-id args)
+                          (EVec (vec-of (DeepCopy (EVec B) inner-id) (DeepCopy (EVec A) inner-id)))))
        (let outer (Switch outer-id
-                          (DeepCopy a outer-id)
+                          a
                           (EVec (vec-push inputs b)) ; pass b as an extra argument
-                          (EVec (vec-of (ExprToEVec rets inner) (EVec A)))))
+                          (EVec (vec-of (ExprToEVec rets inner)
+                                        (DeepCopy (EVec A) outer-id)))))
        (union switch outer)))

--- a/uniqueargs/src/switch_rewrites.egg
+++ b/uniqueargs/src/switch_rewrites.egg
@@ -10,6 +10,24 @@
 ;;          B
 ;;  else:
 ;;      B
+(rule ((= switch (Switch id (band a b) (EVec inputs) (EVec outputs)))
+       (= (vec-length outputs) 2)
+       (= (vec-get outputs 1) (EVec A))
+       (= (vec-get outputs 0) (EVec B))
+       (= (vec-length inputs) args)
+       (= (vec-length A)      rets))
+      ((let inner-id (id (i64-fresh!)))
+       (let outer-id (id (i64-fresh!)))
+       (let inner (Switch inner-id
+                          (Arg inner-id args) ; we pass b as an extra argument to the outer gamma
+                          (PassThroughArgs inner-id args)
+                          (EVec (vec-of (EVec B) (EVec A)))))
+       (let outer (Switch outer-id
+                          (DeepCopy a inner-id)
+                          (EVec (vec-push inputs b)) ; pass b as an extra argument
+                          (EVec (vec-of (EVec B)
+                                        (ExprToEVec rets inner)))))
+       (union switch outer)))
 
 ;;  if a || b:
 ;;      A

--- a/uniqueargs/src/switch_rewrites.rs
+++ b/uniqueargs/src/switch_rewrites.rs
@@ -2,9 +2,21 @@ pub use crate::*;
 
 #[test]
 fn switch_rewrite_and() -> Result {
-    let a = "(Num global-id 1)";
-    let b = "(Num global-id 2)";
-    run_test(a, b)
+    let build = "
+        (let test_a_id (id (i64-fresh!)))
+        (let test_a (Switch test_a_id
+                            (TODO)
+                            (TODO)
+                            (TODO)))
+
+        (let test_b_id (id (i64-fresh!)))
+        (let test_b (Switch test_b_id
+                            (TODO)
+                            (TODO)
+                            (TODO)))
+    ";
+    let check = "(check (= test_a test_b))";
+    run_test(build, check)
 }
 
 #[test]

--- a/uniqueargs/src/switch_rewrites.rs
+++ b/uniqueargs/src/switch_rewrites.rs
@@ -3,23 +3,66 @@ pub use crate::*;
 #[test]
 fn switch_rewrite_and() -> Result {
     let build = "
-        (let test_a_id (id (i64-fresh!)))
-        (let test_a (Switch test_a_id
-                            (TODO)
-                            (TODO)
-                            (TODO)))
-
-        (let test_b_id (id (i64-fresh!)))
-        (let test_b (Switch test_b_id
-                            (TODO)
-                            (TODO)
-                            (TODO)))
+        (let test-a-id (id (i64-fresh!)))
+        (let test-a (Switch
+            test-a-id
+            (band (Bool global-id false) (Bool global-id true))
+            (EVec (vec-of))
+            (EVec (vec-of
+                (EVec (vec-of (Num test-a-id 2)))
+                (EVec (vec-of (Num test-a-id 1)))))))
     ";
-    let check = "(check (= test_a test_b))";
+    let check = "
+        (check (= test-a
+            (Switch
+                test-b-id
+                (Bool global-id false)
+                (EVec (vec-of (Bool global-id true)))
+                (EVec (vec-of
+                    (EVec (vec-of (Num test-b-id 2)))
+                    (EVec (vec-of (Project (Switch
+                        test-c-id
+                        (Arg test-b-id 0)
+                        (EVec (vec-of))
+                        (EVec (vec-of
+                            (EVec (vec-of (Num test-c-id 2)))
+                            (EVec (vec-of (Num test-c-id 1)))))
+                    ) 0)))))
+            )))
+    ";
     run_test(build, check)
 }
 
 #[test]
 fn switch_rewrite_or() -> Result {
-    todo!()
+    let build = "
+        (let test-a-id (id (i64-fresh!)))
+        (let test-a (Switch
+            test-a-id
+            (bor (Bool global-id false) (Bool global-id true))
+            (EVec (vec-of))
+            (EVec (vec-of
+                (EVec (vec-of (Num test-a-id 2)))
+                (EVec (vec-of (Num test-a-id 1)))))))
+    ";
+    let check = "
+        (check (= test-a
+            (Switch
+                test-b-id
+                (Bool global-id false)
+                (EVec (vec-of (Bool global-id true)))
+                (EVec (vec-of
+                    (EVec (vec-of (Project (Switch
+                        test-c-id
+                        (Arg test-b-id 0)
+                        (EVec (vec-of))
+                        (EVec (vec-of
+                            (EVec (vec-of (Num test-c-id 2)))
+                            (EVec (vec-of (Num test-c-id 1)))))
+                    ) 0)))
+                    (EVec (vec-of (Num test-b-id 1)))
+                ))
+            )))
+    ";
+    run_test(build, check)
 }

--- a/uniqueargs/src/switch_rewrites.rs
+++ b/uniqueargs/src/switch_rewrites.rs
@@ -1,0 +1,13 @@
+pub use crate::*;
+
+#[test]
+fn switch_rewrite_and() -> Result {
+    let a = "(Num global-id 1)";
+    let b = "(Num global-id 2)";
+    run_test(a, b)
+}
+
+#[test]
+fn switch_rewrite_or() -> Result {
+    todo!()
+}

--- a/uniqueargs/src/tests.egg
+++ b/uniqueargs/src/tests.egg
@@ -1,1 +1,0 @@
-; Put (check) statements in this file

--- a/uniqueargs/src/util.egg
+++ b/uniqueargs/src/util.egg
@@ -4,17 +4,19 @@
 
 ;; (how many arguments to generate, vector so far)
 (function PassThroughArgsHelper (Id i64 EVecBase) Expr :unextractable)
-(rewrite (PassThroughArgs id i) (PassThroughArgsHelper id i (vec-of)))
+(rewrite (PassThroughArgs id i) (PassThroughArgsHelper id i (vec-of)) :ruleset repairs)
 
 (rule ((= lhs (PassThroughArgsHelper id i rest))
        (< (vec-length rest) i))
       ((union lhs
         (PassThroughArgsHelper id i
-            (vec-push rest (Arg id (vec-length rest)))))))
+            (vec-push rest (Arg id (vec-length rest))))))
+      :ruleset repairs)
 
 (rule ((= lhs (PassThroughArgsHelper id i rest))
        (= (vec-length rest) i))
-      ((union lhs (EVec rest))))
+      ((union lhs (EVec rest)))
+      :ruleset repairs)
 
 ;; Creates a vec of Projects out of a body
 ;; (vec-of (Project body 0) (Project body 1) ...) with length i
@@ -23,17 +25,19 @@
 ;; current index, body length, body, and vector so far
 (function ExprToEVecHelper (i64 i64 Expr EVecBase) Expr :unextractable)
 (rewrite (ExprToEVec body-len body)
-         (ExprToEVecHelper 0 body-len body (vec-of)))
+         (ExprToEVecHelper 0 body-len body (vec-of))
+         :ruleset repairs)
 
 (rule
   ((= helper (ExprToEVecHelper index body-len body so-far))
    (< index body-len))
   ((union helper
           (ExprToEVecHelper (+ index 1) body-len body
-                                  (vec-push so-far (Project body index))))))
+                                  (vec-push so-far (Project body index)))))
+  :ruleset repairs)
 
-(rewrite (ExprToEVecHelper index-=-len index-=-len body so-far) (EVec so-far))
+(rewrite (ExprToEVecHelper body-len body-len body so-far) (EVec so-far) :ruleset repairs)
 
 ;; Delayed vec-push utility
 (function VecPush (Expr Expr) Expr :unextractable)
-(rewrite (VecPush (EVec vec) last) (EVec (vec-push vec last)))
+(rewrite (VecPush (EVec vec) last) (EVec (vec-push vec last)) :ruleset repairs)

--- a/uniqueargs/src/util.egg
+++ b/uniqueargs/src/util.egg
@@ -33,3 +33,7 @@
                                   (vec-push so-far (Project body index))))))
 
 (rewrite (ExprToEVecHelper index-=-len index-=-len body so-far) (EVec so-far))
+
+;; Delayed vec-push utility
+(function VecPush (Expr Expr) Expr :unextractable)
+(rewrite (VecPush (EVec vec) last) (EVec (vec-push vec last)))

--- a/uniqueargs/src/util.egg
+++ b/uniqueargs/src/util.egg
@@ -1,0 +1,35 @@
+;; Creates a vec of Args with some Id
+;; (vec-of (Arg id 0) (Arg id 1) ...) with length i
+(function PassThroughArgs (Id i64) Expr :unextractable)
+
+;; (how many arguments to generate, vector so far)
+(function PassThroughArgsHelper (Id i64 EVecBase) Expr :unextractable)
+(rewrite (PassThroughArgs id i) (PassThroughArgsHelper id i (vec-of)))
+
+(rule ((= lhs (PassThroughArgsHelper id i rest))
+       (< (vec-length rest) i))
+      ((union lhs
+        (PassThroughArgsHelper id i
+            (vec-push rest (Arg id (vec-length rest)))))))
+
+(rule ((= lhs (PassThroughArgsHelper id i rest))
+       (= (vec-length rest) i))
+      ((union lhs (EVec rest))))
+
+;; Creates a vec of Projects out of a body
+;; (vec-of (Project body 0) (Project body 1) ...) with length i
+(function ExprToEVec (i64 Expr) Expr :unextractable)
+
+;; current index, body length, body, and vector so far
+(function ExprToEVecHelper (i64 i64 Expr EVecBase) Expr :unextractable)
+(rewrite (ExprToEVec body-len body)
+         (ExprToEVecHelper 0 body-len body (vec-of)))
+
+(rule
+  ((= helper (ExprToEVecHelper index body-len body so-far))
+   (< index body-len))
+  ((union helper
+          (ExprToEVecHelper (+ index 1) body-len body
+                                  (vec-push so-far (Project body index))))))
+
+(rewrite (ExprToEVecHelper index-=-len index-=-len body so-far) (EVec so-far))


### PR DESCRIPTION
This PR adds the two switch optimizations that simplify predicates.

It also contains a bunch of refactors, such as adding saturated rulesets and creating a `util.egg` file.

It also makes `DeepCopy` `unextractable`; I believe this is correct but would like to double check.

Currently missing tests.