### PR TITLE
[Tree unique] IR enums and purity analysis

### DIFF
--- a/tree_unique_args/Cargo.toml
+++ b/tree_unique_args/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tree_unique_args"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# add fresh i64 branch
+egglog = { git = "https://github.com/oflatt/egg-smol", rev = "057725d9353727d831c90c7f8fdd76954d06b351" }

--- a/tree_unique_args/src/ir.rs
+++ b/tree_unique_args/src/ir.rs
@@ -1,0 +1,78 @@
+#[allow(dead_code)]
+
+pub(crate) enum Sort {
+    Expr,
+    ListExpr,
+    Order,
+    I64,
+    Bool,
+}
+
+impl Sort {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Sort::Expr => "Expr",
+            Sort::ListExpr => "ListExpr",
+            Sort::Order => "Order",
+            Sort::I64 => "i64",
+            Sort::Bool => "bool",
+        }
+    }
+}
+
+pub(crate) enum Constructor {
+    Num,
+    Add,
+    Print,
+    Loop,
+    Cons,
+    Nil,
+}
+
+impl Constructor {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Constructor::Num => "Num",
+            Constructor::Add => "Add",
+            Constructor::Print => "Print",
+            Constructor::Loop => "Loop",
+            Constructor::Cons => "Cons",
+            Constructor::Nil => "Nil",
+        }
+    }
+
+    pub(crate) fn param_sorts(&self) -> Vec<Sort> {
+        match self {
+            Constructor::Num => vec![Sort::I64],
+            Constructor::Add => vec![Sort::Expr, Sort::Expr],
+            Constructor::Print => vec![Sort::Expr],
+            Constructor::Loop => vec![Sort::I64, Sort::Expr, Sort::Expr],
+            Constructor::Cons => vec![Sort::Expr, Sort::ListExpr],
+            Constructor::Nil => vec![],
+        }
+    }
+
+    pub(crate) fn sort(&self) -> Sort {
+        match self {
+            Constructor::Num => Sort::Expr,
+            Constructor::Add => Sort::Expr,
+            Constructor::Print => Sort::Expr,
+            Constructor::Loop => Sort::Expr,
+            Constructor::Cons => Sort::ListExpr,
+            Constructor::Nil => Sort::ListExpr,
+        }
+    }
+
+    pub(crate) fn num_params(&self) -> usize {
+        self.param_sorts().len()
+    }
+}
+
+pub(crate) const CONSTRUCTORS: [Constructor; 6] = [
+    Constructor::Num,
+    Constructor::Add,
+    Constructor::Print,
+    Constructor::Loop,
+    Constructor::Cons,
+    Constructor::Nil,
+];

--- a/tree_unique_args/src/ir.rs
+++ b/tree_unique_args/src/ir.rs
@@ -1,5 +1,3 @@
-#[allow(dead_code)]
-
 pub(crate) enum Sort {
     Expr,
     ListExpr,
@@ -22,9 +20,25 @@ impl Sort {
 
 pub(crate) enum Constructor {
     Num,
+    Boolean,
+    UnitExpr,
     Add,
+    Sub,
+    Mul,
+    LessThan,
+    And,
+    Or,
+    Not,
+    Get,
     Print,
+    Read,
+    Write,
+    All,
+    Switch,
     Loop,
+    Body,
+    Arg,
+    Call,
     Cons,
     Nil,
 }
@@ -33,9 +47,25 @@ impl Constructor {
     pub(crate) fn name(&self) -> &'static str {
         match self {
             Constructor::Num => "Num",
+            Constructor::Boolean => "Boolean",
+            Constructor::UnitExpr => "UnitExpr",
             Constructor::Add => "Add",
+            Constructor::Sub => "Sub",
+            Constructor::Mul => "Mul",
+            Constructor::LessThan => "LessThan",
+            Constructor::And => "And",
+            Constructor::Or => "Or",
+            Constructor::Not => "Not",
+            Constructor::Get => "Get",
             Constructor::Print => "Print",
+            Constructor::Read => "Read",
+            Constructor::Write => "Write",
+            Constructor::All => "All",
+            Constructor::Switch => "Switch",
             Constructor::Loop => "Loop",
+            Constructor::Body => "Body",
+            Constructor::Arg => "Arg",
+            Constructor::Call => "Call",
             Constructor::Cons => "Cons",
             Constructor::Nil => "Nil",
         }
@@ -44,9 +74,25 @@ impl Constructor {
     pub(crate) fn param_sorts(&self) -> Vec<Sort> {
         match self {
             Constructor::Num => vec![Sort::I64],
+            Constructor::Boolean => vec![Sort::Bool],
+            Constructor::UnitExpr => vec![],
             Constructor::Add => vec![Sort::Expr, Sort::Expr],
+            Constructor::Sub => vec![Sort::Expr, Sort::Expr],
+            Constructor::Mul => vec![Sort::Expr, Sort::Expr],
+            Constructor::LessThan => vec![Sort::Expr, Sort::Expr],
+            Constructor::And => vec![Sort::Expr, Sort::Expr],
+            Constructor::Or => vec![Sort::Expr, Sort::Expr],
+            Constructor::Not => vec![Sort::Expr],
+            Constructor::Get => vec![Sort::Expr, Sort::I64],
             Constructor::Print => vec![Sort::Expr],
+            Constructor::Read => vec![Sort::Expr],
+            Constructor::Write => vec![Sort::Expr, Sort::Expr],
+            Constructor::All => vec![Sort::Order, Sort::ListExpr],
+            Constructor::Switch => vec![Sort::Expr, Sort::ListExpr],
             Constructor::Loop => vec![Sort::I64, Sort::Expr, Sort::Expr],
+            Constructor::Body => vec![Sort::I64, Sort::Expr, Sort::Expr],
+            Constructor::Arg => vec![Sort::I64],
+            Constructor::Call => vec![Sort::I64, Sort::Expr],
             Constructor::Cons => vec![Sort::Expr, Sort::ListExpr],
             Constructor::Nil => vec![],
         }
@@ -55,9 +101,25 @@ impl Constructor {
     pub(crate) fn sort(&self) -> Sort {
         match self {
             Constructor::Num => Sort::Expr,
+            Constructor::Boolean => Sort::Expr,
+            Constructor::UnitExpr => Sort::Expr,
             Constructor::Add => Sort::Expr,
+            Constructor::Sub => Sort::Expr,
+            Constructor::Mul => Sort::Expr,
+            Constructor::LessThan => Sort::Expr,
+            Constructor::And => Sort::Expr,
+            Constructor::Or => Sort::Expr,
+            Constructor::Not => Sort::Expr,
+            Constructor::Get => Sort::Expr,
             Constructor::Print => Sort::Expr,
+            Constructor::Read => Sort::Expr,
+            Constructor::Write => Sort::Expr,
+            Constructor::All => Sort::Expr,
+            Constructor::Switch => Sort::Expr,
             Constructor::Loop => Sort::Expr,
+            Constructor::Body => Sort::Expr,
+            Constructor::Arg => Sort::Expr,
+            Constructor::Call => Sort::Expr,
             Constructor::Cons => Sort::ListExpr,
             Constructor::Nil => Sort::ListExpr,
         }
@@ -68,11 +130,27 @@ impl Constructor {
     }
 }
 
-pub(crate) const CONSTRUCTORS: [Constructor; 6] = [
+pub(crate) const CONSTRUCTORS: [Constructor; 22] = [
     Constructor::Num,
+    Constructor::Boolean,
+    Constructor::UnitExpr,
     Constructor::Add,
+    Constructor::Sub,
+    Constructor::Mul,
+    Constructor::LessThan,
+    Constructor::And,
+    Constructor::Or,
+    Constructor::Not,
+    Constructor::Get,
     Constructor::Print,
+    Constructor::Read,
+    Constructor::Write,
+    Constructor::All,
+    Constructor::Switch,
     Constructor::Loop,
+    Constructor::Body,
+    Constructor::Arg,
+    Constructor::Call,
     Constructor::Cons,
     Constructor::Nil,
 ];

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -1,0 +1,19 @@
+use egglog::EGraph;
+
+fn main() {
+    let program = vec![
+        // header
+        include_str!("schema.egg"),
+        // optimizations
+        // execution
+        include_str!("schedule.egg"),
+        include_str!("tests.egg"),
+    ]
+    .join("\n");
+
+    let mut egraph = EGraph::default();
+    match egraph.parse_and_run_program(&program) {
+        Ok(_) => println!("Success!"),
+        Err(e) => println!("Error: {}", e),
+    }
+}

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -1,19 +1,27 @@
-use egglog::EGraph;
+// Rust test modules
+// If you don't put your Rust file here it won't get compiled!
 
-fn main() {
-    let program = vec![
-        // header
-        include_str!("schema.egg"),
-        // optimizations
-        // execution
+pub type Result = std::result::Result<(), egglog::Error>;
+
+// Might be useful for typechecking?
+fn main() -> Result {
+    run_test("", "")
+}
+
+pub fn run_test(build: &str, check: &str) -> Result {
+    let program = format!(
+        "{}\n{build}\n{}\n{check}\n",
+        vec![
+            include_str!("schema.egg"),
+            // analyses
+            // repairs
+            // optimizations
+        ]
+        .join("\n"),
         include_str!("schedule.egg"),
-        include_str!("tests.egg"),
-    ]
-    .join("\n");
+    );
 
-    let mut egraph = EGraph::default();
-    match egraph.parse_and_run_program(&program) {
-        Ok(_) => println!("Success!"),
-        Err(e) => println!("Error: {}", e),
-    }
+    egglog::EGraph::default()
+        .parse_and_run_program(&program)
+        .map(|_| ())
 }

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -16,6 +16,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
         "{}\n{build}\n{}\n{check}\n",
         vec![
             include_str!("schema.egg"),
+            include_str!("sugar.egg"),
             // analyses
             &purity_analysis::purity_analysis_rules().join("\n"),
             // repairs

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -1,5 +1,8 @@
 // Rust test modules
 // If you don't put your Rust file here it won't get compiled!
+pub(crate) mod ir;
+pub(crate) mod purity_analysis;
+pub(crate) mod util;
 
 pub type Result = std::result::Result<(), egglog::Error>;
 
@@ -14,12 +17,15 @@ pub fn run_test(build: &str, check: &str) -> Result {
         vec![
             include_str!("schema.egg"),
             // analyses
+            &purity_analysis::purity_analysis_rules().join("\n"),
             // repairs
             // optimizations
         ]
         .join("\n"),
         include_str!("schedule.egg"),
     );
+
+    println!("{}", program);
 
     egglog::EGraph::default()
         .parse_and_run_program(&program)

--- a/tree_unique_args/src/purity_analysis.rs
+++ b/tree_unique_args/src/purity_analysis.rs
@@ -1,0 +1,79 @@
+use crate::ir::{Constructor, Sort, CONSTRUCTORS};
+use crate::util;
+
+enum Purity {
+    Pure,
+    Impure,
+    PureIfChildrenAre,
+}
+
+fn purity(ctor: &Constructor) -> Purity {
+    match ctor {
+        Constructor::Num => Purity::Pure,
+        Constructor::Add => Purity::PureIfChildrenAre,
+        Constructor::Print => Purity::Impure,
+        Constructor::Loop => Purity::PureIfChildrenAre,
+        Constructor::Cons => Purity::PureIfChildrenAre,
+        Constructor::Nil => Purity::Pure,
+    }
+}
+
+fn purity_queries(sort: &Sort, var: &str) -> Vec<String> {
+    match sort {
+        Sort::Bool => vec![],
+        Sort::I64 => vec![],
+        Sort::Order => vec![],
+        Sort::Expr | Sort::ListExpr => {
+            let sort_name = sort.name();
+            vec![format!("({sort_name}IsPure {var})")]
+        }
+    }
+}
+
+fn purity_rules_for_ctor(ctor: &Constructor) -> Vec<String> {
+    let name = ctor.name();
+    let sort_name = ctor.sort().name();
+    match purity(ctor) {
+        Purity::Pure => {
+            let args_vars = util::n_vars(ctor.num_params(), "arg");
+            let args_vars_s = args_vars.join(" ");
+            vec![format!(
+                "(rule (({name} {args_vars_s}))
+                       (({sort_name}IsPure ({name} {args_vars_s})))
+                       :ruleset fast-analyses)"
+            )]
+        }
+        Purity::PureIfChildrenAre => {
+            let args_vars = util::n_vars(ctor.num_params(), "arg");
+            let args_vars_s = args_vars.join(" ");
+            let args_purity_queries = ctor
+                .param_sorts()
+                .iter()
+                .zip(args_vars)
+                .map(|(sort, var)| purity_queries(sort, &var).join(" "))
+                .collect::<Vec<String>>()
+                .join(" ");
+            vec![format!(
+                "(rule (({name} {args_vars_s}) {args_purity_queries})
+                       (({sort_name}IsPure ({name} {args_vars_s})))
+                       :ruleset fast-analyses)"
+            )]
+        }
+        Purity::Impure => vec![],
+    }
+}
+
+pub(crate) fn purity_analysis_rules() -> Vec<String> {
+    let mut res: Vec<String> = vec![];
+    for sort in [Sort::Expr, Sort::ListExpr] {
+        let sort_name = sort.name();
+        res.push(format!("(relation {sort_name}IsPure ({sort_name}))"));
+    }
+    for ctor in CONSTRUCTORS {
+        match ctor.sort() {
+            Sort::Expr | Sort::ListExpr => res.extend(purity_rules_for_ctor(&ctor).into_iter()),
+            _ => (),
+        }
+    }
+    res
+}

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -2,6 +2,7 @@
 
 (run-schedule
   (repeat 5
+    (saturate desugar)
     (saturate fast-analyses)
     (run)
     (saturate subst)

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -2,7 +2,7 @@
 
 (run-schedule
   (repeat 5
-    (saturate analyses)
+    (saturate fast-analyses)
     (run)
     (saturate subst)
     (saturate repairs)))

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -1,0 +1,3 @@
+; The main (run) statement for the egglog program
+
+(run 5)

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -1,3 +1,8 @@
 ; The main (run) statement for the egglog program
 
-(run 5)
+(run-schedule
+  (repeat 5
+    (saturate analyses)
+    (run)
+    (saturate subst)
+    (saturate repairs)))

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -1,0 +1,69 @@
+(datatype Expr)
+(datatype ListExpr (cons Expr ListExpr) (nil))
+(datatype Id (id i64))
+
+; ==========================
+; Pure operators
+; ==========================
+
+(function num (i64) Expr)
+(function boolean (bool) Expr)
+(function unit () Expr)
+(function badd (Expr Expr) Expr)
+(function bsub (Expr Expr) Expr)
+(function bmul (Expr Expr) Expr)
+(function blt (Expr Expr) Expr)
+(function band (Expr Expr) Expr)
+(function bor (Expr Expr) Expr)
+(function bnot (Expr) Expr)
+(function get (Expr i64) Expr) ; gets from a tuple. static index
+
+; ==========================
+; Effectful operators
+; ==========================
+
+;                value      unit
+(function print (Expr)      Expr)
+;                addr       value
+(function read  (Expr)      Expr)
+;                addr value unit
+(function write (Expr Expr) Expr)
+
+; ==========================
+; Control flow operators
+; ==========================
+
+(datatype Order (parallel) (sequential))
+
+; Perform a list of operations. Only way to create a tuple!
+(function all (Order ListExpr) Expr)
+
+; Switch on a list of lazily-evaluated branches. Desn't create context
+;                 pred branches chosen
+(function switch (Expr ListExpr)    Expr)
+
+; ==========================
+; Regions
+; ==========================
+
+; pred and output are evaluated inside the loop's context
+; input and output may or may not be a tuples. pred must be boolean.
+; 
+;               id input (pred, output) tuple
+(function loop (Id Expr  Expr)  Expr)
+
+;               id input output
+(function body (Id Expr  Expr) Expr)
+
+; Arg gets the input of a region or the parameter of a function
+(function arg (Id) Expr)
+
+; ==========================
+; Functions
+; ==========================
+
+;                   f  output
+(relation Function (Id Expr))
+
+;               f  arg
+(function call (Id Expr) Expr)

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -67,3 +67,7 @@
 
 ;               f  arg
 (function call (Id Expr) Expr)
+
+;; Rulesets
+(ruleset analyses)
+(ruleset repairs)

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -38,7 +38,7 @@
 ; Perform a list of operations. Only way to create a tuple!
 (function all (Order ListExpr) Expr)
 
-; Switch on a list of lazily-evaluated branches. Desn't create context
+; Switch on a list of lazily-evaluated branches. Doesn't create context
 ;                 pred branches chosen
 (function switch (Expr ListExpr)    Expr)
 

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -68,6 +68,6 @@
 (function Call (i64 Expr) Expr)
 
 ;; Rulesets
-(ruleset analyses)
+(ruleset fast-analyses)
 (ruleset repairs)
 (ruleset subst)

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -1,46 +1,45 @@
 (datatype Expr)
-(datatype ListExpr (cons Expr ListExpr) (nil))
-(datatype Id (id i64))
+(datatype ListExpr (Cons Expr ListExpr) (Nil))
 
 ; ==========================
 ; Pure operators
 ; ==========================
 
-(function num (i64) Expr)
-(function boolean (bool) Expr)
-(function unit () Expr)
-(function badd (Expr Expr) Expr)
-(function bsub (Expr Expr) Expr)
-(function bmul (Expr Expr) Expr)
-(function blt (Expr Expr) Expr)
-(function band (Expr Expr) Expr)
-(function bor (Expr Expr) Expr)
-(function bnot (Expr) Expr)
-(function get (Expr i64) Expr) ; gets from a tuple. static index
+(function Num (i64) Expr)
+(function Boolean (bool) Expr)
+(function UnitExpr () Expr) ; Unit is already an egglog sort
+(function Add (Expr Expr) Expr)
+(function Sub (Expr Expr) Expr)
+(function Mul (Expr Expr) Expr)
+(function LessThan (Expr Expr) Expr)
+(function And (Expr Expr) Expr)
+(function Or (Expr Expr) Expr)
+(function Not (Expr) Expr)
+(function Get (Expr i64) Expr) ; gets from a tuple. static index
 
 ; ==========================
 ; Effectful operators
 ; ==========================
 
 ;                value      unit
-(function print (Expr)      Expr)
+(function Print (Expr)      Expr)
 ;                addr       value
-(function read  (Expr)      Expr)
+(function Read  (Expr)      Expr)
 ;                addr value unit
-(function write (Expr Expr) Expr)
+(function Write (Expr Expr) Expr)
 
 ; ==========================
 ; Control flow operators
 ; ==========================
 
-(datatype Order (parallel) (sequential))
+(datatype Order (Parallel) (Sequential))
 
 ; Perform a list of operations. Only way to create a tuple!
-(function all (Order ListExpr) Expr)
+(function All (Order ListExpr) Expr)
 
 ; Switch on a list of lazily-evaluated branches. Doesn't create context
 ;                 pred branches chosen
-(function switch (Expr ListExpr)    Expr)
+(function Switch (Expr ListExpr)    Expr)
 
 ; ==========================
 ; Regions
@@ -49,25 +48,26 @@
 ; pred and output are evaluated inside the loop's context
 ; input and output may or may not be a tuples. pred must be boolean.
 ; 
-;               id input (pred, output) tuple
-(function loop (Id Expr  Expr)  Expr)
+;               id  input (pred, output) tuple
+(function Loop (i64 Expr  Expr)  Expr)
 
-;               id input output
-(function body (Id Expr  Expr) Expr)
+;               id  input output
+(function Body (i64 Expr  Expr) Expr)
 
 ; Arg gets the input of a region or the parameter of a function
-(function arg (Id) Expr)
+(function Arg (i64) Expr)
 
 ; ==========================
 ; Functions
 ; ==========================
 
-;                   f  output
-(relation Function (Id Expr))
+;                   f   output
+(relation Function (i64 Expr))
 
-;               f  arg
-(function call (Id Expr) Expr)
+;               f   arg
+(function Call (i64 Expr) Expr)
 
 ;; Rulesets
 (ruleset analyses)
 (ruleset repairs)
+(ruleset subst)

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -1,0 +1,14 @@
+; Functoins useful for writing tests, but should not be matched on
+(ruleset desugar)
+
+(function Pair (Expr Expr) ListExpr)
+(rewrite (Pair a b)
+         (Cons a (Cons b (Nil)))
+         :ruleset desugar)
+
+(function IgnoreFirst (Expr Expr) Expr)
+(rewrite (IgnoreFirst a b)
+         (Get
+             (All (Sequential) (Cons a (Cons b (Nil))))
+             1)
+         :ruleset desugar)

--- a/tree_unique_args/src/tests.egg
+++ b/tree_unique_args/src/tests.egg
@@ -1,1 +1,0 @@
-; Put (check) statements in this file

--- a/tree_unique_args/src/tests.egg
+++ b/tree_unique_args/src/tests.egg
@@ -1,0 +1,1 @@
+; Put (check) statements in this file

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -3,3 +3,16 @@ pub(crate) fn n_vars(n: usize, base: &str) -> Vec<String> {
         .map(|i| format!("{base}{i}"))
         .collect::<Vec<String>>()
 }
+
+#[allow(dead_code)]
+pub(crate) fn cons_list(els: &Vec<&str>) -> String {
+    let mut res = vec![];
+    for el in els {
+        res.push(format!("(Cons {el} "));
+    }
+    res.push("(Nil)".to_string());
+    for _ in els {
+        res.push(")".to_string());
+    }
+    res.join("")
+}

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -1,0 +1,5 @@
+pub(crate) fn n_vars(n: usize, base: &str) -> Vec<String> {
+    (0..n)
+        .map(|i| format!("{base}{i}"))
+        .collect::<Vec<String>>()
+}

--- a/tree_unique_args/tests/interpreter.rs
+++ b/tree_unique_args/tests/interpreter.rs
@@ -1,7 +1,4 @@
 // This file is a reference for the semantics of tree_unique_args
-// WIP
-#![allow(dead_code)]
-#![allow(unused_variables)]
 
 use std::collections::HashMap;
 
@@ -13,7 +10,7 @@ pub enum Order {
 
 #[derive(Clone)]
 pub struct Id {
-    id: i64,
+    _id: i64,
 }
 
 #[derive(Clone)]
@@ -202,4 +199,6 @@ pub fn interpret(e: &Expr, arg: &Option<Value>, mem: &mut HashMap<usize, Value>)
 }
 
 #[test]
-fn test_interpreter() {}
+fn test_interpreter() {
+    // TODO: test me
+}

--- a/tree_unique_args/tests/interpreter.rs
+++ b/tree_unique_args/tests/interpreter.rs
@@ -1,0 +1,111 @@
+// This file is a reference for the semantics of tree_unique_args
+// WIP
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use std::collections::HashMap;
+
+pub enum Order {
+    Parallel,
+    Sequential,
+}
+pub struct Id {
+    id: i64,
+}
+pub enum Expr {
+    Num(i32),
+    Boolean(bool),
+    Unit,
+    Badd(Box<Expr>, Box<Expr>),
+    // TODO: other pure ops
+    Get(Box<Expr>, usize),
+    Print(Box<Expr>),
+    Read(Box<Expr>),
+    Write(Box<Expr>, Box<Expr>),
+    All(Order, Vec<Expr>),
+    Switch(Box<Expr>, Vec<Expr>),
+    Loop(Id, Box<Expr>, Box<Expr>),
+    Body(Id, Box<Expr>, Box<Expr>),
+    Arg(Id),
+    // TODO: call and functions
+}
+
+pub enum Value {
+    Num(i32),
+    Boolean(bool),
+    Unit,
+    Tuple(Vec<Value>),
+}
+
+#[derive(Clone, PartialEq)]
+pub enum Type {
+    Num,
+    Boolean,
+    Unit,
+    Tuple(Vec<Type>),
+}
+
+pub fn typecheck(e: &Expr) -> Result<Type, &'static str> {
+    match e {
+        Expr::Num(_) => Ok(Type::Num),
+        Expr::Boolean(_) => Ok(Type::Boolean),
+        Expr::Unit => Ok(Type::Unit),
+        Expr::Badd(e1, e2) => {
+            let ty1 = typecheck(&*e1)?;
+            let ty2 = typecheck(&*e2)?;
+            if ty1 == Type::Num && ty2 == Type::Num {
+                Ok(Type::Num)
+            } else {
+                Err("badd")
+            }
+        }
+        Expr::Get(tuple, i) => {
+            let ty_tuple = typecheck(&*tuple)?;
+            match ty_tuple {
+                Type::Tuple(tys) => Ok(tys[*i].clone()),
+                _ => Err("get"),
+            }
+        }
+        Expr::Print(e) => {
+            // right now, any value can be printed
+            typecheck(&*e)?;
+            Ok(Type::Unit)
+        }
+        Expr::Read(addr) => {
+            let ty_addr = typecheck(&*addr)?;
+            if ty_addr == Type::Num {
+                // right now, all memory holds nums.
+                // read could also take a static type to interpret
+                // the memory as.
+                Ok(Type::Num)
+            } else {
+                Err("read")
+            }
+        }
+        Expr::Write(addr, data) => {
+            let ty_addr = typecheck(&*addr)?;
+            let ty_data = typecheck(&*data)?;
+            if ty_addr == Type::Num && ty_data == Type::Num {
+                Ok(Type::Unit)
+            } else {
+                Err("write")
+            }
+        }
+        Expr::All(_, exprs) => {
+            let mut tys: Vec<Type> = vec![];
+            for expr in exprs {
+                let ty = typecheck(&*expr)?;
+                tys.push(ty)
+            }
+            Ok(Type::Tuple(tys))
+        }
+        _ => Err("unimplemented"),
+    }
+}
+
+pub fn interpret(e: Expr, mem: &HashMap<i64, Value>) -> Value {
+    Value::Num(0)
+}
+
+#[test]
+fn test_interpreter() {}


### PR DESCRIPTION
# See #212 instead

**This PR builds on #206, and as GitHub only compares against main, its diff is smaller than it appears.**

We add enums describing the IR (`BRIL_OPS`, but all the way), and use them to concisely generate purity analysis rules.

The main goal of these enums is not to save LOC, but rather:
1. Make us nimble over changes in the IR
2. Reduce bugs caused by egglog typos
3. Get better at egglog metaprogramming