### PR TITLE
[Tree unique] `DeepCopy`, `NewLoop`, `NewLet`

### DIFF
--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -1,0 +1,117 @@
+use std::iter;
+
+use crate::ir::{Constructor, ESort, Purpose};
+use strum::IntoEnumIterator;
+
+fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
+    // e.g. "Add x y"
+    let ctor_pattern = iter::once(ctor.name())
+        .chain(ctor.fields().iter().map(|field| field.name))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // e.g. ["(DeepCopyExpr x new-id)", "(DeepCopyExpr y new-id)"]
+    let substed_fields = ctor
+        .fields()
+        .iter()
+        .map(|field| match field.purpose {
+            Purpose::CapturingId => "new-inner-id".to_string(),
+            Purpose::Static(_) => field.name.to_string(),
+            Purpose::CapturedExpr => {
+                let var = field.name;
+                let sort = field.sort().name();
+                format!("(DeepCopy{sort} {var} new-inner-id)")
+            }
+            Purpose::ReferencingId => "new-id".to_string(),
+            Purpose::SubExpr | Purpose::SubListExpr => {
+                let var = field.name;
+                let sort = field.sort().name();
+                format!("(DeepCopy{sort} {var} new-id)")
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // e.g. "Add (DeepCopyExpr x new-id) (DeepCopyExpr y new-id)"
+    let copied_ctor = iter::once(ctor.name().to_string())
+        .chain(substed_fields.into_iter())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let sort = ctor.sort().name();
+    let br = "\n      ";
+    let creates_context = ctor
+        .fields()
+        .iter()
+        .any(|field| field.purpose == Purpose::CapturingId);
+    let actions = if creates_context {
+        format!("(let new-inner-id (i64-fresh!)){br} (union e ({copied_ctor}))")
+    } else {
+        format!("(union e ({copied_ctor}))")
+    };
+    format!(
+        "(rule ((= e (DeepCopy{sort} ({ctor_pattern}) new-id))){br}({actions}){br}:ruleset subst)"
+    )
+}
+
+pub(crate) fn deep_copy_rules() -> Vec<String> {
+    let mut res: Vec<String> = vec![];
+    for sort in ESort::iter() {
+        let sort_name = sort.name();
+        res.push(format!(
+            "(function DeepCopy{sort_name} ({sort_name} i64) {sort_name} :unextractable)"
+        ));
+    }
+    res.extend(Constructor::iter().map(deep_copy_rule_for_ctor));
+    res
+}
+
+// We use field names as var names, and bind "v" to the value being substituted
+// in, so this test checks we don't overlap/add extra equality constraints
+#[test]
+fn var_names_available() {
+    for ctor in Constructor::iter() {
+        for field in ctor.fields() {
+            assert_ne!(field.name, "new-id");
+            assert_ne!(field.name, "new-inner-id");
+            assert_ne!(field.name, "e");
+        }
+    }
+}
+
+#[test]
+fn test_deep_copy() -> Result<(), egglog::Error> {
+    let build = "
+(let id1 (i64-fresh!))
+(let id2 (i64-fresh!))
+(let loop
+    (Loop id1
+        (All (Parallel) (Pair (Arg id1) (Num 0)))
+        (All (Sequential) (Pair
+            ; pred
+            (LessThan (Get (Arg id1) 0) (Get (Arg id1) 1))
+            ; output
+            (Body id2
+                (All (Parallel) (Pair
+                    (Add (Get (Arg id1) 0) (Num 1))
+                    (Sub (Get (Arg id1) 1) (Num 1))))
+                (Arg id2))))))
+(let loop-copied (DeepCopyExpr loop (i64-fresh!)))
+    ";
+    let check = "
+(let loop-copied-expected
+    (Loop 3
+        (All (Parallel) (Pair (Arg 2) (Num 0)))
+        (All (Sequential) (Pair
+            ; pred
+            (LessThan (Get (Arg 3) 0) (Get (Arg 3) 1))
+            ; output
+            (Body 4
+                (All (Parallel) (Pair
+                    (Add (Get (Arg 3) 0) (Num 1))
+                    (Sub (Get (Arg 3) 1) (Num 1))))
+                (Arg 4))))))
+(run-schedule (saturate desugar))
+(check (= loop-copied loop-copied-expected))
+    ";
+    crate::run_test(build, check)
+}

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -35,15 +35,10 @@ fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
 }
 
 pub(crate) fn deep_copy_rules() -> Vec<String> {
-    let mut res: Vec<String> = vec![];
-    for sort in ESort::iter() {
-        let sort_name = sort.name();
-        res.push(format!(
-            "(function DeepCopy{sort_name} ({sort_name} i64) {sort_name} :unextractable)"
-        ));
-    }
-    res.extend(Constructor::iter().map(deep_copy_rule_for_ctor));
-    res
+    ESort::iter()
+        .map(|sort| "(function DeepCopy* (* i64) * :unextractable)".replace("*", sort.name()))
+        .chain(Constructor::iter().map(deep_copy_rule_for_ctor))
+        .collect::<Vec<_>>()
 }
 
 // We use field names as var names, and bind "v" to the value being substituted

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -49,7 +49,7 @@ fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
         format!("(union e ({copied_ctor}))")
     };
     format!(
-        "(rule ((= e (DeepCopy{sort} ({ctor_pattern}) new-id))){br}({actions}){br}:ruleset subst)"
+        "(rule ((= e (DeepCopy{sort} ({ctor_pattern}) new-id))){br}({actions}){br}:ruleset always-run)"
     )
 }
 
@@ -90,7 +90,7 @@ fn test_deep_copy() -> Result<(), egglog::Error> {
             ; pred
             (LessThan (Get (Arg id1) 0) (Get (Arg id1) 1))
             ; output
-            (Body id2
+            (Let id2
                 (All (Parallel) (Pair
                     (Add (Get (Arg id1) 0) (Num 1))
                     (Sub (Get (Arg id1) 1) (Num 1))))
@@ -105,12 +105,12 @@ fn test_deep_copy() -> Result<(), egglog::Error> {
             ; pred
             (LessThan (Get (Arg 3) 0) (Get (Arg 3) 1))
             ; output
-            (Body 4
+            (Let 4
                 (All (Parallel) (Pair
                     (Add (Get (Arg 3) 0) (Num 1))
                     (Sub (Get (Arg 3) 1) (Num 1))))
                 (Arg 4))))))
-(run-schedule (saturate desugar))
+(run-schedule (saturate always-run))
 (check (= loop-copied loop-copied-expected))
     ";
     crate::run_test(build, check)

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -3,20 +3,20 @@ use strum::IntoEnumIterator;
 
 fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
     // e.g. "(Add x y)"
-    let ctor_pattern = ctor.construct(|field| field.name.to_string());
+    let ctor_pattern = ctor.construct(|field| field.var());
 
     // e.g. "(Add (DeepCopyExpr x new-id)", "(DeepCopyExpr y new-id))"
     let copied_ctor = ctor.construct(|field| match field.purpose {
         Purpose::CapturingId => "new-inner-id".to_string(),
-        Purpose::Static(_) => field.name.to_string(),
+        Purpose::Static(_) => field.var(),
         Purpose::CapturedExpr => {
-            let var = field.name;
+            let var = field.var();
             let sort = field.sort().name();
             format!("(DeepCopy{sort} {var} new-inner-id)")
         }
         Purpose::ReferencingId => "new-id".to_string(),
         Purpose::SubExpr | Purpose::SubListExpr => {
-            let var = field.name;
+            let var = field.var();
             let sort = field.sort().name();
             format!("(DeepCopy{sort} {var} new-id)")
         }

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -24,11 +24,7 @@ fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
 
     let sort = ctor.sort().name();
     let br = "\n      ";
-    let creates_context = ctor
-        .fields()
-        .iter()
-        .any(|field| field.purpose == Purpose::CapturingId);
-    let actions = if creates_context {
+    let actions = if ctor.creates_context() {
         format!("(let new-inner-id (i64-fresh!)){br} (union e {copied_ctor})")
     } else {
         format!("(union e {copied_ctor})")

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -41,8 +41,6 @@ pub(crate) fn deep_copy_rules() -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
-// We use field names as var names, and bind "v" to the value being substituted
-// in, so this test checks we don't overlap/add extra equality constraints
 #[test]
 fn var_names_available() {
     for ctor in Constructor::iter() {

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -1,41 +1,26 @@
-use std::iter;
-
 use crate::ir::{Constructor, ESort, Purpose};
 use strum::IntoEnumIterator;
 
 fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
-    // e.g. "Add x y"
-    let ctor_pattern = iter::once(ctor.name())
-        .chain(ctor.fields().iter().map(|field| field.name))
-        .collect::<Vec<_>>()
-        .join(" ");
+    // e.g. "(Add x y)"
+    let ctor_pattern = ctor.construct(|field| field.name.to_string());
 
-    // e.g. ["(DeepCopyExpr x new-id)", "(DeepCopyExpr y new-id)"]
-    let substed_fields = ctor
-        .fields()
-        .iter()
-        .map(|field| match field.purpose {
-            Purpose::CapturingId => "new-inner-id".to_string(),
-            Purpose::Static(_) => field.name.to_string(),
-            Purpose::CapturedExpr => {
-                let var = field.name;
-                let sort = field.sort().name();
-                format!("(DeepCopy{sort} {var} new-inner-id)")
-            }
-            Purpose::ReferencingId => "new-id".to_string(),
-            Purpose::SubExpr | Purpose::SubListExpr => {
-                let var = field.name;
-                let sort = field.sort().name();
-                format!("(DeepCopy{sort} {var} new-id)")
-            }
-        })
-        .collect::<Vec<_>>();
-
-    // e.g. "Add (DeepCopyExpr x new-id) (DeepCopyExpr y new-id)"
-    let copied_ctor = iter::once(ctor.name().to_string())
-        .chain(substed_fields.into_iter())
-        .collect::<Vec<_>>()
-        .join(" ");
+    // e.g. "(Add (DeepCopyExpr x new-id)", "(DeepCopyExpr y new-id))"
+    let copied_ctor = ctor.construct(|field| match field.purpose {
+        Purpose::CapturingId => "new-inner-id".to_string(),
+        Purpose::Static(_) => field.name.to_string(),
+        Purpose::CapturedExpr => {
+            let var = field.name;
+            let sort = field.sort().name();
+            format!("(DeepCopy{sort} {var} new-inner-id)")
+        }
+        Purpose::ReferencingId => "new-id".to_string(),
+        Purpose::SubExpr | Purpose::SubListExpr => {
+            let var = field.name;
+            let sort = field.sort().name();
+            format!("(DeepCopy{sort} {var} new-id)")
+        }
+    });
 
     let sort = ctor.sort().name();
     let br = "\n      ";
@@ -44,12 +29,12 @@ fn deep_copy_rule_for_ctor(ctor: Constructor) -> String {
         .iter()
         .any(|field| field.purpose == Purpose::CapturingId);
     let actions = if creates_context {
-        format!("(let new-inner-id (i64-fresh!)){br} (union e ({copied_ctor}))")
+        format!("(let new-inner-id (i64-fresh!)){br} (union e {copied_ctor})")
     } else {
-        format!("(union e ({copied_ctor}))")
+        format!("(union e {copied_ctor})")
     };
     format!(
-        "(rule ((= e (DeepCopy{sort} ({ctor_pattern}) new-id))){br}({actions}){br}:ruleset always-run)"
+        "(rule ((= e (DeepCopy{sort} {ctor_pattern} new-id))){br}({actions}){br}:ruleset always-run)"
     )
 }
 

--- a/tree_unique_args/src/ir.rs
+++ b/tree_unique_args/src/ir.rs
@@ -1,6 +1,6 @@
 use strum_macros::EnumIter;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum Sort {
     Expr,
     ListExpr,
@@ -76,6 +76,7 @@ pub(crate) enum Constructor {
 // Invariants of a valid term in the IR:
 // - A ReferencingId must match the nearest enclosing BindingId
 // - It must typecheck (see typechecker in interpreter.rs).
+#[derive(PartialEq)]
 pub(crate) enum Purpose {
     Static(Sort), // some int, bool, order that parameterizes constructor
     CapturingId,

--- a/tree_unique_args/src/ir.rs
+++ b/tree_unique_args/src/ir.rs
@@ -224,6 +224,12 @@ impl Constructor {
             Constructor::Nil => ESort::ListExpr,
         }
     }
+
+    pub(crate) fn creates_context(&self) -> bool {
+        self.fields()
+            .iter()
+            .any(|field| field.purpose == Purpose::CapturingId)
+    }
 }
 
 #[cfg(test)]

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -1,5 +1,6 @@
 // Rust test modules
 // If you don't put your Rust file here it won't get compiled!
+pub(crate) mod deep_copy;
 pub(crate) mod ir;
 pub(crate) mod purity_analysis;
 pub(crate) mod subst;
@@ -16,12 +17,14 @@ pub fn run_test(build: &str, check: &str) -> Result {
         "{}\n{build}\n{}\n{check}\n",
         vec![
             include_str!("schema.egg"),
-            include_str!("sugar.egg"),
             // analyses
             &purity_analysis::purity_analysis_rules().join("\n"),
             &subst::subst_rules().join("\n"),
+            &deep_copy::deep_copy_rules().join("\n"),
             // repairs
             // optimizations
+            // sugar
+            include_str!("sugar.egg"),
         ]
         .join("\n"),
         include_str!("schedule.egg"),
@@ -31,5 +34,9 @@ pub fn run_test(build: &str, check: &str) -> Result {
 
     egglog::EGraph::default()
         .parse_and_run_program(&program)
-        .map(|_| ())
+        .map(|lines| {
+            for line in lines {
+                println!("{}", line);
+            }
+        })
 }

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -12,3 +12,13 @@
              (All (Sequential) (Cons a (Cons b (Nil))))
              1)
          :ruleset desugar)
+
+(function NewLoop (i64 Expr Expr) Expr)
+(rewrite (NewLoop id in out)
+         (Loop id (DeepCopyExpr in id) (DeepCopyExpr out id))
+         :ruleset desugar)
+
+(function NewBody (i64 Expr Expr) Expr)
+(rewrite (NewBody id in out)
+         (Body id (DeepCopyExpr in id) (DeepCopyExpr out id))
+         :ruleset desugar)

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -13,10 +13,10 @@
 
 (function NewLoop (i64 Expr Expr) Expr)
 (rewrite (NewLoop id in out)
-         (Loop id (DeepCopyExpr in id) (DeepCopyExpr out id))
+         (Loop id in (DeepCopyExpr out id))
          :ruleset always-run)
 
 (function NewLet (i64 Expr Expr) Expr)
 (rewrite (NewLet id in out)
-         (Let id (DeepCopyExpr in id) (DeepCopyExpr out id))
+         (Let id in (DeepCopyExpr out id))
          :ruleset always-run)


### PR DESCRIPTION
Add rules for the following functions:
```
(function DeepCopyExpr (Expr i64) Expr)
(function DeepCopyListExpr (ListExpr i64) ListExpr)
(function NewLoop (i64 Expr Expr) Expr)
(function NewLet (i64 Expr Expr) Expr)
```

## Stack
1. https://github.com/egraphs-good/eggcc/pull/206
2. https://github.com/egraphs-good/eggcc/pull/212
3. https://github.com/egraphs-good/eggcc/pull/213
4. https://github.com/egraphs-good/eggcc/pull/214
5. https://github.com/egraphs-good/eggcc/pull/216