### PR TITLE
[Tree unique] Add `IdOf` and `ArgOf`

### DIFF
--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -20,3 +20,16 @@
 (rewrite (NewLet id in out)
          (Let id in (DeepCopyExpr out id))
          :ruleset always-run)
+
+(function IdOf (Expr) i64)
+(rule ((IdOf (Let id in out)))
+      ((set (IdOf (Let id in out)) id))
+      :ruleset always-run)
+(rule ((IdOf (Loop id in out)))
+      ((set (IdOf (Loop id in out)) id))
+      :ruleset always-run)
+
+(function ArgOf (Expr) Expr)
+(rewrite (ArgOf body)
+         (Arg (IdOf body))
+         :ruleset always-run)


### PR DESCRIPTION
`IdOf` gets a body's capturing id. `ArgOf` creates an arg that can be placed within a body's captured expression.