### PR TITLE
[Tree unique] WIP Loop unrolling 

### DIFF
--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -73,20 +73,21 @@ fn test_deep_copy() -> Result<(), egglog::Error> {
 (let loop-copied (DeepCopyExpr loop (Id (i64-fresh!))))
     ";
     let check = "
-(let loop-copied-expected
-    (Loop (Id 4)
-        (All (Parallel) (Pair (Arg (Id 3)) (Num (Id 3) 0)))
+(run-schedule (saturate always-run))
+(extract loop-copied)
+(check (= loop-copied
+          (Loop new-id
+        (All (Parallel) (Pair (Arg some-other-id) (Num some-other-id 0)))
         (All (Sequential) (Pair
             ; pred
-            (LessThan (Get (Arg (Id 4)) 0) (Get (Arg (Id 4)) 1))
+            (LessThan (Get (Arg new-id) 0) (Get (Arg new-id) 1))
             ; output
-            (Let (Id 5)
+            (Let third-new-id
                 (All (Parallel) (Pair
-                    (Add (Get (Arg (Id 4)) 0) (Num (Id 4) 1))
-                    (Sub (Get (Arg (Id 4)) 1) (Num (Id 4) 1))))
-                (Arg (Id 5)))))))
-(run-schedule (saturate always-run))
-(check (= loop-copied loop-copied-expected))
+                    (Add (Get (Arg new-id) 0) (Num new-id 1))
+                    (Sub (Get (Arg new-id) 1) (Num new-id 1))))
+                (Arg third-new-id))))))
+            )
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/loop_unrolling.egg
+++ b/tree_unique_args/src/loop_unrolling.egg
@@ -1,10 +1,5 @@
-
 (ruleset loop-unroll)
 
-
-;; this rule depends on the "loop-desugar"
-;; rule, which makes loop inputs
-;; just refer to a let-bound argument
 
 ;; Loop unrolling is fairly simple,
 ;; but we must be careful about evaluation
@@ -14,26 +9,26 @@
 ;; use a "NewLet" to bind them together.
 (rule
   ((= lhs (Loop id inputs pred-outputs))
+   (ExprIsValid lhs)
    (= pred-outputs (All seq-or-parallel pred-outputs-list))
    (= length (ListExpr-length pred-outputs-list)))
   ((let outputs (SubArgList 1 length))
    (union lhs
-    (NewLet ;; new let to bind inputs
+    ;; NewLet to deep copy everything
+    (NewLet ;; let to bind inputs
       (Id (i64-fresh!))
       inputs
-      (NewLet ;; evaluate the pred and outputs
-        (Id (i64-fresh!))
+      (Let ;; evaluate the pred and outputs
+        aid
         pred-outputs
         ;; check the pred, run loop if true
         (Switch
           (Get aarg 0)
           (Pair
-            ;; bind outputs 
-            (NewLoop
-              (Id (i64-fresh!))
-              outputs pred-outputs)
             ;; if pred is false, return outputs
-            outputs))))))
+            outputs
+            ;; inputs to loop are outputs of last iteration
+            (Loop aid outputs pred-outputs)))))))
    :ruleset loop-unroll
    :name "loop-unrolling")
 

--- a/tree_unique_args/src/loop_unrolling.egg
+++ b/tree_unique_args/src/loop_unrolling.egg
@@ -1,0 +1,39 @@
+
+(ruleset loop-unroll)
+
+
+;; this rule depends on the "loop-desugar"
+;; rule, which makes loop inputs
+;; just refer to a let-bound argument
+
+;; Loop unrolling is fairly simple,
+;; but we must be careful about evaluation
+;; order and effects.
+;; For example, the predicate and outputs
+;; must be evalutaed together, so we
+;; use a "NewLet" to bind them together.
+(rule
+  ((= lhs (Loop id inputs pred-outputs))
+   (= pred-outputs (All seq-or-parallel pred-outputs-list))
+   (= length (ListExpr-length pred-outputs-list)))
+  ((let outputs (SubArgList 1 length))
+   (union lhs
+    (NewLet ;; new let to bind inputs
+      (Id (i64-fresh!))
+      inputs
+      (NewLet ;; evaluate the pred and outputs
+        (Id (i64-fresh!))
+        pred-outputs
+        ;; check the pred, run loop if true
+        (Switch
+          (Get aarg 0)
+          (Pair
+            ;; bind outputs 
+            (NewLoop
+              (Id (i64-fresh!))
+              outputs pred-outputs)
+            ;; if pred is false, return outputs
+            outputs))))))
+   :ruleset loop-unroll
+   :name "loop-unrolling")
+

--- a/tree_unique_args/src/loop_unrolling.rs
+++ b/tree_unique_args/src/loop_unrolling.rs
@@ -9,7 +9,7 @@ fn test_unroll_once() -> Result<(), egglog::Error> {
     (All (Parallel)
      (Pair (LessThan (Num id1 3) (Num id1 3))
            (Print (Num id1 4))))))
-  ";
+(ExprIsValid loop)";
     let expected = "(Let newid1
     (Num id-outer 2)
     (Let newid2

--- a/tree_unique_args/src/loop_unrolling.rs
+++ b/tree_unique_args/src/loop_unrolling.rs
@@ -1,0 +1,39 @@
+#[test]
+fn test_unroll_once() -> Result<(), egglog::Error> {
+    let build = "
+(let id1 (Id (i64-fresh!)))
+(let id-outer (Id (i64-fresh!)))
+(let loop
+  (Loop id1
+    (Num id-outer 2)
+    (All (Parallel)
+     (Pair (LessThan (Num id1 3) (Num id1 3))
+           (Print (Num id1 4))))))
+  ";
+    let expected = "(Let newid1
+    (Num id-outer 2)
+    (Let newid2
+      (All (Parallel)
+           (Pair
+              (LessThan (Num newid1 3) (Num newid1 3))
+              (Print (Num newid1 4))))
+      (Switch
+        (Get (Arg newid2) 0)
+        (Pair
+          (Loop newid3
+            (All (Parallel) (Single (Get (Arg newid2) 1)))
+            (All (Parallel)
+              (Pair (LessThan (Num newid3 3) (Num newid3 3))
+                    (Print (Num newid3 4)))))
+         (All (Parallel) (Single (Get (Arg newid2) 1)))))))";
+    let check = format!(
+        "
+;; first check that loop was desugared
+;; to a let loop
+(check 
+  (= loop
+     {expected}))
+"
+    );
+    crate::run_test(build, &check)
+}

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -37,6 +37,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
             &switch_rewrites::egglog(),
             include_str!("function_inlining.egg"),
             &conditional_invariant_code_motion::rules().join("\n"),
+            include_str!("loop_unrolling.egg"),
         ]
         .join("\n"),
         include_str!("schedule.egg"),

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -9,6 +9,7 @@ pub(crate) mod conditional_invariant_code_motion;
 pub(crate) mod deep_copy;
 pub(crate) mod function_inlining;
 pub(crate) mod ir;
+pub(crate) mod loop_unrolling;
 pub(crate) mod purity_analysis;
 pub(crate) mod subst;
 pub(crate) mod switch_rewrites;

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -1,6 +1,11 @@
 ; The main (run) statement for the egglog program
 
 (run-schedule
+  ;; unrolling is extremely expensive
+  ;; do it 3 times at the beginning
+  (repeat 3
+   (saturate always-run)
+   loop-unroll)
   (repeat 5
     (saturate always-run)
     conditional-invariant-code-motion

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -63,6 +63,10 @@
 ; Arg gets the input of a region or the parameter of a function
 (function Arg (IdSort) Expr)
 
+; When the id does not matter (e.g. in a NewLet)
+; any id will work.
+(let aarg (Arg (Id 0)))
+
 ; ==========================
 ; Functions
 ; ==========================

--- a/tree_unique_args/src/schema.egg
+++ b/tree_unique_args/src/schema.egg
@@ -63,9 +63,12 @@
 ; Arg gets the input of a region or the parameter of a function
 (function Arg (IdSort) Expr)
 
-; When the id does not matter (e.g. in a NewLet)
+; aid stands for "any id" and aarg stands for "any argument"
+; When the id does not matter (e.g. under a DeepCopy),
 ; any id will work.
+(let aid (Id 0))
 (let aarg (Arg (Id 0)))
+
 
 ; ==========================
 ; Functions

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -26,10 +26,4 @@
          (Let id in (DeepCopyExpr out id))
          :ruleset always-run)
 
-(function FreshLet (Expr Expr) Expr :unextractable)
-(rule ((FreshLet in out))
-      ((let new-id (Id (i64-fresh!)))
-       (Let new-id in (DeepCopyExpr out new-id)))
-       :ruleset always-run)
-         
 

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -29,8 +29,9 @@
 (rule ((Loop id inputs outputs)
        (= inputs (All any-order any-contents)))
       ((let new-id (Id (i64-fresh!)))
+       (let new-id-2 (Id (i64-fresh!)))
        (union (Loop id inputs outputs)
               (NewLet new-id inputs
-                      (Loop id (Arg new-id) outputs))))
+                      (NewLoop new-id-2 (Arg new-id) outputs))))
       :ruleset always-run
       :name "loop-desugar")

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -21,17 +21,3 @@
          (Let id in (DeepCopyExpr out id))
          :ruleset always-run)
 
-;; desugar loops to not have single argument
-;; as input
-;; sometimes it may be useful to have inputs
-;; and no intermediate let, so we 
-;; store both
-(rule ((Loop id inputs outputs)
-       (= inputs (All any-order any-contents)))
-      ((let new-id (Id (i64-fresh!)))
-       (let new-id-2 (Id (i64-fresh!)))
-       (union (Loop id inputs outputs)
-              (NewLet new-id inputs
-                      (NewLoop new-id-2 (Arg new-id) outputs))))
-      :ruleset always-run
-      :name "loop-desugar")

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -1,8 +1,8 @@
 ; Functions useful for writing tests and actions, but should not be matched on
 (function Pair (Expr Expr) ListExpr)
-(rewrite (Pair a b)
-         (Cons a (Cons b (Nil)))
-         :ruleset always-run)
+(birewrite (Pair a b)
+           (Cons a (Cons b (Nil)))
+           :ruleset always-run)
 
 (function IgnoreFirst (Expr Expr) Expr)
 (rewrite (IgnoreFirst a b)
@@ -20,3 +20,17 @@
 (rewrite (NewLet id in out)
          (Let id in (DeepCopyExpr out id))
          :ruleset always-run)
+
+;; desugar loops to not have single argument
+;; as input
+;; sometimes it may be useful to have inputs
+;; and no intermediate let, so we 
+;; store both
+(rule ((Loop id inputs outputs)
+       (= inputs (All any-order any-contents)))
+      ((let new-id (Id (i64-fresh!)))
+       (union (Loop id inputs outputs)
+              (NewLet new-id inputs
+                      (Loop id (Arg new-id) outputs))))
+      :ruleset always-run
+      :name "loop-desugar")

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -4,6 +4,11 @@
            (Cons a (Cons b (Nil)))
            :ruleset always-run)
 
+(function Single (Expr) ListExpr)
+(birewrite (Single a)
+           (Cons a (Nil))
+           :ruleset always-run)
+
 (function IgnoreFirst (Expr Expr) Expr)
 (rewrite (IgnoreFirst a b)
          (Get
@@ -11,13 +16,20 @@
              1)
          :ruleset always-run)
 
-(function NewLoop (IdSort Expr Expr) Expr)
+(function NewLoop (IdSort Expr Expr) Expr :unextractable)
 (rewrite (NewLoop id in out)
          (Loop id in (DeepCopyExpr out id))
          :ruleset always-run)
 
-(function NewLet (IdSort Expr Expr) Expr)
+(function NewLet (IdSort Expr Expr) Expr :unextractable)
 (rewrite (NewLet id in out)
          (Let id in (DeepCopyExpr out id))
          :ruleset always-run)
+
+(function FreshLet (Expr Expr) Expr :unextractable)
+(rule ((FreshLet in out))
+      ((let new-id (Id (i64-fresh!)))
+       (Let new-id in (DeepCopyExpr out new-id)))
+       :ruleset always-run)
+         
 

--- a/tree_unique_args/src/util.egg
+++ b/tree_unique_args/src/util.egg
@@ -11,3 +11,20 @@
 (rule ((= (ListExpr-suffix list n) (Nil)))
     ((set (ListExpr-length list) n)) :ruleset always-run)
 
+;; given a start i and an end j,
+;; constructs a list
+;; [(Get (Arg (Id 0)) i), (Get (Arg (Id 0)) i+1), ..., (Get (Arg (Id 0)) j-1)]
+(function SubArgList (i64 i64) Expr :unextractable)
+(function SubArgListHelper (i64 i64) ListExpr :unextractable)
+
+
+(rewrite (SubArgList i j) (All (Parallel) (SubArgListHelper i j)) :ruleset always-run)
+
+(rewrite (SubArgListHelper i i) (Nil) :ruleset always-run)
+
+(rule ((SubArgListHelper i j)
+       (< i j))
+      ((union (SubArgListHelper i j)
+              (Cons (Get aarg i)
+                    (SubArgListHelper (+ i 1) j))))
+      :ruleset always-run)


### PR DESCRIPTION
This PR adds a work-in-progress loop unrolling rule.

The rule is inefficient because it uses multiple layers of deep copying. I think this could be made more efficient by only having a top-level deep copy- however, that would add invalid intermediate terms to the database. We should decide how to resolve this issue.

On the other hand, maybe this does not matter. Doing loop unrolling in this IR is quite inefficient anyways, since each unrolling doubles the size of the sub-egraph.