### PR TITLE
Add Append util for ListExpr

### DIFF
--- a/tree_unique_args/src/util.egg
+++ b/tree_unique_args/src/util.egg
@@ -1,6 +1,7 @@
 (function ListExpr-length (ListExpr) i64)
 (function ListExpr-ith (ListExpr i64) Expr :unextractable)
 (function ListExpr-suffix (ListExpr i64) ListExpr :unextractable)
+(function Append (ListExpr Expr) ListExpr :unextractable)
 
 (rule ((All order top)) ((union (ListExpr-suffix top 0) top)) :ruleset always-run)
 
@@ -11,3 +12,9 @@
 (rule ((= (ListExpr-suffix list n) (Nil)))
     ((set (ListExpr-length list) n)) :ruleset always-run)
 
+(rewrite (Append (Cons a b) e)
+    (Cons a (Append b e))
+    :ruleset always-run)
+(rewrite (Append (Nil) e)
+    (Cons e (Nil))
+    :ruleset always-run)

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -15,3 +15,24 @@ fn test_list_util() -> Result<(), egglog::Error> {
     );
     crate::run_test(build, check)
 }
+
+#[test]
+fn append_test() -> Result<(), egglog::Error> {
+    let build = "
+        (let id (Id (i64-fresh!)))
+        (let appended
+            (Append
+                (Cons (Num id 0) (Cons (Num id 1) (Nil)))
+                (Num id 2)))
+    ";
+
+    let check = "
+        (check (
+            =
+            (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Nil))))
+            appended
+        ))
+    ";
+
+    crate::run_test(build, check)
+}


### PR DESCRIPTION
Add the function `Append (ListExpr Expr)` to add an expression to the end of a list. This is useful for adding new inputs/outputs.