### PR TITLE
Fix several bugs in structured conversion

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -10,6 +10,7 @@ use std::{collections::HashMap, fmt::Display};
 use std::{fmt, mem};
 
 use bril_rs::{Argument, Code, EffectOps, Function, Instruction, Position, Program, Type};
+use hashbrown::HashSet;
 use petgraph::dot::Dot;
 
 use petgraph::stable_graph::{EdgeReference, StableDiGraph};
@@ -328,6 +329,7 @@ pub struct CfgFunction<CfgType> {
     /// The arguments to the function.
     pub(crate) args: Vec<Argument>,
     /// The graph itself.
+    /// Invariant: contains only reachable nodes.
     pub(crate) graph: StableDiGraph<BasicBlock, Branch>,
     /// The entry node for the CFG.
     pub(crate) entry: NodeIndex,
@@ -345,6 +347,22 @@ pub type SimpleCfgFunction = CfgFunction<Simple>;
 pub type SwitchCfgFunction = CfgFunction<Switch>;
 
 impl<CfgType> CfgFunction<CfgType> {
+    pub(crate) fn remove_unreachable(&mut self) {
+        let mut reachable = HashSet::new();
+        let mut dfs = DfsPostOrder::new(&self.graph, self.entry);
+        while let Some(node) = dfs.next(&self.graph) {
+            reachable.insert(node);
+        }
+        let mut to_remove = Vec::new();
+        for node in self.graph.node_indices() {
+            if !reachable.contains(&node) {
+                to_remove.push(node);
+            }
+        }
+        for node in to_remove {
+            self.graph.remove_node(node);
+        }
+    }
     pub(crate) fn has_return_value(&self) -> bool {
         self.return_ty.is_some()
     }
@@ -455,6 +473,14 @@ pub(crate) fn function_to_cfg(func: &Function) -> SimpleCfgFunction {
     for inst in &func.instrs {
         match inst {
             Code::Label { label, pos } => {
+                assert!(
+                    label != &BlockName::Entry.to_string(),
+                    "not allowed to use entry___ as a label"
+                );
+                assert!(
+                    label != &BlockName::Exit.to_string(),
+                    "not allowed to use exit___ as a label"
+                );
                 let next_block = builder.get_index(label);
                 builder.finish_block(current, mem::take(&mut block), mem::take(&mut anns));
                 builder.set_pos(next_block, pos.clone());
@@ -563,6 +589,7 @@ pub(crate) fn function_to_cfg(func: &Function) -> SimpleCfgFunction {
         }
     }
     builder.finish_block(current, block, anns);
+
     if !had_branch {
         builder.add_edge(
             current,
@@ -573,6 +600,9 @@ pub(crate) fn function_to_cfg(func: &Function) -> SimpleCfgFunction {
             },
         )
     }
+
+    // also, remove any unreachable blocks
+    builder.cfg.remove_unreachable();
 
     builder.cfg
 }

--- a/src/cfg/structured.rs
+++ b/src/cfg/structured.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use super::BasicBlock;
+use super::{function_to_cfg, BasicBlock};
 use bril_rs::{Argument, Code, EffectOps, Function, Instruction, Program, Type};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -123,6 +123,9 @@ impl StructuredFunction {
             pos: None,
             return_type: self.return_ty.clone(),
         }
+        /*function_to_cfg(&)
+        .optimize_jumps()
+        .to_bril()*/
     }
 }
 

--- a/src/cfg/structured.rs
+++ b/src/cfg/structured.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use super::BasicBlock;
-use bril_rs::{Argument, Code, EffectOps, Function, Instruction, Program};
+use bril_rs::{Argument, Code, EffectOps, Function, Instruction, Program, Type};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum StructuredBlock {
@@ -51,6 +51,7 @@ impl StructuredProgram {
 pub struct StructuredFunction {
     pub name: String,
     pub args: Vec<Argument>,
+    pub return_ty: Option<Type>,
     pub block: StructuredBlock,
 }
 
@@ -120,7 +121,7 @@ impl StructuredFunction {
             args: self.args.clone(),
             instrs: builder.resulting_code,
             pos: None,
-            return_type: None,
+            return_type: self.return_ty.clone(),
         }
     }
 }

--- a/src/cfg/structured.rs
+++ b/src/cfg/structured.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use super::{function_to_cfg, BasicBlock};
+use super::BasicBlock;
 use bril_rs::{Argument, Code, EffectOps, Function, Instruction, Program, Type};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -116,6 +116,7 @@ impl StructuredFunction {
         };
         self.block.to_code(&mut builder);
 
+        // TODO get rid of intermediate jumps
         Function {
             name: self.name.clone(),
             args: self.args.clone(),
@@ -123,9 +124,6 @@ impl StructuredFunction {
             pos: None,
             return_type: self.return_ty.clone(),
         }
-        /*function_to_cfg(&)
-        .optimize_jumps()
-        .to_bril()*/
     }
 }
 

--- a/src/cfg/structured.rs
+++ b/src/cfg/structured.rs
@@ -193,10 +193,12 @@ impl StructuredBlock {
                     pos: None,
                 });
                 then_block.to_code(builder);
+
                 builder.resulting_code.push(Code::Label {
                     label: else_name,
                     pos: None,
                 });
+
                 else_block.to_code(builder);
             }
             StructuredBlock::Loop(block) => {

--- a/src/cfg/to_structured.rs
+++ b/src/cfg/to_structured.rs
@@ -107,14 +107,6 @@ impl<'a> StructuredCfgBuilder<'a> {
             .filter(|n| self.is_merge_node(*n))
             .collect::<Vec<_>>();
         merge_nodes.sort_by_key(|n| self.postorder[&self.cfg.graph[*n].name]);
-        eprintln!(
-            "merge nodes of {}: {:?}",
-            self.name(node),
-            merge_nodes
-                .iter()
-                .map(|n| self.name(*n))
-                .collect::<Vec<_>>()
-        );
         self.node_within(node, merge_nodes)
     }
 
@@ -151,12 +143,6 @@ impl<'a> StructuredCfgBuilder<'a> {
                     // Unconditionally jumps to out
                     [out] => self.do_branch(out),
                     [branch1, branch2] => {
-                        eprintln!(
-                            "Two branches {} and {}",
-                            self.name(branch1.target()),
-                            self.name(branch2.target())
-                        );
-                        eprintln!("Branches: {:?} and {:?}", branch1, branch2);
                         if let (
                             Branch {
                                 op:
@@ -177,7 +163,6 @@ impl<'a> StructuredCfgBuilder<'a> {
                                 .do_branch(if val1 == &CondVal::from(true) {
                                     branch1
                                 } else {
-                                    eprintln!("if true go to {}", self.name(branch2.target()));
                                     branch2
                                 })
                                 .unwrap_or(StructuredBlock::Sequence(vec![]));

--- a/src/cfg/to_structured.rs
+++ b/src/cfg/to_structured.rs
@@ -257,7 +257,6 @@ impl<'a> StructuredCfgBuilder<'a> {
         let top_context = self.context.last().unwrap();
         for (index, context) in self.context.iter().rev().enumerate() {
             match &context.enclosing {
-                //ContainingHistory::ThenOrElseBranch => {}
                 ContainingHistory::LoopWithLabel(label) if label == &target => {
                     if let Some(true) = top_context
                         .fallthrough

--- a/src/cfg/to_structured.rs
+++ b/src/cfg/to_structured.rs
@@ -76,6 +76,7 @@ impl<'a> StructuredCfgBuilder<'a> {
             name: self.cfg.name.clone(),
             args: self.cfg.args.clone(),
             block: result,
+            return_ty: self.cfg.return_ty.clone(),
         })
     }
 

--- a/src/rvsdg/optimize_direct_jumps.rs
+++ b/src/rvsdg/optimize_direct_jumps.rs
@@ -25,10 +25,10 @@ impl<'a> JumpOptimizer<'a> {
     fn optimized(&mut self) -> SimpleCfgFunction {
         let mut resulting_graph: StableGraph<BasicBlock, Branch> = StableDiGraph::new();
 
-        // a map from nodes in the old graph to nodes in the
-        // new graph
-        // if a node was fused into another node,
-        // it points to the new, fused node
+        // a map from nodes in the new graph to nodes in the
+        // old graph
+        // if a node was fused into another node, fix this
+        // so it points to the fused node
         let mut node_mapping: HashMap<NodeIndex, NodeIndex> = HashMap::new();
 
         // we use a bfs so that previous nodes are mapped to new nodes
@@ -59,18 +59,15 @@ impl<'a> JumpOptimizer<'a> {
                 // single outgoing edge from previous
                 // and two distinct nodes
                 if previous_outgoing.len() == 1 && previous != node {
-                    let previous_new = node_mapping[&previous];
+                    let previous_node = node_mapping[&previous];
 
                     // this node will be mapped to the previous
-                    node_mapping.insert(node, previous_new);
+                    node_mapping.insert(node, previous_node);
 
                     // add instructions to the end of the previous node
-                    resulting_graph[previous_new]
+                    resulting_graph[previous_node]
                         .instrs
                         .extend(self.simple_func.graph[node].instrs.to_vec());
-                    resulting_graph[previous_new]
-                        .footer
-                        .extend(self.simple_func.graph[node].footer.to_vec());
 
                     collapse_node = true;
                 }

--- a/src/rvsdg/optimize_direct_jumps.rs
+++ b/src/rvsdg/optimize_direct_jumps.rs
@@ -25,10 +25,10 @@ impl<'a> JumpOptimizer<'a> {
     fn optimized(&mut self) -> SimpleCfgFunction {
         let mut resulting_graph: StableGraph<BasicBlock, Branch> = StableDiGraph::new();
 
-        // a map from nodes in the new graph to nodes in the
-        // old graph
-        // if a node was fused into another node, fix this
-        // so it points to the fused node
+        // a map from nodes in the old graph to nodes in the
+        // new graph
+        // if a node was fused into another node,
+        // it points to the new, fused node
         let mut node_mapping: HashMap<NodeIndex, NodeIndex> = HashMap::new();
 
         // we use a bfs so that previous nodes are mapped to new nodes
@@ -59,15 +59,18 @@ impl<'a> JumpOptimizer<'a> {
                 // single outgoing edge from previous
                 // and two distinct nodes
                 if previous_outgoing.len() == 1 && previous != node {
-                    let previous_node = node_mapping[&previous];
+                    let previous_new = node_mapping[&previous];
 
                     // this node will be mapped to the previous
-                    node_mapping.insert(node, previous_node);
+                    node_mapping.insert(node, previous_new);
 
                     // add instructions to the end of the previous node
-                    resulting_graph[previous_node]
+                    resulting_graph[previous_new]
                         .instrs
                         .extend(self.simple_func.graph[node].instrs.to_vec());
+                    resulting_graph[previous_new]
+                        .footer
+                        .extend(self.simple_func.graph[node].footer.to_vec());
 
                     collapse_node = true;
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -146,6 +146,10 @@ pub enum RunType {
     /// Output a human-readable debug version of this structured
     /// program, using while loops and if statements.
     StructuredConversion,
+    /// Convert the input bril program to
+    /// a structured format, then
+    /// back to bril again.
+    StructuredRoundTrip,
     /// Convert the input bril program to an RVSDG and output it as an SVG.
     RvsdgConversion,
     /// Convert to RVSDG and back to Bril again,
@@ -184,6 +188,7 @@ impl FromStr for RunType {
         match s {
             "nothing" => Ok(RunType::Nothing),
             "structured" => Ok(RunType::StructuredConversion),
+            "structured-roundtrip" => Ok(RunType::StructuredRoundTrip),
             "rvsdg" => Ok(RunType::RvsdgConversion),
             "rvsdg-roundtrip" => Ok(RunType::RvsdgRoundTrip),
             "to-cfg" => Ok(RunType::ToCfg),
@@ -203,6 +208,7 @@ impl Display for RunType {
         match self {
             RunType::Nothing => write!(f, "nothing"),
             RunType::StructuredConversion => write!(f, "structured"),
+            RunType::StructuredRoundTrip => write!(f, "structured-roundtrip"),
             RunType::RvsdgConversion => write!(f, "rvsdg"),
             RunType::RvsdgRoundTrip => write!(f, "rvsdg-roundtrip"),
             RunType::ToCfg => write!(f, "to-cfg"),
@@ -221,6 +227,7 @@ impl RunType {
         match self {
             RunType::Nothing => true,
             RunType::StructuredConversion => false,
+            RunType::StructuredRoundTrip => true,
             RunType::RvsdgConversion => false,
             RunType::RvsdgRoundTrip => true,
             RunType::ToCfg => true,
@@ -357,6 +364,18 @@ impl Run {
                         name: "".to_string(),
                     }],
                     None,
+                )
+            }
+            RunType::StructuredRoundTrip => {
+                let structured = Optimizer::program_to_structured(&self.prog_with_args.program)?;
+                let bril = structured.to_program();
+                (
+                    vec![Visualization {
+                        result: bril.to_string(),
+                        file_extension: ".bril".to_string(),
+                        name: "".to_string(),
+                    }],
+                    Some(bril),
                 )
             }
             RunType::RvsdgConversion => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -150,11 +150,6 @@ pub enum RunType {
     /// a structured format, then
     /// back to bril again.
     StructuredRoundTrip,
-    /// Removes unecessary direct
-    /// jumps from the input program by
-    /// converting it to a CFG, calling
-    /// optimize_jumps, then converting it back to bril.
-    OptimizeDirectJumps,
     /// Convert the input bril program to an RVSDG and output it as an SVG.
     RvsdgConversion,
     /// Convert to RVSDG and back to Bril again,
@@ -194,7 +189,6 @@ impl FromStr for RunType {
             "nothing" => Ok(RunType::Nothing),
             "structured" => Ok(RunType::StructuredConversion),
             "structured-roundtrip" => Ok(RunType::StructuredRoundTrip),
-            "optimize-direct-jumps" => Ok(RunType::OptimizeDirectJumps),
             "rvsdg" => Ok(RunType::RvsdgConversion),
             "rvsdg-roundtrip" => Ok(RunType::RvsdgRoundTrip),
             "to-cfg" => Ok(RunType::ToCfg),
@@ -215,7 +209,6 @@ impl Display for RunType {
             RunType::Nothing => write!(f, "nothing"),
             RunType::StructuredConversion => write!(f, "structured"),
             RunType::StructuredRoundTrip => write!(f, "structured-roundtrip"),
-            RunType::OptimizeDirectJumps => write!(f, "optimize-direct-jumps"),
             RunType::RvsdgConversion => write!(f, "rvsdg"),
             RunType::RvsdgRoundTrip => write!(f, "rvsdg-roundtrip"),
             RunType::ToCfg => write!(f, "to-cfg"),
@@ -235,7 +228,6 @@ impl RunType {
             RunType::Nothing => true,
             RunType::StructuredConversion => false,
             RunType::StructuredRoundTrip => true,
-            RunType::OptimizeDirectJumps => true,
             RunType::RvsdgConversion => false,
             RunType::RvsdgRoundTrip => true,
             RunType::ToCfg => true,
@@ -317,7 +309,6 @@ impl Run {
         for test_type in [
             RunType::StructuredConversion,
             RunType::StructuredRoundTrip,
-            RunType::OptimizeDirectJumps,
             RunType::RvsdgConversion,
             RunType::RvsdgRoundTrip,
             RunType::CfgRoundTrip,
@@ -379,19 +370,6 @@ impl Run {
             RunType::StructuredRoundTrip => {
                 let structured = Optimizer::program_to_structured(&self.prog_with_args.program)?;
                 let bril = structured.to_program();
-                (
-                    vec![Visualization {
-                        result: bril.to_string(),
-                        file_extension: ".bril".to_string(),
-                        name: "".to_string(),
-                    }],
-                    Some(bril),
-                )
-            }
-            RunType::OptimizeDirectJumps => {
-                let cfg = Optimizer::program_to_cfg(&self.prog_with_args.program);
-                let optimized = cfg.optimize_jumps();
-                let bril = optimized.to_bril();
                 (
                     vec![Visualization {
                         result: bril.to_string(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -308,6 +308,7 @@ impl Run {
         let mut res = vec![];
         for test_type in [
             RunType::StructuredConversion,
+            RunType::StructuredRoundTrip,
             RunType::RvsdgConversion,
             RunType::RvsdgRoundTrip,
             RunType::CfgRoundTrip,

--- a/tests/snapshots/files__add-structured.snap
+++ b/tests/snapshots/files__add-structured.snap
@@ -3,11 +3,9 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
- v0: int = const 1;
- v1: int = const 2;
- v2: int = add v0 v1;
- print v2;
- return
-
+v0: int = const 1;
+v1: int = const 2;
+v2: int = add v0 v1;
+print v2;
+return
 }

--- a/tests/snapshots/files__add_block_indirection-structured.snap
+++ b/tests/snapshots/files__add_block_indirection-structured.snap
@@ -3,15 +3,10 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
 
-block:
- v0: int = const 1;
-block:
- v1: int = const 2;
- v2: int = add v0 v1;
-block:
- print v2;
- return
-
+v0: int = const 1;
+v1: int = const 2;
+v2: int = add v0 v1;
+print v2;
+return
 }

--- a/tests/snapshots/files__block-diamond-structured.snap
+++ b/tests/snapshots/files__block-diamond-structured.snap
@@ -5,31 +5,22 @@ expression: visualization.result
 main {
 block:
  block:
-  block:
-   block:
-    one: int = const 1;
-    two: int = const 2;
-    x: int = const 0;
-    a_cond: bool = lt arg two;
-    if a_cond:
-     break 2
-    else:
-     break 1
-   x: int = add x one;
-   break 1
-  block:
+  one: int = const 1;
+  two: int = const 2;
+  x: int = const 0;
+  a_cond: bool = lt arg two;
+  if a_cond:
    b_cond: bool = lt two arg;
    x: int = add x two;
    if b_cond:
-    break 1
-   else:
+    x: int = add x two;
     break 2
-  x: int = add x two;
-  break 1
- x: int = add x two;
-block:
- x: int = add x one;
- print x;
- return
+   else:
 
+  else:
+   x: int = add x one;
+ x: int = add x two;
+x: int = add x one;
+print x;
+return
 }

--- a/tests/snapshots/files__bool-structured.snap
+++ b/tests/snapshots/files__bool-structured.snap
@@ -3,9 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
- cond: bool = const true;
- print cond;
- return
-
+cond: bool = const true;
+print cond;
+return
 }

--- a/tests/snapshots/files__branch_duplicate_work-structured.snap
+++ b/tests/snapshots/files__branch_duplicate_work-structured.snap
@@ -11,10 +11,10 @@ block:
    if isless:
     break 2
    else:
-    break 1
+
   double: int = add x x;
   result: int = mul double two;
-  break 1
+  break 2
  result: int = add x x;
 block:
  print result;

--- a/tests/snapshots/files__branch_duplicate_work-structured.snap
+++ b/tests/snapshots/files__branch_duplicate_work-structured.snap
@@ -4,20 +4,13 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   two: int = const 2;
-   isless: bool = lt x two;
-   if isless:
-    break 2
-   else:
-
+ two: int = const 2;
+ isless: bool = lt x two;
+ if isless:
+  result: int = add x x;
+ else:
   double: int = add x x;
   result: int = mul double two;
-  break 2
- result: int = add x x;
-block:
- print result;
- return
-
+print result;
+return
 }

--- a/tests/snapshots/files__collatz-structured.snap
+++ b/tests/snapshots/files__collatz-structured.snap
@@ -11,31 +11,19 @@ block:
  var: int = id arg;
  counter: int = id zero;
 while true:
- block:
-  block:
-   cond: bool = eq var one;
-   if cond:
-    break 2
-   else:
-
-  block:
-   block:
-    counter: int = add counter one;
-    d: int = div var two;
-    m: int = mul d two;
-    mod: int = sub var m;
-    cond: bool = eq mod zero;
-    if cond:
-     break 2
-    else:
-
-   v1: int = mul three var;
-   var: int = add one v1;
-   break 3
-  var: int = div var two;
-  break 2
- block:
+ cond: bool = eq var one;
+ if cond:
   print counter;
   return
-
+ else:
+  counter: int = add counter one;
+  d: int = div var two;
+  m: int = mul d two;
+  mod: int = sub var m;
+  cond: bool = eq mod zero;
+  if cond:
+   var: int = div var two;
+  else:
+   v1: int = mul three var;
+   var: int = add one v1;
 }

--- a/tests/snapshots/files__collatz-structured.snap
+++ b/tests/snapshots/files__collatz-structured.snap
@@ -17,7 +17,7 @@ while true:
    if cond:
     break 2
    else:
-    break 1
+
   block:
    block:
     counter: int = add counter one;
@@ -28,12 +28,12 @@ while true:
     if cond:
      break 2
     else:
-     break 1
+
    v1: int = mul three var;
    var: int = add one v1;
-   break 2
+   break 3
   var: int = div var two;
-  break 1
+  break 2
  block:
   print counter;
   return

--- a/tests/snapshots/files__collatz_redundant_computation-structured.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-structured.snap
@@ -10,33 +10,21 @@ block:
  zero: int = const 0;
  var: int = id arg;
 while true:
- block:
-  block:
-   cond: bool = eq var one;
-   if cond:
-    break 2
-   else:
-
-  block:
-   block:
-    d: int = div var two;
-    m: int = mul d two;
-    mod: int = sub var m;
-    cond: bool = eq mod zero;
-    print var;
-    var_then: int = div var two;
-    v1_else: int = mul three var;
-    var_else: int = add one v1_else;
-    if cond:
-     break 2
-    else:
-
-   var: int = id var_else;
-   break 3
-  var: int = id var_then;
-  break 2
- block:
+ cond: bool = eq var one;
+ if cond:
   print arg;
   return
-
+ else:
+  d: int = div var two;
+  m: int = mul d two;
+  mod: int = sub var m;
+  cond: bool = eq mod zero;
+  print var;
+  var_then: int = div var two;
+  v1_else: int = mul three var;
+  var_else: int = add one v1_else;
+  if cond:
+   var: int = id var_then;
+  else:
+   var: int = id var_else;
 }

--- a/tests/snapshots/files__collatz_redundant_computation-structured.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-structured.snap
@@ -16,7 +16,7 @@ while true:
    if cond:
     break 2
    else:
-    break 1
+
   block:
    block:
     d: int = div var two;
@@ -30,11 +30,11 @@ while true:
     if cond:
      break 2
     else:
-     break 1
+
    var: int = id var_else;
-   break 2
+   break 3
   var: int = id var_then;
-  break 1
+  break 2
  block:
   print arg;
   return

--- a/tests/snapshots/files__constant_fold_simple-structured.snap
+++ b/tests/snapshots/files__constant_fold_simple-structured.snap
@@ -3,13 +3,11 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
- v0: int = const 1;
- v1: int = const 2;
- v2: int = mul v0 v1;
- v3: int = add v0 v1;
- v4: int = div v3 v2;
- print v4;
- return
-
+v0: int = const 1;
+v1: int = const 2;
+v2: int = mul v0 v1;
+v3: int = add v0 v1;
+v4: int = div v3 v2;
+print v4;
+return
 }

--- a/tests/snapshots/files__diamond-structured.snap
+++ b/tests/snapshots/files__diamond-structured.snap
@@ -10,10 +10,10 @@ block:
    if cond:
     break 2
    else:
-    break 1
+
   a: int = const 2;
   print a;
-  break 1
+  break 2
  a: int = const 1;
  print a;
 block:

--- a/tests/snapshots/files__diamond-structured.snap
+++ b/tests/snapshots/files__diamond-structured.snap
@@ -4,20 +4,13 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   cond: bool = lt x x;
-   if cond:
-    break 2
-   else:
-
+ cond: bool = lt x x;
+ if cond:
+  a: int = const 1;
+  print a;
+ else:
   a: int = const 2;
   print a;
-  break 2
- a: int = const 1;
- print a;
-block:
 
- return
-
+return
 }

--- a/tests/snapshots/files__duplicate_branch-structured.snap
+++ b/tests/snapshots/files__duplicate_branch-structured.snap
@@ -4,18 +4,13 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  x: int = const 4;
-  cond: bool = lt x y;
-  if cond:
-   break 2
-  else:
+ x: int = const 4;
+ cond: bool = lt x y;
+ if cond:
 
- a: int = const 1;
-block:
- a: int = const 1;
-block:
- print x;
- return
-
+ else:
+  a: int = const 1;
+a: int = const 1;
+print x;
+return
 }

--- a/tests/snapshots/files__duplicate_branch-structured.snap
+++ b/tests/snapshots/files__duplicate_branch-structured.snap
@@ -10,7 +10,7 @@ block:
   if cond:
    break 2
   else:
-   break 1
+
  a: int = const 1;
 block:
  a: int = const 1;

--- a/tests/snapshots/files__eliminate_gamma-structured.snap
+++ b/tests/snapshots/files__eliminate_gamma-structured.snap
@@ -4,22 +4,15 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   a: int = const 1;
-   b: int = const 2;
-   condition: bool = lt a b;
-   if condition:
-    break 2
-   else:
-
+ a: int = const 1;
+ b: int = const 2;
+ condition: bool = lt a b;
+ if condition:
+  thenval: int = const 1;
+  print thenval;
+ else:
   elseval: int = const 2;
   print elseval;
-  break 2
- thenval: int = const 1;
- print thenval;
-block:
 
- return
-
+return
 }

--- a/tests/snapshots/files__eliminate_gamma-structured.snap
+++ b/tests/snapshots/files__eliminate_gamma-structured.snap
@@ -12,10 +12,10 @@ block:
    if condition:
     break 2
    else:
-    break 1
+
   elseval: int = const 2;
   print elseval;
-  break 1
+  break 2
  thenval: int = const 1;
  print thenval;
 block:

--- a/tests/snapshots/files__eliminate_gamma_interval-structured.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-structured.snap
@@ -12,10 +12,10 @@ block:
    if cond1:
     break 2
    else:
-    break 1
+
   x: int = const 3;
   y: int = add x five;
-  break 1
+  break 2
  x: int = const 2;
  y: int = add x five;
 block:
@@ -25,10 +25,10 @@ block:
    if condition:
     break 2
    else:
-    break 1
+
   elseval: int = const 2;
   print elseval;
-  break 1
+  break 2
  thenval: int = const 1;
  print thenval;
 block:

--- a/tests/snapshots/files__eliminate_gamma_interval-structured.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-structured.snap
@@ -4,35 +4,23 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   ten: int = const 10;
-   five: int = const 5;
-   cond1: bool = lt input ten;
-   if cond1:
-    break 2
-   else:
-
+ ten: int = const 10;
+ five: int = const 5;
+ cond1: bool = lt input ten;
+ if cond1:
+  x: int = const 2;
+  y: int = add x five;
+ else:
   x: int = const 3;
   y: int = add x five;
-  break 2
- x: int = const 2;
- y: int = add x five;
 block:
- block:
-  block:
-   condition: bool = lt y five;
-   if condition:
-    break 2
-   else:
-
+ condition: bool = lt y five;
+ if condition:
+  thenval: int = const 1;
+  print thenval;
+ else:
   elseval: int = const 2;
   print elseval;
-  break 2
- thenval: int = const 1;
- print thenval;
-block:
 
- return
-
+return
 }

--- a/tests/snapshots/files__eliminate_loop-structured.snap
+++ b/tests/snapshots/files__eliminate_loop-structured.snap
@@ -13,7 +13,7 @@ while true:
   if cond:
    break 2
   else:
-   break 1
+
  block:
   print one;
   return

--- a/tests/snapshots/files__eliminate_loop-structured.snap
+++ b/tests/snapshots/files__eliminate_loop-structured.snap
@@ -6,16 +6,12 @@ main {
 block:
 
 while true:
- block:
-  one: int = const 1;
-  three: int = const 3;
-  cond: bool = lt three one;
-  if cond:
-   break 2
-  else:
+ one: int = const 1;
+ three: int = const 3;
+ cond: bool = lt three one;
+ if cond:
 
- block:
+ else:
   print one;
   return
-
 }

--- a/tests/snapshots/files__fib_shape-structured.snap
+++ b/tests/snapshots/files__fib_shape-structured.snap
@@ -13,7 +13,7 @@ while true:
    if cond:
     break 2
    else:
-    break 1
+
   block:
    donebody: int = const 1;
    print i;

--- a/tests/snapshots/files__fib_shape-structured.snap
+++ b/tests/snapshots/files__fib_shape-structured.snap
@@ -7,18 +7,12 @@ block:
  one: int = const 1;
  i: int = const 0;
 while true:
- block:
-  block:
-   cond: bool = lt i input;
-   if cond:
-    break 2
-   else:
-
-  block:
-   donebody: int = const 1;
-   print i;
-   return
-
- i: int = add i one;
- bodyvar: int = const 1;
+ cond: bool = lt i input;
+ if cond:
+  i: int = add i one;
+  bodyvar: int = const 1;
+ else:
+  donebody: int = const 1;
+  print i;
+  return
 }

--- a/tests/snapshots/files__flatten_loop-structured.snap
+++ b/tests/snapshots/files__flatten_loop-structured.snap
@@ -20,7 +20,7 @@ while true:
     j: int = add j one;
    else:
     i: int = add i one;
-    break 2
+    break 1
  else:
   print i;
   return

--- a/tests/snapshots/files__flatten_loop-structured.snap
+++ b/tests/snapshots/files__flatten_loop-structured.snap
@@ -7,31 +7,21 @@ block:
  one: int = const 1;
  i: int = const 0;
 while true:
- block:
+ cond: bool = lt i N;
+ if cond:
   block:
-   cond: bool = lt i N;
+   j: int = const 0;
+  while true:
+   cond: bool = lt j M;
    if cond:
-    break 2
+    i_times_m: int = mul i M;
+    plus_j: int = add i_times_m j;
+    print plus_j;
+    j: int = add j one;
    else:
-
-  block:
-   print i;
-   return
-
- block:
-  j: int = const 0;
- while true:
-  block:
-   block:
-    cond: bool = lt j M;
-    if cond:
-     break 2
-    else:
-
-   i: int = add i one;
-   break 3
-  i_times_m: int = mul i M;
-  plus_j: int = add i_times_m j;
-  print plus_j;
-  j: int = add j one;
+    i: int = add i one;
+    break 2
+ else:
+  print i;
+  return
 }

--- a/tests/snapshots/files__flatten_loop-structured.snap
+++ b/tests/snapshots/files__flatten_loop-structured.snap
@@ -13,7 +13,7 @@ while true:
    if cond:
     break 2
    else:
-    break 1
+
   block:
    print i;
    return
@@ -27,9 +27,9 @@ while true:
     if cond:
      break 2
     else:
-     break 1
+
    i: int = add i one;
-   break 2
+   break 3
   i_times_m: int = mul i M;
   plus_j: int = add i_times_m j;
   print plus_j;

--- a/tests/snapshots/files__gamma_condition_and-structured.snap
+++ b/tests/snapshots/files__gamma_condition_and-structured.snap
@@ -14,9 +14,9 @@ block:
    if c:
     break 2
    else:
-    break 1
+
   print y;
-  break 1
+  break 2
  print x;
 block:
  print z;

--- a/tests/snapshots/files__gamma_condition_and-structured.snap
+++ b/tests/snapshots/files__gamma_condition_and-structured.snap
@@ -4,22 +4,15 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   y: int = const 2;
-   z: int = const 3;
-   a: bool = lt x y;
-   b: bool = lt y z;
-   c: bool = and a b;
-   if c:
-    break 2
-   else:
-
+ y: int = const 2;
+ z: int = const 3;
+ a: bool = lt x y;
+ b: bool = lt y z;
+ c: bool = and a b;
+ if c:
+  print x;
+ else:
   print y;
-  break 2
- print x;
-block:
- print z;
- return
-
+print z;
+return
 }

--- a/tests/snapshots/files__gamma_pull_in-structured.snap
+++ b/tests/snapshots/files__gamma_pull_in-structured.snap
@@ -11,9 +11,9 @@ block:
    if cond:
     break 2
    else:
-    break 1
+
   x: int = const 3;
-  break 1
+  break 2
  x: int = const 2;
 block:
  y: int = add x x;

--- a/tests/snapshots/files__gamma_pull_in-structured.snap
+++ b/tests/snapshots/files__gamma_pull_in-structured.snap
@@ -4,22 +4,14 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   ten: int = const 10;
-   cond: bool = lt input ten;
-   if cond:
-    break 2
-   else:
-
+ ten: int = const 10;
+ cond: bool = lt input ten;
+ if cond:
+  x: int = const 2;
+ else:
   x: int = const 3;
-  break 2
- x: int = const 2;
-block:
- y: int = add x x;
- print y;
-block:
+y: int = add x x;
+print y;
 
- return
-
+return
 }

--- a/tests/snapshots/files__implicit-return-structured.snap
+++ b/tests/snapshots/files__implicit-return-structured.snap
@@ -3,17 +3,15 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
- v0: int = const 4;
- x: int = id v0;
- v1: int = const 15;
- n: int = id v1;
- v2: int = id x;
- v3: int = id n;
- call @pow v2 v3;
- v4: int = const 0;
- return
-
+v0: int = const 4;
+x: int = id v0;
+v1: int = const 15;
+n: int = id v1;
+v2: int = id x;
+v3: int = id n;
+call @pow v2 v3;
+v4: int = const 0;
+return
 }
 
 pow {
@@ -23,29 +21,23 @@ block:
  v2: int = const 0;
  _i: int = id v2;
 while true:
- block:
-  block:
-   v3: int = id _i;
-   v4: int = id n;
-   v5: int = const 1;
-   v6: int = sub v4 v5;
-   v7: bool = lt v3 v6;
-   if v7:
-    break 2
-   else:
-
-  block:
-   v14: int = id res;
-   print v14;
-   v15: int = const 0;
-   return
-
- v8: int = id res;
- v9: int = id x;
- v10: int = mul v8 v9;
- res: int = id v10;
- v11: int = id _i;
- v12: int = const 1;
- v13: int = add v11 v12;
- _i: int = id v13;
+ v3: int = id _i;
+ v4: int = id n;
+ v5: int = const 1;
+ v6: int = sub v4 v5;
+ v7: bool = lt v3 v6;
+ if v7:
+  v8: int = id res;
+  v9: int = id x;
+  v10: int = mul v8 v9;
+  res: int = id v10;
+  v11: int = id _i;
+  v12: int = const 1;
+  v13: int = add v11 v12;
+  _i: int = id v13;
+ else:
+  v14: int = id res;
+  print v14;
+  v15: int = const 0;
+  return
 }

--- a/tests/snapshots/files__implicit-return-structured.snap
+++ b/tests/snapshots/files__implicit-return-structured.snap
@@ -33,7 +33,7 @@ while true:
    if v7:
     break 2
    else:
-    break 1
+
   block:
    v14: int = id res;
    print v14;

--- a/tests/snapshots/files__loop_if-structured.snap
+++ b/tests/snapshots/files__loop_if-structured.snap
@@ -8,26 +8,17 @@ block:
  x: int = const 0;
 while true:
  block:
-  block:
-   block:
-    iseq: bool = eq y x;
-    if iseq:
-     break 2
-    else:
-     break 1
+  iseq: bool = eq y x;
+  if iseq:
+   two: int = const 2;
+  else:
    one: int = const 1;
    x: int = add x one;
    y: int = add y one;
-   break 1
-  two: int = const 2;
- block:
 
-  if iseq:
-   break 1
-  else:
-   break 2
- block:
+ if iseq:
   print x;
   return
+ else:
 
 }

--- a/tests/snapshots/files__loop_pass_through-structured.snap
+++ b/tests/snapshots/files__loop_pass_through-structured.snap
@@ -6,17 +6,13 @@ main {
 block:
  i: int = const 1;
 while true:
- block:
-  max: int = const 10;
-  cond: bool = lt i max;
-  i: int = add i i;
-  if cond:
-   break 2
-  else:
+ max: int = const 10;
+ cond: bool = lt i max;
+ i: int = add i i;
+ if cond:
 
- block:
+ else:
   res: int = add i input;
   print res;
   return
-
 }

--- a/tests/snapshots/files__loop_pass_through-structured.snap
+++ b/tests/snapshots/files__loop_pass_through-structured.snap
@@ -13,7 +13,7 @@ while true:
   if cond:
    break 2
   else:
-   break 1
+
  block:
   res: int = add i input;
   print res;

--- a/tests/snapshots/files__nested_call-structured.snap
+++ b/tests/snapshots/files__nested_call-structured.snap
@@ -3,30 +3,24 @@ source: tests/files.rs
 expression: visualization.result
 ---
 double {
-block:
- two: int = const 2;
- res: int = mul two x;
- return res
-
+two: int = const 2;
+res: int = mul two x;
+return res
 }
 
 inc {
-block:
- one: int = const 1;
- x: int = add one x;
- x: int = call @double x;
- return x
-
+one: int = const 1;
+x: int = add one x;
+x: int = call @double x;
+return x
 }
 
 main {
-block:
- a: int = const 0;
- b: int = call @inc a;
- print b;
- c: int = const 1;
- c: int = call @double c;
- print c;
- return
-
+a: int = const 0;
+b: int = call @inc a;
+print b;
+c: int = const 1;
+c: int = call @double c;
+print c;
+return
 }

--- a/tests/snapshots/files__range_check-structured.snap
+++ b/tests/snapshots/files__range_check-structured.snap
@@ -7,30 +7,21 @@ block:
  i: int = const 0;
 while true:
  block:
-  block:
-   block:
-    five: int = const 5;
-    if_cond: bool = lt i five;
-    if if_cond:
-     break 2
-    else:
-
+  five: int = const 5;
+  if_cond: bool = lt i five;
+  if if_cond:
+   one: int = const 1;
+   print one;
+  else:
    two: int = const 2;
    print two;
-   break 2
-  one: int = const 1;
-  print one;
- block:
-  six: int = const 6;
-  loop_cond: bool = lt i six;
-  one: int = const 1;
-  i: int = add i one;
-  if loop_cond:
-   break 2
-  else:
+ six: int = const 6;
+ loop_cond: bool = lt i six;
+ one: int = const 1;
+ i: int = add i one;
+ if loop_cond:
 
- block:
+ else:
   print i;
   return
-
 }

--- a/tests/snapshots/files__range_check-structured.snap
+++ b/tests/snapshots/files__range_check-structured.snap
@@ -14,10 +14,10 @@ while true:
     if if_cond:
      break 2
     else:
-     break 1
+
    two: int = const 2;
    print two;
-   break 1
+   break 2
   one: int = const 1;
   print one;
  block:
@@ -28,7 +28,7 @@ while true:
   if loop_cond:
    break 2
   else:
-   break 1
+
  block:
   print i;
   return

--- a/tests/snapshots/files__range_splitting-structured.snap
+++ b/tests/snapshots/files__range_splitting-structured.snap
@@ -7,30 +7,21 @@ block:
  i: int = const 0;
 while true:
  block:
-  block:
-   block:
-    a: int = const 5;
-    if_cond: bool = lt i a;
-    if if_cond:
-     break 2
-    else:
-
+  a: int = const 5;
+  if_cond: bool = lt i a;
+  if if_cond:
+   one: int = const 1;
+   print one;
+  else:
    two: int = const 2;
    print two;
-   break 2
-  one: int = const 1;
-  print one;
- block:
-  one: int = const 1;
-  i: int = add i one;
-  b: int = const 5;
-  loop_cond: bool = lt i b;
-  if loop_cond:
-   break 2
-  else:
+ one: int = const 1;
+ i: int = add i one;
+ b: int = const 5;
+ loop_cond: bool = lt i b;
+ if loop_cond:
 
- block:
+ else:
   print i;
   return
-
 }

--- a/tests/snapshots/files__range_splitting-structured.snap
+++ b/tests/snapshots/files__range_splitting-structured.snap
@@ -14,10 +14,10 @@ while true:
     if if_cond:
      break 2
     else:
-     break 1
+
    two: int = const 2;
    print two;
-   break 1
+   break 2
   one: int = const 1;
   print one;
  block:
@@ -28,7 +28,7 @@ while true:
   if loop_cond:
    break 2
   else:
-   break 1
+
  block:
   print i;
   return

--- a/tests/snapshots/files__reassoc-structured.snap
+++ b/tests/snapshots/files__reassoc-structured.snap
@@ -3,16 +3,14 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
- one: int = const 1;
- two: int = const 2;
- three: int = const 3;
- four: int = const 4;
- a2: int = add a three;
- b4: int = add b four;
- a2b4: int = add a2 b4;
- onea2b4: int = add one a2b4;
- print onea2b4;
- return
-
+one: int = const 1;
+two: int = const 2;
+three: int = const 3;
+four: int = const 4;
+a2: int = add a three;
+b4: int = add b four;
+a2b4: int = add a2 b4;
+onea2b4: int = add one a2b4;
+print onea2b4;
+return
 }

--- a/tests/snapshots/files__simple-call-structured.snap
+++ b/tests/snapshots/files__simple-call-structured.snap
@@ -3,18 +3,14 @@ source: tests/files.rs
 expression: visualization.result
 ---
 inc {
-block:
- one: int = const 1;
- res: int = add one x;
- return res
-
+one: int = const 1;
+res: int = add one x;
+return res
 }
 
 main {
-block:
- a: int = const 0;
- c: int = call @inc a;
- print c;
- return
-
+a: int = const 0;
+c: int = call @inc a;
+print c;
+return
 }

--- a/tests/snapshots/files__simple_branch-structured.snap
+++ b/tests/snapshots/files__simple_branch-structured.snap
@@ -11,9 +11,9 @@ block:
    if isless:
     break 2
    else:
-    break 1
+
   result: int = const 0;
-  break 1
+  break 2
  result: int = const 1;
 block:
  print result;

--- a/tests/snapshots/files__simple_branch-structured.snap
+++ b/tests/snapshots/files__simple_branch-structured.snap
@@ -4,19 +4,12 @@ expression: visualization.result
 ---
 main {
 block:
- block:
-  block:
-   zero: int = const 0;
-   isless: bool = lt arg zero;
-   if isless:
-    break 2
-   else:
-
+ zero: int = const 0;
+ isless: bool = lt arg zero;
+ if isless:
+  result: int = const 1;
+ else:
   result: int = const 0;
-  break 2
- result: int = const 1;
-block:
- print result;
- return
-
+print result;
+return
 }

--- a/tests/snapshots/files__simple_call-structured.snap
+++ b/tests/snapshots/files__simple_call-structured.snap
@@ -3,18 +3,14 @@ source: tests/files.rs
 expression: visualization.result
 ---
 inc {
-block:
- one: int = const 1;
- res: int = add one x;
- print res;
- return
-
+one: int = const 1;
+res: int = add one x;
+print res;
+return
 }
 
 main {
-block:
- a: int = const 0;
- call @inc a;
- return
-
+a: int = const 0;
+call @inc a;
+return
 }

--- a/tests/snapshots/files__simple_loop-structured.snap
+++ b/tests/snapshots/files__simple_loop-structured.snap
@@ -12,7 +12,7 @@ while true:
   if cond:
    break 2
   else:
-   break 1
+
  block:
   print i;
   return

--- a/tests/snapshots/files__simple_loop-structured.snap
+++ b/tests/snapshots/files__simple_loop-structured.snap
@@ -6,15 +6,11 @@ main {
 block:
 
 while true:
- block:
-  i: int = const 0;
-  cond: bool = lt i i;
-  if cond:
-   break 2
-  else:
+ i: int = const 0;
+ cond: bool = lt i i;
+ if cond:
 
- block:
+ else:
   print i;
   return
-
 }

--- a/tests/snapshots/files__simple_recursive-structured.snap
+++ b/tests/snapshots/files__simple_recursive-structured.snap
@@ -4,28 +4,22 @@ expression: visualization.result
 ---
 inc {
 block:
- block:
-  max: int = const 2;
-  cond: bool = lt x max;
-  if cond:
-   break 1
-  else:
-   break 2
- one: int = const 1;
- x: int = add one x;
- print x;
- x: int = call @inc x;
-block:
+ max: int = const 2;
+ cond: bool = lt x max;
+ if cond:
+  one: int = const 1;
+  x: int = add one x;
+  print x;
+  x: int = call @inc x;
+ else:
 
- return x
 
+return x
 }
 
 main {
-block:
- a: int = const 0;
- c: int = call @inc a;
- print c;
- return
-
+a: int = const 0;
+c: int = call @inc a;
+print c;
+return
 }

--- a/tests/snapshots/files__strong_loop-structured.snap
+++ b/tests/snapshots/files__strong_loop-structured.snap
@@ -19,7 +19,7 @@ while true:
   if cond:
    break 2
   else:
-   break 1
+
  block:
   print total;
   print x;

--- a/tests/snapshots/files__strong_loop-structured.snap
+++ b/tests/snapshots/files__strong_loop-structured.snap
@@ -8,22 +8,18 @@ block:
  x: int = add n i;
  total: int = const 0;
 while true:
- block:
-  c: int = const 7;
-  one: int = const 2;
-  cond: bool = lt i n;
-  y: int = mul c i;
-  print y;
-  total: int = add total y;
-  i: int = add i one;
-  if cond:
-   break 2
-  else:
+ c: int = const 7;
+ one: int = const 2;
+ cond: bool = lt i n;
+ y: int = mul c i;
+ print y;
+ total: int = add total y;
+ i: int = add i one;
+ if cond:
 
- block:
+ else:
   print total;
   print x;
   print i;
   return
-
 }

--- a/tests/snapshots/files__two_fns-structured.snap
+++ b/tests/snapshots/files__two_fns-structured.snap
@@ -3,20 +3,16 @@ source: tests/files.rs
 expression: visualization.result
 ---
 main {
-block:
- v0: int = const 1;
- v1: int = const 2;
- v2: int = add v0 v1;
- print v2;
- return
-
+v0: int = const 1;
+v1: int = const 2;
+v2: int = add v0 v1;
+print v2;
+return
 }
 
 sub {
-block:
- v0: int = const 1;
- v1: int = const 2;
- v2: int = sub v0 v1;
- return v2
-
+v0: int = const 1;
+v1: int = const 2;
+v2: int = sub v0 v1;
+return v2
 }

--- a/tests/snapshots/files__unroll_and_constant_fold-structured.snap
+++ b/tests/snapshots/files__unroll_and_constant_fold-structured.snap
@@ -13,7 +13,7 @@ while true:
   if cond:
    break 2
   else:
-   break 1
+
  block:
   print i;
   return

--- a/tests/snapshots/files__unroll_and_constant_fold-structured.snap
+++ b/tests/snapshots/files__unroll_and_constant_fold-structured.snap
@@ -7,15 +7,11 @@ block:
  i: int = const 0;
  one: int = const 1;
 while true:
- block:
-  i: int = add i one;
-  cond: bool = lt i one;
-  if cond:
-   break 2
-  else:
+ i: int = add i one;
+ cond: bool = lt i one;
+ if cond:
 
- block:
+ else:
   print i;
   return
-
 }


### PR DESCRIPTION
I've re-visited the Bril `Program` to `StructuredProgram` conversion code because I would like to use it for the tree unique schema.

There were two bugs to fix:
- Structured conversion considered `If` to be a scope in some places but not others
- Breaking out of a block within a loop was incorrect and broke out too far
