### PR TITLE
Fix a bug in `optimize_direct_jumps` and add testing

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -10,6 +10,7 @@ use std::{collections::HashMap, fmt::Display};
 use std::{fmt, mem};
 
 use bril_rs::{Argument, Code, EffectOps, Function, Instruction, Position, Program, Type};
+use hashbrown::HashSet;
 use petgraph::dot::Dot;
 
 use petgraph::stable_graph::{EdgeReference, StableDiGraph};
@@ -328,6 +329,7 @@ pub struct CfgFunction<CfgType> {
     /// The arguments to the function.
     pub(crate) args: Vec<Argument>,
     /// The graph itself.
+    /// Invariant: contains only reachable nodes.
     pub(crate) graph: StableDiGraph<BasicBlock, Branch>,
     /// The entry node for the CFG.
     pub(crate) entry: NodeIndex,
@@ -345,6 +347,22 @@ pub type SimpleCfgFunction = CfgFunction<Simple>;
 pub type SwitchCfgFunction = CfgFunction<Switch>;
 
 impl<CfgType> CfgFunction<CfgType> {
+    pub(crate) fn remove_unreachable(&mut self) {
+        let mut reachable = HashSet::new();
+        let mut dfs = DfsPostOrder::new(&self.graph, self.entry);
+        while let Some(node) = dfs.next(&self.graph) {
+            reachable.insert(node);
+        }
+        let mut to_remove = Vec::new();
+        for node in self.graph.node_indices() {
+            if !reachable.contains(&node) {
+                to_remove.push(node);
+            }
+        }
+        for node in to_remove {
+            self.graph.remove_node(node);
+        }
+    }
     pub(crate) fn has_return_value(&self) -> bool {
         self.return_ty.is_some()
     }
@@ -455,6 +473,14 @@ pub(crate) fn function_to_cfg(func: &Function) -> SimpleCfgFunction {
     for inst in &func.instrs {
         match inst {
             Code::Label { label, pos } => {
+                assert!(
+                    label != &BlockName::Entry.to_string(),
+                    "not allowed to use entry___ as a label"
+                );
+                assert!(
+                    label != &BlockName::Exit.to_string(),
+                    "not allowed to use exit___ as a label"
+                );
                 let next_block = builder.get_index(label);
                 builder.finish_block(current, mem::take(&mut block), mem::take(&mut anns));
                 builder.set_pos(next_block, pos.clone());
@@ -563,6 +589,7 @@ pub(crate) fn function_to_cfg(func: &Function) -> SimpleCfgFunction {
         }
     }
     builder.finish_block(current, block, anns);
+
     if !had_branch {
         builder.add_edge(
             current,
@@ -573,6 +600,9 @@ pub(crate) fn function_to_cfg(func: &Function) -> SimpleCfgFunction {
             },
         )
     }
+
+    // also, remove any unreachable blocks
+    builder.cfg.remove_unreachable();
 
     builder.cfg
 }

--- a/src/rvsdg/optimize_direct_jumps.rs
+++ b/src/rvsdg/optimize_direct_jumps.rs
@@ -25,10 +25,10 @@ impl<'a> JumpOptimizer<'a> {
     fn optimized(&mut self) -> SimpleCfgFunction {
         let mut resulting_graph: StableGraph<BasicBlock, Branch> = StableDiGraph::new();
 
-        // a map from nodes in the new graph to nodes in the
-        // old graph
-        // if a node was fused into another node, fix this
-        // so it points to the fused node
+        // a map from nodes in the old graph to nodes in the
+        // new graph
+        // if a node was fused into another node,
+        // it points to the new, fused node
         let mut node_mapping: HashMap<NodeIndex, NodeIndex> = HashMap::new();
 
         // we use a bfs so that previous nodes are mapped to new nodes
@@ -59,15 +59,18 @@ impl<'a> JumpOptimizer<'a> {
                 // single outgoing edge from previous
                 // and two distinct nodes
                 if previous_outgoing.len() == 1 && previous != node {
-                    let previous_node = node_mapping[&previous];
+                    let previous_new = node_mapping[&previous];
 
                     // this node will be mapped to the previous
-                    node_mapping.insert(node, previous_node);
+                    node_mapping.insert(node, previous_new);
 
                     // add instructions to the end of the previous node
-                    resulting_graph[previous_node]
+                    resulting_graph[previous_new]
                         .instrs
                         .extend(self.simple_func.graph[node].instrs.to_vec());
+                    resulting_graph[previous_new]
+                        .footer
+                        .extend(self.simple_func.graph[node].footer.to_vec());
 
                     collapse_node = true;
                 }

--- a/tests/repro-directjumps.bril
+++ b/tests/repro-directjumps.bril
@@ -1,0 +1,26 @@
+@main {
+.entry:
+  a: int = const 0;
+  c: int = call @inc a;
+  print c;
+  ret;
+}
+@inc(x: int): int {
+.entry:
+  max: int = const 2;
+  cond: bool = lt x max;
+  br cond .sblock1 .sblock2;
+.sblock1:
+.recurse:
+  one: int = const 1;
+  x: int = add one x;
+  print x;
+  x: int = call @inc x;
+  jmp .sblock3;
+.sblock2:
+.sblock3:
+.sblock0:
+.done:
+  ret x;
+}
+


### PR DESCRIPTION
We use `optimize_direct_jumps` to clean up cfgs that are generated by translation passes. It was fairly un-tested, and this PR fixes a bug where the footer wasn't getting copied over to the new cfg.