### PR TITLE
[Tree unique] Add `{Expr,ListExpr}IsValid` & update existing optimizations

### DIFF
--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -44,7 +44,7 @@ fn rules_for_ctor(ctor: Constructor) -> Option<String> {
                          :ruleset always-run)
 
                 ; Lift {ctor_name} when only {varying_field_name} varies
-                (rule ((Switch pred exprs)
+                (rule ((ExprShouldBeValid (Switch pred exprs))
                        ({relation} exprs)
                        ; Bind non-varying field(s)
                        (= list (Cons {ctor_pattern1} rest)))
@@ -93,6 +93,7 @@ fn test_easy_lift_switch() -> Result<(), egglog::Error> {
             (LessThan (Get (Arg id1) 0) (Num id1 7))
             (LessThan (Get (Arg id1) 1) (Num id1 7))
         )))
+(ExprShouldBeValid switch1)
     "
     );
     let check = "
@@ -123,6 +124,7 @@ fn test_lift_switch_through_switch() -> Result<(), egglog::Error> {
             (Switch (LessThan (Get (Arg id1) 0) (Num id1 7)) (Cons (Num id1 11) (Nil)))
             (Switch (LessThan (Get (Arg id1) 1) (Num id1 7)) (Cons (Num id1 11) (Nil)))
         )))
+(ExprShouldBeValid switch1)
     "
     );
     let check = "

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -44,7 +44,7 @@ fn rules_for_ctor(ctor: Constructor) -> Option<String> {
                          :ruleset always-run)
 
                 ; Lift {ctor_name} when only {varying_field_name} varies
-                (rule ((ExprShouldBeValid (Switch pred exprs))
+                (rule ((ExprIsValid (Switch pred exprs))
                        ({relation} exprs)
                        ; Bind non-varying field(s)
                        (= list (Cons {ctor_pattern1} rest)))
@@ -93,7 +93,7 @@ fn test_easy_lift_switch() -> Result<(), egglog::Error> {
             (LessThan (Get (Arg id1) 0) (Num id1 7))
             (LessThan (Get (Arg id1) 1) (Num id1 7))
         )))
-(ExprShouldBeValid switch1)
+(ExprIsValid switch1)
     "
     );
     let check = "
@@ -124,7 +124,7 @@ fn test_lift_switch_through_switch() -> Result<(), egglog::Error> {
             (Switch (LessThan (Get (Arg id1) 0) (Num id1 7)) (Cons (Num id1 11) (Nil)))
             (Switch (LessThan (Get (Arg id1) 1) (Num id1 7)) (Cons (Num id1 11) (Nil)))
         )))
-(ExprShouldBeValid switch1)
+(ExprIsValid switch1)
     "
     );
     let check = "

--- a/tree_unique_args/src/function_inlining.egg
+++ b/tree_unique_args/src/function_inlining.egg
@@ -4,7 +4,7 @@
     (
         (= call (Call f arg))
         (Function f out)
-        (ExprShouldBeValid call)
+        (ExprIsValid call)
     )
     (
         (let new-id (Id (i64-fresh!)))

--- a/tree_unique_args/src/function_inlining.egg
+++ b/tree_unique_args/src/function_inlining.egg
@@ -4,6 +4,7 @@
     (
         (= call (Call f arg))
         (Function f out)
+        (ExprShouldBeValid call)
     )
     (
         (let new-id (Id (i64-fresh!)))

--- a/tree_unique_args/src/function_inlining.rs
+++ b/tree_unique_args/src/function_inlining.rs
@@ -17,7 +17,7 @@ fn function_inlining() -> Result<(), egglog::Error> {
                 (Num outer-id 2)
             )
         )
-        (ExprShouldBeValid call)
+        (ExprIsValid call)
     ";
 
     let check = "

--- a/tree_unique_args/src/function_inlining.rs
+++ b/tree_unique_args/src/function_inlining.rs
@@ -17,6 +17,7 @@ fn function_inlining() -> Result<(), egglog::Error> {
                 (Num outer-id 2)
             )
         )
+        (ExprShouldBeValid call)
     ";
 
     let check = "

--- a/tree_unique_args/src/is_valid.rs
+++ b/tree_unique_args/src/is_valid.rs
@@ -5,7 +5,7 @@ fn rule_for_ctor(ctor: Constructor) -> Option<String> {
     let actions = ctor.filter_map_fields(|field| match field.purpose {
         Purpose::Static(_) | Purpose::CapturingId | Purpose::ReferencingId => None,
         Purpose::CapturedExpr | Purpose::SubExpr | Purpose::SubListExpr => Some(format!(
-            "({sort}ShouldBeValid {var})",
+            "({sort}IsValid {var})",
             sort = field.sort().name(),
             var = field.var()
         )),
@@ -21,13 +21,13 @@ fn rule_for_ctor(ctor: Constructor) -> Option<String> {
 
 pub(crate) fn rules() -> Vec<String> {
     ESort::iter()
-        .map(|sort| "(relation *ShouldBeValid (*))".replace('*', sort.name()))
+        .map(|sort| "(relation *IsValid (*))".replace('*', sort.name()))
         .chain(Constructor::iter().filter_map(rule_for_ctor))
         .collect::<Vec<_>>()
 }
 
 #[test]
-fn test_should_be_valid() -> Result<(), egglog::Error> {
+fn test_is_valid() -> Result<(), egglog::Error> {
     let build = &*format!(
         "
 (let id1 (Id (i64-fresh!)))
@@ -42,13 +42,13 @@ fn test_should_be_valid() -> Result<(), egglog::Error> {
             (All (Parallel) (Pair
                 (Add (Get (Arg id1) 0) (Num id1 1))
                 (Sub (Get (Arg id1) 1) (Num id1 1))))))))
-(ExprShouldBeValid loop)
+(ExprIsValid loop)
     "
     );
     let check = "
-(check (ExprShouldBeValid (Num id-outer 0)))
-(check (ExprShouldBeValid (Arg id1)))
-(check (ListExprShouldBeValid
+(check (ExprIsValid (Num id-outer 0)))
+(check (ExprIsValid (Arg id1)))
+(check (ListExprIsValid
          (Pair (Add (Get (Arg id1) 0) (Num id1 1))
                (Sub (Get (Arg id1) 1) (Num id1 1)))))
     ";

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -28,11 +28,11 @@ pub fn run_test(build: &str, check: &str) -> Result {
         [
             include_str!("schema.egg"),
             // analyses
+            &should_be_valid::rules().join("\n"),
             &purity_analysis::purity_analysis_rules().join("\n"),
             &body_contains::rules().join("\n"),
             &subst::subst_rules().join("\n"),
             &deep_copy::deep_copy_rules().join("\n"),
-            &should_be_valid::rules().join("\n"),
             include_str!("sugar.egg"),
             include_str!("util.egg"),
             // optimizations

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -9,8 +9,8 @@ pub(crate) mod conditional_invariant_code_motion;
 pub(crate) mod deep_copy;
 pub(crate) mod function_inlining;
 pub(crate) mod ir;
+pub(crate) mod is_valid;
 pub(crate) mod purity_analysis;
-pub(crate) mod should_be_valid;
 pub(crate) mod simple;
 pub(crate) mod subst;
 pub(crate) mod switch_rewrites;
@@ -29,7 +29,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
         [
             include_str!("schema.egg"),
             // analyses
-            &should_be_valid::rules().join("\n"),
+            &is_valid::rules().join("\n"),
             &purity_analysis::purity_analysis_rules().join("\n"),
             &body_contains::rules().join("\n"),
             &subst::subst_rules().join("\n"),

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -10,6 +10,7 @@ pub(crate) mod deep_copy;
 pub(crate) mod function_inlining;
 pub(crate) mod ir;
 pub(crate) mod purity_analysis;
+pub(crate) mod should_be_valid;
 pub(crate) mod subst;
 pub(crate) mod switch_rewrites;
 pub(crate) mod util;
@@ -31,6 +32,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
             &body_contains::rules().join("\n"),
             &subst::subst_rules().join("\n"),
             &deep_copy::deep_copy_rules().join("\n"),
+            &should_be_valid::rules().join("\n"),
             include_str!("sugar.egg"),
             include_str!("util.egg"),
             // optimizations

--- a/tree_unique_args/src/should_be_valid.rs
+++ b/tree_unique_args/src/should_be_valid.rs
@@ -1,0 +1,56 @@
+use crate::ir::{Constructor, ESort, Purpose};
+use strum::IntoEnumIterator;
+
+fn rule_for_ctor(ctor: Constructor) -> Option<String> {
+    let actions = ctor.filter_map_fields(|field| match field.purpose {
+        Purpose::Static(_) | Purpose::CapturingId | Purpose::ReferencingId => None,
+        Purpose::CapturedExpr | Purpose::SubExpr | Purpose::SubListExpr => Some(format!(
+            "({sort}ShouldBeValid {var})",
+            sort = field.sort().name(),
+            var = field.var()
+        )),
+    });
+
+    if actions.is_empty() {
+        return None;
+    }
+    let actions = actions.join("\n");
+    let pat = ctor.construct(|field| field.var());
+    Some(format!("(rule ({pat}) ({actions}) :ruleset always-run)"))
+}
+
+pub(crate) fn rules() -> Vec<String> {
+    ESort::iter()
+        .map(|sort| "(relation *ShouldBeValid (*))".replace('*', sort.name()))
+        .chain(Constructor::iter().filter_map(rule_for_ctor))
+        .collect::<Vec<_>>()
+}
+
+#[test]
+fn test_should_be_valid() -> Result<(), egglog::Error> {
+    let build = &*format!(
+        "
+(let id1 (Id (i64-fresh!)))
+(let id-outer (Id (i64-fresh!)))
+(let loop
+    (Loop id1
+        (All (Parallel) (Pair (Num id-outer 0) (Num id-outer 0)))
+        (All (Sequential) (Pair
+            ; pred
+            (LessThan (Get (Arg id1) 0) (Get (Arg id1) 1))
+            ; output
+            (All (Parallel) (Pair
+                (Add (Get (Arg id1) 0) (Num id1 1))
+                (Sub (Get (Arg id1) 1) (Num id1 1))))))))
+(ExprShouldBeValid loop)
+    "
+    );
+    let check = "
+(check (ExprShouldBeValid (Num id-outer 0)))
+(check (ExprShouldBeValid (Arg id1)))
+(check (ListExprShouldBeValid
+         (Pair (Add (Get (Arg id1) 0) (Num id1 1))
+               (Sub (Get (Arg id1) 1) (Num id1 1)))))
+    ";
+    crate::run_test(build, check)
+}

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -12,9 +12,9 @@ pub(crate) fn rules() -> String {
     let rules_needing_purity = equiv_when_b_pure
         .map(|(e1, e2)| {
             format!(
-                "(rewrite {e1} {e2} :when ((ExprIsPure b) (ExprShouldBeValid {e1}))
+                "(rewrite {e1} {e2} :when ((ExprIsPure b) (ExprIsValid {e1}))
                                     :ruleset switch-rewrites)
-                 (rewrite {e2} {e1} :when ((ExprIsPure b) (ExprShouldBeValid {e2}))
+                 (rewrite {e2} {e1} :when ((ExprIsPure b) (ExprIsValid {e2}))
                                     :ruleset switch-rewrites)"
             )
         })
@@ -25,11 +25,11 @@ pub(crate) fn rules() -> String {
         ; Constant condition elimination
         (rewrite (Switch (Boolean id true) (Cons A (Cons B (Nil))))
                  A
-                 :when ((ExprShouldBeValid (Switch (Boolean id true) (Cons A (Cons B (Nil))))))
+                 :when ((ExprIsValid (Switch (Boolean id true) (Cons A (Cons B (Nil))))))
                  :ruleset switch-rewrites)
         (rewrite (Switch (Boolean id false) (Cons A (Cons B (Nil))))
                  B
-                 :when ((ExprShouldBeValid (Switch (Boolean id false) (Cons A (Cons B (Nil))))))
+                 :when ((ExprIsValid (Switch (Boolean id false) (Cons A (Cons B (Nil))))))
                  :ruleset switch-rewrites)
 
         ; (if E then S1 else S2); S3 ==> if E then S1;S3 else S2;S3
@@ -47,7 +47,7 @@ fn switch_rewrite_and() -> crate::Result {
 (let id (Id (i64-fresh!)))
 (let switch (Switch (And (Boolean id false) (Boolean id true))
                     (Pair (Num id 1) (Num id 2))))
-(ExprShouldBeValid switch)
+(ExprIsValid switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean id false)
@@ -64,7 +64,7 @@ fn switch_rewrite_or() -> crate::Result {
 (let id (Id (i64-fresh!)))
 (let switch (Switch (Or (Boolean id false) (Boolean id true))
                     (Pair (Num id 1) (Num id 2))))
-(ExprShouldBeValid switch)
+(ExprIsValid switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean id false)
@@ -83,7 +83,7 @@ fn switch_rewrite_purity() -> crate::Result {
 (let impure (Let let-id (UnitExpr let-id) (All (Sequential) (Pair (Boolean let-id true) (Print (Num let-id 1))))))
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
-(ExprShouldBeValid switch)
+(ExprIsValid switch)
     ";
     let check = "
 (fail (check (= switch (Switch (Boolean switch-id false)
@@ -99,7 +99,7 @@ fn switch_rewrite_purity() -> crate::Result {
 (let impure (Let let-id (UnitExpr let-id) (All (Sequential) (Cons (Boolean let-id true) (Nil)))))
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
-(ExprShouldBeValid switch)
+(ExprIsValid switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean switch-id false)
@@ -119,8 +119,8 @@ fn test_constant_condition() -> Result<(), egglog::Error> {
     (let b (Num (Id (i64-fresh!)) 4))
     (let switch_t (Switch t (Cons a (Cons b (Nil)))))
     (let switch_f (Switch f (Cons a (Cons b (Nil)))))
-    (ExprShouldBeValid switch_t)
-    (ExprShouldBeValid switch_f)
+    (ExprIsValid switch_t)
+    (ExprIsValid switch_f)
   ";
     let check = "
     (check (= switch_t a))

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -1,22 +1,23 @@
 pub(crate) fn egglog() -> String {
-    format!(
-        "
-; Generated from switch_rewrites.rs
-(ruleset switch-rewrites)
-
-(birewrite (Switch (And a b) (Cons A (Cons B (Nil))))
-         (Switch a (Pair (Switch b (Pair A B))
-                         B))
-         :when ((ExprIsPure b))
-         :ruleset switch-rewrites)
-
-(birewrite (Switch (Or a b) (Cons A (Cons B (Nil))))
-         (Switch a (Pair A
-                         (Switch b (Pair A B))))
-         :when ((ExprIsPure b))
-         :ruleset switch-rewrites)
-"
-    )
+    let equiv_when_b_pure = [
+        (
+            "(Switch (And a b) (Cons A (Cons B (Nil))))",
+            "(Switch a (Pair (Switch b (Pair A B)) B))",
+        ),
+        (
+            "(Switch (Or a b) (Cons A (Cons B (Nil))))",
+            "(Switch a (Pair A (Switch b (Pair A B))))",
+        ),
+    ];
+    let rules = equiv_when_b_pure
+        .map(|(e1, e2)| {
+            format!(
+                "(rewrite {e1} {e2} :when ((ExprIsPure b) (ExprShouldBeValid {e1}))
+                                    :ruleset switch-rewrites)"
+            )
+        })
+        .join("\n");
+    format!("(ruleset switch-rewrites)\n{rules}")
 }
 
 #[test]
@@ -25,6 +26,7 @@ fn switch_rewrite_and() -> crate::Result {
 (let id (Id (i64-fresh!)))
 (let switch (Switch (And (Boolean id false) (Boolean id true))
                     (Pair (Num id 1) (Num id 2))))
+(ExprShouldBeValid switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean id false)
@@ -41,6 +43,7 @@ fn switch_rewrite_or() -> crate::Result {
 (let id (Id (i64-fresh!)))
 (let switch (Switch (Or (Boolean id false) (Boolean id true))
                     (Pair (Num id 1) (Num id 2))))
+(ExprShouldBeValid switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean id false)
@@ -59,6 +62,7 @@ fn switch_rewrite_purity() -> crate::Result {
 (let impure (Let let-id (UnitExpr let-id) (All (Sequential) (Pair (Boolean let-id true) (Print (Num let-id 1))))))
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
+(ExprShouldBeValid switch)
     ";
     let check = "
 (fail (check (= switch (Switch (Boolean switch-id false)
@@ -74,6 +78,7 @@ fn switch_rewrite_purity() -> crate::Result {
 (let impure (Let let-id (UnitExpr let-id) (All (Sequential) (Cons (Boolean let-id true) (Nil)))))
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
+(ExprShouldBeValid switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean switch-id false)

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -13,6 +13,8 @@ pub(crate) fn egglog() -> String {
         .map(|(e1, e2)| {
             format!(
                 "(rewrite {e1} {e2} :when ((ExprIsPure b) (ExprShouldBeValid {e1}))
+                                    :ruleset switch-rewrites)
+                 (rewrite {e2} {e1} :when ((ExprIsPure b) (ExprShouldBeValid {e2}))
                                     :ruleset switch-rewrites)"
             )
         })


### PR DESCRIPTION
Adds the following relations, which indicate that we expect some IR to be well-formed (typecheck, proper use of referencing and capturing ids).
```
(relation ExprIsValid (Expr))
(relation ListExprIsValid (ListExpr))
```

All optimizations that add to the e-graph should first match on these relations, to make sure we optimize code we care about, and not intermediary terms that still need to be substed or copied. This has the following benefits:
- Preserve invariants - it prevents provenance of an Expr term from having semantics, which makes [soundness of our capturing id invariants](https://gist.github.com/rtjoa/a28a0dd7b16da2f4a5a414ad8c4c7127/) easier.
- Performance - when we only optimize `IsValid` expressions, we avoid wasting time on intermediary to-be-copied-or-substed expressions, which could be a source of blowup.

This PR also ports existing optimizations to use these relations.