### PR TITLE
[Tree unique] Referencing Id Analysis

### DIFF
--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -9,11 +9,15 @@ fn id_analysis_rules_for_ctor(ctor: Constructor) -> String {
         let field_sort = field.sort().name();
         match field.purpose {
             Purpose::Static(_) | Purpose::CapturedExpr | Purpose::CapturingId => None,
+
+            // Base case: constructor has referencing id specified as a field
             Purpose::ReferencingId => Some(format!(
                 "(rule ({pat})
                        (({sort}HasRefId {pat} {field_var}))
                        :ruleset always-run)"
             )),
+
+            // Constructor has referencing id of its subexpr fields
             Purpose::SubExpr | Purpose::SubListExpr => Some(format!(
                 "(rule ({pat} ({field_sort}HasRefId {field_var} ref-id))
                        (({sort}HasRefId {pat} ref-id))
@@ -25,6 +29,7 @@ fn id_analysis_rules_for_ctor(ctor: Constructor) -> String {
 }
 
 pub(crate) fn id_analysis_rules() -> Vec<String> {
+    // Error checks
     let id_check = vec!["
 (rule ((ExprHasRefId x id1)
        (ExprHasRefId x id2)

--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -1,0 +1,62 @@
+use crate::ir::{Constructor, ESort};
+use strum::IntoEnumIterator;
+
+fn id_analysis_rule_for_ctor(ctor: Constructor) -> Option<String> {
+    if ctor.fields().is_empty() {
+        None
+    } else {
+        let ctor_pattern = ctor.construct(|field| field.var());
+        // TODO: this should be preceded by an underscore
+        let first_var = ctor.fields()[0].var();
+        let var_sort = ctor.fields()[0].sort().name();
+        let sort = ctor.sort().name();
+
+        Some(
+            match ctor {
+                // Base cases: Num, Boolean, UnitExpr, Arg
+                // First arg for these is the id
+                Constructor::Num | Constructor::Boolean | Constructor::UnitExpr | Constructor::Arg=> 
+                    format!(
+"(rule
+    ({ctor_pattern})
+    ((union (RefIdOf{sort} {ctor_pattern}) {first_var}))
+    :ruleset always-run)"),
+
+                // For loops, call, all, let, get the id of the second item
+                Constructor::Loop | Constructor::Call | Constructor::All | Constructor::Let
+                    => format!(
+"(rule
+    ({ctor_pattern} (= aid (RefIdOf{} {})))
+    ((union (RefIdOf{sort} {ctor_pattern}) aid))
+    :ruleset always-run)", ctor.fields()[1].sort().name(), ctor.fields()[1].var()),
+
+                // For everything else, get the id of the first item
+                _ => 
+                    format!(
+"(rule ({ctor_pattern} (= aid (RefIdOf{var_sort} {first_var})))
+    ((union (RefIdOf{sort} {ctor_pattern}) aid))
+    :ruleset always-run)")
+            }
+        )
+    }
+}
+
+pub(crate) fn id_analysis_rules() -> Vec<String> {
+    let id_check = vec!["
+(rule ((= (Id a) (Id b))
+    (!= a b))
+  ((panic \"RefIdOf: Ids don't match\"))
+  :ruleset always-run)
+    ".to_string()];
+    
+    ESort::iter()
+        .map(|sort| "(function RefIdOf* (*) IdSort :unextractable)".replace('*', sort.name()))
+        .chain(Constructor::iter().filter_map(id_analysis_rule_for_ctor))
+        .chain(id_check)
+        .collect::<Vec<_>>()
+}
+
+#[test]
+fn test_id_analysis() {
+    print!("{}", id_analysis_rules().join("\n"));
+}

--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -29,25 +29,19 @@ fn id_analysis_rules_for_ctor(ctor: Constructor) -> String {
 }
 
 pub(crate) fn id_analysis_rules() -> Vec<String> {
-    // Error checks
-    let id_check = vec!["
-(rule ((ExprHasRefId x id1)
-       (ExprHasRefId x id2)
-       (!= id1 id2))
-      ((panic \"Ref ids don't match\"))
-      :ruleset error-checking)
-(rule ((ListExprHasRefId x id1)
-       (ListExprHasRefId x id2)
-       (!= id1 id2))
-      ((panic \"Ref ids don't match\"))
-      :ruleset error-checking)
-    "
-    .to_string()];
-
     ESort::iter()
-        .map(|sort| "(relation *HasRefId (* IdSort))".replace('*', sort.name()))
+        .flat_map(|sort|
+
+            // Declare relation for ref id
+            ["(relation *HasRefId (* IdSort))".replace('*', sort.name()),
+
+            // Error checking - each (list)expr should only have a single ref id
+            "(rule ((*HasRefId x id1)
+                (*HasRefId x id2)
+                (!= id1 id2))
+                ((panic \"Ref ids don't match\"))
+                :ruleset error-checking)".replace('*', sort.name())])
         .chain(Constructor::iter().map(id_analysis_rules_for_ctor))
-        .chain(id_check)
         .collect::<Vec<_>>()
 }
 

--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -12,14 +12,14 @@ fn id_analysis_rules_for_ctor(ctor: Constructor) -> String {
 
             // Base case: constructor has referencing id specified as a field
             Purpose::ReferencingId => Some(format!(
-                "(rule ({pat})
+                "(rule ({pat} ({sort}IsValid {pat}))
                        (({sort}HasRefId {pat} {field_var}))
                        :ruleset always-run)"
             )),
 
             // Constructor has referencing id of its subexpr fields
             Purpose::SubExpr | Purpose::SubListExpr => Some(format!(
-                "(rule ({pat} ({field_sort}HasRefId {field_var} ref-id))
+                "(rule ({pat} ({field_sort}HasRefId {field_var} ref-id) ({sort}IsValid {pat}))
                        (({sort}HasRefId {pat} ref-id))
                        :ruleset always-run)"
             )),
@@ -51,7 +51,7 @@ fn test_id_analysis() -> Result<(), egglog::Error> {
         (let outer-id (Id (i64-fresh!)))
         (let let0-id (Id (i64-fresh!)))
         (let let1-id (Id (i64-fresh!)))
-        (Let
+        (ExprIsValid (Let
             let0-id
             (Num outer-id 0)
             (All
@@ -62,7 +62,7 @@ fn test_id_analysis() -> Result<(), egglog::Error> {
                         (Num let0-id 3)
                         (Boolean let1-id true))
                     (UnitExpr let0-id)
-                    )))
+                    ))))
     ";
 
     let check = "

--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -104,3 +104,41 @@ fn test_id_analysis() -> Result<(), egglog::Error> {
 
     crate::run_test(build, check)
 }
+
+// Check that invalid expr (expr that has not been marked valid) does not have a RefId
+#[test]
+fn test_id_analysis_no_invalid_entry() {
+    let build = "(let some-expr (Not (Boolean (Id (i64-fresh!)) false))";
+    let check = "(fail (check (ExprHasRefId some-expr any-id)))";
+
+    let _ = crate::run_test(build, check);
+}
+
+// Create an id conflict for an Expr on purpose and check that we catch it
+#[test]
+#[should_panic]
+fn test_id_analysis_expr_id_conflict_panics_if_valid() {
+    let build = "
+        (let id1 (Id (i64-fresh!)))
+        (let id2 (Id (i64-fresh!)))
+        (let conflict-expr (And (Boolean id1 false) (Boolean id2 true)))
+        (ExprIsValid conflict-expr)";
+    let check = "";
+
+    let _ = crate::run_test(build, check);
+}
+
+
+#[test]
+#[should_panic]
+// Create an id conflict for a ListExpr on purpose and check that we catch it
+fn test_id_analysis_listexpr_id_conflict_panics() {
+    let build = "
+        (let id1 (Id (i64-fresh!)))
+        (let id2 (Id (i64-fresh!)))
+        (let conflict-expr (Cons (Num id1 3) (Cons (UnitExpr id2) (Nil))))
+        (ListExprIsValid conflict-expr)";
+    let check = "";
+
+    let _ = crate::run_test(build, check);
+}

--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -128,7 +128,6 @@ fn test_id_analysis_expr_id_conflict_panics_if_valid() {
     let _ = crate::run_test(build, check);
 }
 
-
 #[test]
 #[should_panic]
 // Create an id conflict for a ListExpr on purpose and check that we catch it

--- a/tree_unique_args/src/lib.rs
+++ b/tree_unique_args/src/lib.rs
@@ -2,6 +2,7 @@ pub(crate) mod body_contains;
 pub(crate) mod conditional_invariant_code_motion;
 pub(crate) mod deep_copy;
 pub(crate) mod function_inlining;
+pub(crate) mod id_analysis;
 pub mod interpreter;
 pub(crate) mod ir;
 pub(crate) mod is_valid;
@@ -83,6 +84,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
             &deep_copy::deep_copy_rules().join("\n"),
             include_str!("sugar.egg"),
             include_str!("util.egg"),
+            &id_analysis::id_analysis_rules().join("\n"),
             // optimizations
             include_str!("simple.egg"),
             include_str!("function_inlining.egg"),

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -3,7 +3,7 @@
 (run-schedule
   (repeat 5
     (saturate always-run)
-    (saturate error-checking) ; In the future, this will be "release mode" only
+    (saturate error-checking) ; In the future, this will be "debug mode" only
     simple-pure
     conditional-invariant-code-motion
     switch-rewrites

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -3,6 +3,7 @@
 (run-schedule
   (repeat 5
     (saturate always-run)
+    (saturate error-checking) ; In the future, this will be "release mode" only
     simple-pure
     conditional-invariant-code-motion
     switch-rewrites

--- a/tree_unique_args/src/simple.rs
+++ b/tree_unique_args/src/simple.rs
@@ -1,10 +1,9 @@
 #[test]
 fn test_simple_bool_rules() -> Result<(), egglog::Error> {
     let build = "
-    (let id1 (Id (i64-fresh!)))
-    (let id2 (Id (i64-fresh!)))
-    (let a (Boolean id1 true))
-    (let b (Boolean id2 false))
+    (let id (Id (i64-fresh!)))
+    (let a (Boolean id true))
+    (let b (Boolean id false))
     (let lhs1 (Not (Or a b)))
     (let lhs2 (Not (And a b)))
     (let lhs3 (Not (Not a)))

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -113,10 +113,11 @@ fn switch_rewrite_purity() -> crate::Result {
 #[test]
 fn test_constant_condition() -> Result<(), egglog::Error> {
     let build = "
-    (let t (Boolean (Id (i64-fresh!)) true))
-    (let f (Boolean (Id (i64-fresh!)) false))
-    (let a (Num (Id (i64-fresh!)) 3))
-    (let b (Num (Id (i64-fresh!)) 4))
+    (let id (Id (i64-fresh!)))
+    (let t (Boolean id true))
+    (let f (Boolean id false))
+    (let a (Num id 3))
+    (let b (Num id 4))
     (let switch_t (Switch t (Cons a (Cons b (Nil)))))
     (let switch_f (Switch f (Cons a (Cons b (Nil)))))
     (ExprIsValid switch_t)
@@ -132,10 +133,11 @@ fn test_constant_condition() -> Result<(), egglog::Error> {
 #[test]
 fn switch_pull_in_below() -> Result<(), egglog::Error> {
     let build = "
-    (let c (Read (Num (Id (i64-fresh!)) 3)))
-    (let s1 (Read (Num (Id (i64-fresh!)) 4)))
-    (let s2 (Read (Num (Id (i64-fresh!)) 5)))
-    (let s3 (Read (Num (Id (i64-fresh!)) 6)))
+    (let id (Id (i64-fresh!)))
+    (let c (Read (Num id 3)))
+    (let s1 (Read (Num id 4)))
+    (let s2 (Read (Num id 5)))
+    (let s3 (Read (Num id 6)))
 
     (let switch (Switch c (Cons s1 (Cons s2 (Nil)))))
     (let lhs (All (Sequential) (Cons switch (Cons s3 (Nil)))))

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -80,7 +80,7 @@ fn switch_rewrite_purity() -> crate::Result {
     let build = "
 (let switch-id (Id (i64-fresh!)))
 (let let-id (Id (i64-fresh!)))
-(let impure (Let let-id (UnitExpr let-id) (All (Sequential) (Pair (Boolean let-id true) (Print (Num let-id 1))))))
+(let impure (Let let-id (UnitExpr switch-id) (All (Sequential) (Pair (Boolean let-id true) (Print (Num let-id 1))))))
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
 (ExprIsValid switch)
@@ -96,7 +96,7 @@ fn switch_rewrite_purity() -> crate::Result {
     let build = "
 (let switch-id (Id (i64-fresh!)))
 (let let-id (Id (i64-fresh!)))
-(let impure (Let let-id (UnitExpr let-id) (All (Sequential) (Cons (Boolean let-id true) (Nil)))))
+(let impure (Let let-id (UnitExpr switch-id) (All (Sequential) (Cons (Boolean let-id true) (Nil)))))
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
 (ExprIsValid switch)


### PR DESCRIPTION
Creates relations `ExprHasRefId`, `ListExprHasRefId` to find the referencing id of an expression (the id of the context containing the expression).