### PR TITLE
[TreeUnique] IVT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ target/
 # vscode prefs
 .vscode/
 
+# vim prefs
+.*.swp
+
 # Added by cargo
 
 /target

--- a/tree_unique_args/src/ivt.egg
+++ b/tree_unique_args/src/ivt.egg
@@ -32,7 +32,7 @@
 (rule ((= loop (Loop id in out))
        (ExprHasRefId loop outer-id)
        (ExprIsValid loop)
-       (= out (All ord (Pair pred switch)))
+       (= out (All ord (Cons pred (Cons switch (Nil)))))
        (= switch (Switch pred branches))
        (ExprIsPure pred))
       ((LiftSwitch switch in outer-id)) :ruleset ivt)
@@ -40,12 +40,12 @@
 ; Apply the rule
 (rule ((= loop (Loop id in out))
        (ExprIsValid loop)
-       (= out (All ord (Pair pred switch)))
-       (= switch (Switch pred (Pair thn* els*)))
+       (= out (All ord (Cons pred (Cons switch (Nil)))))
+       (= switch (Switch pred (Cons thn* (Cons els* (Nil)))))
        ; NB: we don't constrain 'outer-id' here in part because there can only
        ; be _one_ outer-id that is referenced by it. (See the panic in the rules
        ; for *HasRefId).
-       (= (Switch pred_ (Pair thn els)) (LiftSwitch switch in outer-id)))
+       (= (Switch pred_ (Cons thn (Cons els (Nil)))) (LiftSwitch switch in outer-id)))
       ((let new-id (Id (i64-fresh!)))
        (let inner (NewLoop new-id in (All ord (Pair pred thn*))))
        (let outer (Switch pred_ (Cons inner (Cons els (Nil)))))

--- a/tree_unique_args/src/ivt.egg
+++ b/tree_unique_args/src/ivt.egg
@@ -1,18 +1,24 @@
 (ruleset ivt)
 
-; do {
-;    if (x) Y else Z
-; } while(x);
+; IVT inverts ifs and loops when their predicates match, e.g.
+;
+;        do {
+;           if (x) Y else Z
+;        } while(x);
 ; 
-; =>
+;        =>
 ; 
-; if (x) {
-;     do {
-;         Y
-;     } while (x);
-; } else {
-;     Z
-; }
+;        if (x) {
+;            do {
+;                Y
+;            } while (x);
+;        } else {
+;            Z
+;        }
+;
+; The rules here assume that the entire loop body _is_ an if. This of course
+; will not match most loops directly: we rely on optimizations that nest
+; computations inside of an if for this rule to fire.
 
 ;                     switch  inputs
 (function LiftSwitch (Expr    Expr)   Expr)
@@ -34,5 +40,3 @@
        (let inner (NewLoop new-id in (All ord (Pair pred thn*))))
        (let outer (Switch pred_ (Cons inner (Cons els (Nil)))))
        (union loop outer)) :ruleset ivt)
-       
-

--- a/tree_unique_args/src/ivt.egg
+++ b/tree_unique_args/src/ivt.egg
@@ -16,23 +16,23 @@
 
 ;                     switch  inputs
 (function LiftSwitch (Expr    Expr)   Expr)
-(rewrite (LiftSwitch inner subst) (SubstExpr inner subst))
+(rewrite (LiftSwitch inner subst) (SubstExpr inner subst) :ruleset always-run)
 
 ; Create demand
 (rule ((= loop (Loop id in out))
-       (= out (All ord (Pair pred1 switch)))
-       (= switch (Switch pred2 branches))
-       (ExprIsPure pred2))
+       (= out (All ord (Pair pred switch)))
+       (= switch (Switch pred branches))
+       (ExprIsPure pred))
       ((LiftSwitch switch in)) :ruleset ivt)
 
 ; Apply the rule
 (rule ((= loop (Loop id in out))
        (= out (All ord (Pair pred switch)))
-       (= switch (Switch pred2 (Pair thn* els*)))
-       (= (Switch pred (Pair thn els)) (LiftSwitch switch in)))
+       (= switch (Switch pred (Pair thn* els*)))
+       (= (Switch pred_ (Pair thn els)) (LiftSwitch switch in)))
       ((let new-id (Id (i64-fresh!)))
        (let inner (NewLoop new-id in (All ord (Pair pred thn*))))
-       (let outer (Switch pred (Cons els (Cons inner (Nil)))))
+       (let outer (Switch pred_ (Cons inner (Cons els (Nil)))))
        (union loop outer)) :ruleset ivt)
        
 

--- a/tree_unique_args/src/ivt.egg
+++ b/tree_unique_args/src/ivt.egg
@@ -1,0 +1,38 @@
+(ruleset ivt)
+
+; do {
+;    if (x) Y else Z
+; } while(x);
+; 
+; =>
+; 
+; if (x) {
+;     do {
+;         Y
+;     } while (x);
+; } else {
+;     Z
+; }
+
+;                     switch  inputs
+(function LiftSwitch (Expr    Expr)   Expr)
+(rewrite (LiftSwitch inner subst) (SubstExpr inner subst))
+
+; Create demand
+(rule ((= loop (Loop id in out))
+       (= out (All ord (Pair pred1 switch)))
+       (= switch (Switch pred2 branches))
+       (ExprIsPure pred2))
+      ((LiftSwitch switch in)) :ruleset ivt)
+
+; Apply the rule
+(rule ((= loop (Loop id in out))
+       (= out (All ord (Pair pred switch)))
+       (= switch (Switch pred2 (Pair thn* els*)))
+       (= (Switch pred (Pair thn els)) (LiftSwitch switch in)))
+      ((let new-id (Id (i64-fresh!)))
+       (let inner (NewLoop new-id in (All ord (Pair pred thn*))))
+       (let outer (Switch pred (Cons els (Cons inner (Nil)))))
+       (union loop outer)) :ruleset ivt)
+       
+

--- a/tree_unique_args/src/ivt.egg
+++ b/tree_unique_args/src/ivt.egg
@@ -20,9 +20,6 @@
 ; will not match most loops directly: we rely on optimizations that nest
 ; computations inside of an if for this rule to fire.
 
-; TODO, wait for #265 to ship
-; hmmm...
-
 ;                     switch  inputs output id
 (function LiftSwitch (Expr    Expr   IdSort)     Expr)
 (rewrite (LiftSwitch inner subst outer-id) 

--- a/tree_unique_args/src/ivt.egg
+++ b/tree_unique_args/src/ivt.egg
@@ -20,22 +20,32 @@
 ; will not match most loops directly: we rely on optimizations that nest
 ; computations inside of an if for this rule to fire.
 
-;                     switch  inputs
-(function LiftSwitch (Expr    Expr)   Expr)
-(rewrite (LiftSwitch inner subst) (SubstExpr inner subst) :ruleset always-run)
+; TODO, wait for #265 to ship
+; hmmm...
+
+;                     switch  inputs output id
+(function LiftSwitch (Expr    Expr   IdSort)     Expr)
+(rewrite (LiftSwitch inner subst outer-id) 
+         (DeepCopyExpr (SubstExpr inner subst) outer-id) :ruleset always-run)
 
 ; Create demand
 (rule ((= loop (Loop id in out))
+       (ExprHasRefId loop outer-id)
+       (ExprIsValid loop)
        (= out (All ord (Pair pred switch)))
        (= switch (Switch pred branches))
        (ExprIsPure pred))
-      ((LiftSwitch switch in)) :ruleset ivt)
+      ((LiftSwitch switch in outer-id)) :ruleset ivt)
 
 ; Apply the rule
 (rule ((= loop (Loop id in out))
+       (ExprIsValid loop)
        (= out (All ord (Pair pred switch)))
        (= switch (Switch pred (Pair thn* els*)))
-       (= (Switch pred_ (Pair thn els)) (LiftSwitch switch in)))
+       ; NB: we don't constrain 'outer-id' here in part because there can only
+       ; be _one_ outer-id that is referenced by it. (See the panic in the rules
+       ; for *HasRefId).
+       (= (Switch pred_ (Pair thn els)) (LiftSwitch switch in outer-id)))
       ((let new-id (Id (i64-fresh!)))
        (let inner (NewLoop new-id in (All ord (Pair pred thn*))))
        (let outer (Switch pred_ (Cons inner (Cons els (Nil)))))

--- a/tree_unique_args/src/ivt.rs
+++ b/tree_unique_args/src/ivt.rs
@@ -31,13 +31,13 @@ fn basic_ivt() -> Result {
         (let loop (Loop loop-id (Arg outer-id) (All (Sequential) (Pair pred switch))))
         (ExprIsValid loop)";
     let check = "
-        (check (= loop 
-          (Switch 
-            (LessThan (Arg outer-id) (Num outer-id 1)) 
-            (Cons 
-                (Loop new-id (Arg outer-id) 
+        (check (= loop
+          (Switch
+            (LessThan (Arg outer-id) (Num outer-id 1))
+            (Cons
+                (Loop new-id (Arg outer-id)
                     (All (Sequential)
-                        (Cons (LessThan (Arg new-id) (Num new-id 1)) 
+                        (Cons (LessThan (Arg new-id) (Num new-id 1))
                         (Cons (Print (Num new-id 0)) (Nil)))))
                 (Cons (Print (Num outer-id 1)) (Nil))))))";
     run_test(build, check)

--- a/tree_unique_args/src/ivt.rs
+++ b/tree_unique_args/src/ivt.rs
@@ -1,24 +1,43 @@
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn basic_ivt() {
-        // do {
-        //     if (x == 0) {
-        //         (print 0);
-        //     } else {
-        //         (print 1);
-        //     }
-        // } while (x == 0);
-        //
-        // =>
-        //
-        // if (x == 0) {
-        //     do {
-        //         (print 0);
-        //     } while (x == 0);
-        // } else {
-        //     (print 1)
-        // }
-    }
+#![cfg(test)]
+
+use crate::{run_test, Result};
+
+#[test]
+fn basic_ivt() -> Result {
+    // do {
+    //     if (x < 1) {
+    //         (print 0);
+    //     } else {
+    //         (print 1);
+    //     }
+    // } while (x == 0);
+    //
+    // =>
+    //
+    // if (x < 1) {
+    //     do {
+    //         (print 0);
+    //     } while (x == 0);
+    // } else {
+    //     (print 1)
+    // }
+    let build = "
+        (let outer-id (Id (i64-fresh!)))
+        (let loop-id (Id (i64-fresh!)))
+        (let pred (LessThan (Arg loop-id) (Num loop-id 1)))
+        (let switch (Switch pred
+                            (Pair (Print (Num loop-id 0))
+                                  (Print (Num loop-id 1)))))
+        (let loop (Loop loop-id (Arg outer-id) (All (Sequential) (Pair pred switch))))";
+    let check = "
+        ; TOdO: some-id should be outer-id
+        (check (= loop (Switch 
+            (LessThan (Arg outer-id) (Num some-id 1)) 
+            (Cons 
+                (Loop new-id (Arg outer-id) 
+                    (All (Sequential)
+                        (Cons (LessThan (Arg new-id) (Num new-id 1)) 
+                        (Cons (Print (Num new-id 0)) (Nil)))))
+                (Cons (Print (Num some-id 1)) (Nil))))))";
+    run_test(build, check)
 }

--- a/tree_unique_args/src/ivt.rs
+++ b/tree_unique_args/src/ivt.rs
@@ -28,16 +28,17 @@ fn basic_ivt() -> Result {
         (let switch (Switch pred
                             (Pair (Print (Num loop-id 0))
                                   (Print (Num loop-id 1)))))
-        (let loop (Loop loop-id (Arg outer-id) (All (Sequential) (Pair pred switch))))";
+        (let loop (Loop loop-id (Arg outer-id) (All (Sequential) (Pair pred switch))))
+        (ExprIsValid loop)";
     let check = "
-        ; TOdO: some-id should be outer-id
-        (check (= loop (Switch 
-            (LessThan (Arg outer-id) (Num some-id 1)) 
+        (check (= loop 
+          (Switch 
+            (LessThan (Arg outer-id) (Num outer-id 1)) 
             (Cons 
                 (Loop new-id (Arg outer-id) 
                     (All (Sequential)
                         (Cons (LessThan (Arg new-id) (Num new-id 1)) 
                         (Cons (Print (Num new-id 0)) (Nil)))))
-                (Cons (Print (Num some-id 1)) (Nil))))))";
+                (Cons (Print (Num outer-id 1)) (Nil))))))";
     run_test(build, check)
 }

--- a/tree_unique_args/src/ivt.rs
+++ b/tree_unique_args/src/ivt.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn basic_ivt() {
+        // do {
+        //     if (x == 0) {
+        //         (print 0);
+        //     } else {
+        //         (print 1);
+        //     }
+        // } while (x == 0);
+        //
+        // =>
+        //
+        // if (x == 0) {
+        //     do {
+        //         (print 0);
+        //     } while (x == 0);
+        // } else {
+        //     (print 1)
+        // }
+    }
+}

--- a/tree_unique_args/src/lib.rs
+++ b/tree_unique_args/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod id_analysis;
 pub mod interpreter;
 pub(crate) mod ir;
 pub(crate) mod is_valid;
+pub(crate) mod ivt;
 pub(crate) mod purity_analysis;
 pub(crate) mod simple;
 pub(crate) mod subst;
@@ -89,6 +90,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
             include_str!("simple.egg"),
             include_str!("function_inlining.egg"),
             include_str!("interval_analysis.egg"),
+            include_str!("ivt.egg"),
             &switch_rewrites::rules(),
             &conditional_invariant_code_motion::rules().join("\n"),
         ]

--- a/tree_unique_args/src/schedule.egg
+++ b/tree_unique_args/src/schedule.egg
@@ -1,7 +1,7 @@
 ; The main (run) statement for the egglog program
 
 (run-schedule
-  (repeat 5
+  (repeat 6
     (saturate always-run)
     (saturate error-checking) ; In the future, this will be "debug mode" only
     simple-pure
@@ -9,4 +9,5 @@
     switch-rewrites
     function-inlining
     interval-analysis
+    ivt
     ))

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -11,7 +11,7 @@
              1)
          :ruleset always-run)
 
-(function NewLoop (IdSort Expr Expr) Expr)
+(function NewLoop (IdSort Expr Expr) Expr :unextractable)
 (rewrite (NewLoop id in out)
          (Loop id in (DeepCopyExpr out id))
          :ruleset always-run)


### PR DESCRIPTION
This is my attempt at #244 

The rules are a lot simpler than in the milestone encoding. That's due to the encoding itself being easier to write rules for, and also because the rule itself only matches loops whose body is "just a switch." I think we want to have rules that push computations _inside_ switches in order to expose opportunities to IVT (we already have some of these).

Marking this as a draft as I'm not sure about the best way to re-assign expressions' ids (e.g. within `Num`s) to ids from the outer scope. The test gives an example (see the `TODO`) of a case where the `Num`s retain the id from the old loop. I figure this is something that's come up before and I'd appreciate guidance on on the cleanest way to do it.