### PR TITLE
Reorganize files in preparation for Rvsdg -> Tree translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
  "bril2json",
  "brilirs",
  "clap",
- "egglog",
+ "egglog 0.1.0 (git+https://github.com/egraphs-good/egglog?rev=60668dd3f465e5674142c47eea449e64310ecb6a)",
  "egraph-serialize",
  "fixedbitset",
  "glob",
@@ -352,6 +352,35 @@ dependencies = [
  "petgraph",
  "serde_json",
  "smallvec",
+ "thiserror",
+ "tree-unique-args",
+]
+
+[[package]]
+name = "egglog"
+version = "0.1.0"
+source = "git+https://github.com/oflatt/egg-smol?rev=057725d9353727d831c90c7f8fdd76954d06b351#057725d9353727d831c90c7f8fdd76954d06b351"
+dependencies = [
+ "clap",
+ "egraph-serialize",
+ "env_logger",
+ "generic_symbolic_expressions",
+ "hashbrown 0.14.1",
+ "indexmap",
+ "instant",
+ "lalrpop",
+ "lalrpop-util 0.20.0",
+ "lazy_static",
+ "log",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "ordered-float",
+ "regex",
+ "rustc-hash",
+ "serde_json",
+ "smallvec",
+ "symbol_table",
  "thiserror",
 ]
 
@@ -747,6 +776,12 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "main_error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155db5e86c6e45ee456bf32fad5a290ee1f7151c2faca27ea27097568da67d1a"
 
 [[package]]
 name = "memchr"
@@ -1169,6 +1204,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "symbol_table"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tree-unique-args"
+version = "0.1.0"
+dependencies = [
+ "egglog 0.1.0 (git+https://github.com/oflatt/egg-smol?rev=057725d9353727d831c90c7f8fdd76954d06b351)",
+ "main_error",
+ "strum",
+ "strum_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ bril-rs = { git = "https://github.com/sampsyo/bril", rev = "daaff28" }
 ordered-float = { version = "3.7" }
 serde_json = "1.0.103"
 
+tree-unique-args = { path = "tree_unique_args" }
+
 # binary dependencies
 clap = { version = "4.4.7", features = ["derive"] }
 

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod restructure;
 pub(crate) mod rvsdg2svg;
 pub(crate) mod to_cfg;
 pub(crate) mod to_egglog;
+mod tree_unique;
 
 use std::fmt;
 

--- a/src/rvsdg/tree_unique/mod.rs
+++ b/src/rvsdg/tree_unique/mod.rs
@@ -1,0 +1,9 @@
+//! Convert RVSDG programs to the tree
+//! encoding of programs.
+//! RVSDGs are close to this encoding,
+//! but use a DAG-based semantics.
+//! This means that nodes that are shared
+//! are only computed once.
+//! These shared nodes need to be let-bound so that they are only
+//! computed once in the tree encoded
+//! program.

--- a/tree_unique_args/Cargo.lock
+++ b/tree_unique_args/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_unique_args"
+name = "tree-unique-args"
 version = "0.1.0"
 dependencies = [
  "egglog",

--- a/tree_unique_args/Cargo.toml
+++ b/tree_unique_args/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tree_unique_args"
+name = "tree-unique-args"
 version = "0.1.0"
 edition = "2021"
 

--- a/tree_unique_args/src/body_contains.rs
+++ b/tree_unique_args/src/body_contains.rs
@@ -2,7 +2,7 @@ use crate::ir::{Constructor, ESort, Purpose};
 use strum::IntoEnumIterator;
 
 /// Builds rules like:
-/// ```no_run
+/// ```txt
 /// (rule ((Let in out))
 ///       ((BodyContains (Let in out) out))
 ///       :ruleset always-run)
@@ -22,7 +22,7 @@ fn captured_expr_rule_for_ctor(ctor: Constructor) -> Option<String> {
 }
 
 /// Builds rules like:
-/// ```no_run
+/// ```txt
 /// (rule ((BodyContainsExpr body (Add x y)))
 ///       ((BodyContainsExpr body x)
 ///        (BodyContainsExpr body y))
@@ -60,8 +60,7 @@ pub(crate) fn rules() -> Vec<String> {
 
 #[test]
 fn test_body_contains() -> Result<(), egglog::Error> {
-    let build = &*format!(
-        "
+    let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))
 (let loop
@@ -73,7 +72,7 @@ fn test_body_contains() -> Result<(), egglog::Error> {
             ; output
             (Switch (Boolean id1 true) (Pair (Num id1 4) (Num id1 5)))))))
     "
-    );
+    .to_string();
     let check = "
 (fail (check (BodyContainsExpr loop (Num id-outer 1))))
 (check (BodyContainsExpr loop (Num id1 2)))

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -83,8 +83,7 @@ fn var_names_available() {
 
 #[test]
 fn test_easy_lift_switch() -> Result<(), egglog::Error> {
-    let build = &*format!(
-        "
+    let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let switch1
     (Switch
@@ -95,7 +94,7 @@ fn test_easy_lift_switch() -> Result<(), egglog::Error> {
         )))
 (ExprIsValid switch1)
     "
-    );
+    .to_string();
     let check = "
 (let switch1-lifted-expected
     (LessThan
@@ -114,8 +113,7 @@ fn test_easy_lift_switch() -> Result<(), egglog::Error> {
 
 #[test]
 fn test_lift_switch_through_switch() -> Result<(), egglog::Error> {
-    let build = &*format!(
-        "
+    let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let switch1
     (Switch
@@ -126,7 +124,7 @@ fn test_lift_switch_through_switch() -> Result<(), egglog::Error> {
         )))
 (ExprIsValid switch1)
     "
-    );
+    .to_string();
     let check = "
 (let all1-lifted-expected
     (Switch

--- a/tree_unique_args/src/interpreter.rs
+++ b/tree_unique_args/src/interpreter.rs
@@ -2,62 +2,7 @@
 
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum Order {
-    Parallel,
-    Sequential,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Id(i64);
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum Expr {
-    Num(i64),
-    Boolean(bool),
-    Unit,
-    Add(Box<Expr>, Box<Expr>),
-    Sub(Box<Expr>, Box<Expr>),
-    Mul(Box<Expr>, Box<Expr>),
-    LessThan(Box<Expr>, Box<Expr>),
-    And(Box<Expr>, Box<Expr>),
-    Or(Box<Expr>, Box<Expr>),
-    Not(Box<Expr>),
-    Get(Box<Expr>, usize),
-    Print(Box<Expr>),
-    Read(Box<Expr>),
-    Write(Box<Expr>, Box<Expr>),
-    All(Order, Vec<Expr>),
-    Switch(Box<Expr>, Vec<Expr>),
-    Loop(Id, Box<Expr>, Box<Expr>),
-    Let(Id, Box<Expr>, Box<Expr>),
-    Arg(Id),
-    Function(Id, Box<Expr>),
-    Call(Id, Box<Expr>),
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum Value {
-    Num(i64),
-    Boolean(bool),
-    Unit,
-    Tuple(Vec<Value>),
-}
-
-#[derive(Clone, PartialEq)]
-pub enum Type {
-    Num,
-    Boolean,
-    Unit,
-    Tuple(Vec<Type>),
-}
-
-pub enum TypeError {
-    ExpectedType(Expr, Type, Type),
-    ExpectedTupleType(Expr, Type),
-    ExpectedLoopOutputType(Expr, Type),
-    NoArg(Expr),
-}
+use crate::{Expr, Id, Order, Type, TypeError, Value};
 
 pub fn typecheck(e: &Expr, arg_ty: &Option<Type>) -> Result<Type, TypeError> {
     let expect_type = |sub_e: &Expr, expected_ty: Type| -> Result<(), TypeError> {

--- a/tree_unique_args/src/is_valid.rs
+++ b/tree_unique_args/src/is_valid.rs
@@ -28,8 +28,7 @@ pub(crate) fn rules() -> Vec<String> {
 
 #[test]
 fn test_is_valid() -> Result<(), egglog::Error> {
-    let build = &*format!(
-        "
+    let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))
 (let loop
@@ -44,7 +43,7 @@ fn test_is_valid() -> Result<(), egglog::Error> {
                 (Sub (Get (Arg id1) 1) (Num id1 1))))))))
 (ExprIsValid loop)
     "
-    );
+    .to_string();
     let check = "
 (check (ExprIsValid (Num id-outer 0)))
 (check (ExprIsValid (Arg id1)))

--- a/tree_unique_args/src/lib.rs
+++ b/tree_unique_args/src/lib.rs
@@ -1,0 +1,69 @@
+pub(crate) mod body_contains;
+pub(crate) mod conditional_invariant_code_motion;
+pub(crate) mod deep_copy;
+pub(crate) mod function_inlining;
+pub mod interpreter;
+pub(crate) mod ir;
+pub(crate) mod is_valid;
+pub(crate) mod purity_analysis;
+pub(crate) mod simple;
+pub(crate) mod subst;
+pub(crate) mod switch_rewrites;
+pub(crate) mod util;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Order {
+    Parallel,
+    Sequential,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Id(i64);
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Expr {
+    Num(i64),
+    Boolean(bool),
+    Unit,
+    Add(Box<Expr>, Box<Expr>),
+    Sub(Box<Expr>, Box<Expr>),
+    Mul(Box<Expr>, Box<Expr>),
+    LessThan(Box<Expr>, Box<Expr>),
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
+    Not(Box<Expr>),
+    Get(Box<Expr>, usize),
+    Print(Box<Expr>),
+    Read(Box<Expr>),
+    Write(Box<Expr>, Box<Expr>),
+    All(Order, Vec<Expr>),
+    Switch(Box<Expr>, Vec<Expr>),
+    Loop(Id, Box<Expr>, Box<Expr>),
+    Let(Id, Box<Expr>, Box<Expr>),
+    Arg(Id),
+    Function(Id, Box<Expr>),
+    Call(Id, Box<Expr>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    Num(i64),
+    Boolean(bool),
+    Unit,
+    Tuple(Vec<Value>),
+}
+
+#[derive(Clone, PartialEq)]
+pub enum Type {
+    Num,
+    Boolean,
+    Unit,
+    Tuple(Vec<Type>),
+}
+
+pub enum TypeError {
+    ExpectedType(Expr, Type, Type),
+    ExpectedTupleType(Expr, Type),
+    ExpectedLoopOutputType(Expr, Type),
+    NoArg(Expr),
+}

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -1,44 +1,9 @@
 #![allow(clippy::useless_format)]
 
 use main_error::MainError;
-
-pub type Result = std::result::Result<(), egglog::Error>;
+use tree_unique_args::run_test;
 
 // Might be useful for typechecking?
 fn main() -> std::result::Result<(), MainError> {
     run_test("", "").map_err(|e| e.into())
-}
-
-pub fn run_test(build: &str, check: &str) -> Result {
-    let program = format!(
-        "{}\n{build}\n{}\n{check}\n",
-        [
-            include_str!("schema.egg"),
-            // analyses
-            &is_valid::rules().join("\n"),
-            &purity_analysis::purity_analysis_rules().join("\n"),
-            &body_contains::rules().join("\n"),
-            &subst::subst_rules().join("\n"),
-            &deep_copy::deep_copy_rules().join("\n"),
-            include_str!("sugar.egg"),
-            include_str!("util.egg"),
-            // optimizations
-            include_str!("simple.egg"),
-            include_str!("function_inlining.egg"),
-            &switch_rewrites::rules(),
-            &conditional_invariant_code_motion::rules().join("\n"),
-        ]
-        .join("\n"),
-        include_str!("schedule.egg"),
-    );
-
-    println!("{}", program);
-
-    egglog::EGraph::default()
-        .parse_and_run_program(&program)
-        .map(|lines| {
-            for line in lines {
-                println!("{}", line);
-            }
-        })
 }

--- a/tree_unique_args/src/main.rs
+++ b/tree_unique_args/src/main.rs
@@ -2,20 +2,6 @@
 
 use main_error::MainError;
 
-// Rust test modules
-// If you don't put your Rust file here it won't get compiled!
-pub(crate) mod body_contains;
-pub(crate) mod conditional_invariant_code_motion;
-pub(crate) mod deep_copy;
-pub(crate) mod function_inlining;
-pub(crate) mod ir;
-pub(crate) mod is_valid;
-pub(crate) mod purity_analysis;
-pub(crate) mod simple;
-pub(crate) mod subst;
-pub(crate) mod switch_rewrites;
-pub(crate) mod util;
-
 pub type Result = std::result::Result<(), egglog::Error>;
 
 // Might be useful for typechecking?

--- a/tree_unique_args/src/purity_analysis.rs
+++ b/tree_unique_args/src/purity_analysis.rs
@@ -55,8 +55,7 @@ pub(crate) fn purity_analysis_rules() -> Vec<String> {
 
 #[test]
 fn test_purity_analysis() -> Result<(), egglog::Error> {
-    let build = &*format!(
-        "
+    let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))
 (let pure-loop
@@ -84,7 +83,7 @@ fn test_purity_analysis() -> Result<(), egglog::Error> {
                     (Add (Get (Arg id2) 0) (Num id2 1))
                     (Sub (Get (Arg id2) 1) (Num id2 1)))))))))
     "
-    );
+    .to_string();
     let check = "
 (check (ExprIsPure pure-loop))
 (fail (check (ExprIsPure impure-loop)))

--- a/tree_unique_args/src/subst.rs
+++ b/tree_unique_args/src/subst.rs
@@ -47,8 +47,7 @@ fn var_names_available() {
 
 #[test]
 fn test_subst() -> Result<(), egglog::Error> {
-    let build = &*format!(
-        "
+    let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))
 (let loop1
@@ -63,7 +62,7 @@ fn test_subst() -> Result<(), egglog::Error> {
                 (Sub (Get (Arg id1) 1) (Num id1 1))))))))
 (let loop1-substed (SubstExpr loop1 (Num id-outer 7)))
     "
-    );
+    .to_string();
     let check = "
 (let loop1-substed-expected
     (Loop id1

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -1,18 +1,17 @@
 #[test]
 fn test_list_util() -> Result<(), egglog::Error> {
-    let build = &*format!("
+    let build = &*"
         (let id (Id 1))
         (let list (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Cons (Num id 3) (Cons (Num id 4) (Nil)))))))
         (let t (All (Sequential) list))
-    ");
-    let check = &*format!(
-        "
+    ".to_string();
+    let check = &*"
         (check (= (ListExpr-ith list 1) (Num id 1)))
         (check (= (ListExpr-ith list 4) (Num id 4)))
         (check (= (ListExpr-length list) 5))
         
     "
-    );
+    .to_string();
     crate::run_test(build, check)
 }
 


### PR DESCRIPTION
This PR makes a `lib.rs` in the tree unique crate so that we can export the grammar. My plan is to connect the "front end" crate to the "back end" tree-unique-args crate.