### PR TITLE
Interpret tests

### DIFF
--- a/tree_unique_args/src/body_contains.rs
+++ b/tree_unique_args/src/body_contains.rs
@@ -71,6 +71,7 @@ fn test_body_contains() -> crate::Result {
             (LessThan (Arg id1) (Num id1 3))
             ; output
             (Switch (Boolean id1 true) (Pair (Num id1 4) (Num id1 5)))))))
+(extract loop)
     "
     .to_string();
     let check = "
@@ -80,7 +81,6 @@ fn test_body_contains() -> crate::Result {
 (check (BodyContainsExpr loop (Num id1 4)))
 (check (BodyContainsExpr loop (Num id1 5)))
 (check (BodyContainsListExpr loop (Pair (Num id1 4) (Num id1 5))))
-(extract loop)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/body_contains.rs
+++ b/tree_unique_args/src/body_contains.rs
@@ -68,14 +68,14 @@ fn test_body_contains() -> crate::Result {
         (Num id-outer 1)
         (All (Sequential) (Pair
             ; pred
-            (LessThan (Num id1 2) (Num id1 3))
+            (LessThan (Arg id1) (Num id1 3))
             ; output
             (Switch (Boolean id1 true) (Pair (Num id1 4) (Num id1 5)))))))
     "
     .to_string();
     let check = "
 (fail (check (BodyContainsExpr loop (Num id-outer 1))))
-(check (BodyContainsExpr loop (Num id1 2)))
+(check (BodyContainsExpr loop (Arg id1)))
 (check (BodyContainsExpr loop (Num id1 3)))
 (check (BodyContainsExpr loop (Num id1 4)))
 (check (BodyContainsExpr loop (Num id1 5)))

--- a/tree_unique_args/src/body_contains.rs
+++ b/tree_unique_args/src/body_contains.rs
@@ -59,7 +59,7 @@ pub(crate) fn rules() -> Vec<String> {
 }
 
 #[test]
-fn test_body_contains() -> Result<(), egglog::Error> {
+fn test_body_contains() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))
@@ -80,6 +80,7 @@ fn test_body_contains() -> Result<(), egglog::Error> {
 (check (BodyContainsExpr loop (Num id1 4)))
 (check (BodyContainsExpr loop (Num id1 5)))
 (check (BodyContainsListExpr loop (Pair (Num id1 4) (Num id1 5))))
+(extract loop)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -93,6 +93,7 @@ fn test_easy_lift_switch() -> crate::Result {
             (LessThan (Num id1 1) (Num id1 7))
         )))
 (ExprIsValid switch1)
+(extract switch1)
     "
     .to_string();
     let check = "
@@ -105,10 +106,9 @@ fn test_easy_lift_switch() -> crate::Result {
                 (Num id1 1)
             ))
         (Num id1 7)))
+(extract switch1-lifted-expected)
 (run-schedule (saturate always-run))
 (check (= switch1 switch1-lifted-expected))
-(extract switch1)
-(extract switch1-lifted-expected)
     ";
     crate::run_test(build, check)
 }
@@ -125,6 +125,7 @@ fn test_lift_switch_through_switch() -> crate::Result {
             (Switch (LessThan (Num id1 1) (Num id1 -7)) (Cons (Num id1 11) (Nil)))
         )))
 (ExprIsValid switch1)
+(extract switch1)
     "
     .to_string();
     let check = "
@@ -139,10 +140,9 @@ fn test_lift_switch_through_switch() -> crate::Result {
                 ))
             (Num id1 -7))
         (Cons (Num id1 11) (Nil))))
+(extract all1-lifted-expected)
 (run-schedule (saturate always-run))
 (check (= switch1 all1-lifted-expected))
-(extract switch1)
-(extract all1-lifted-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -113,37 +113,36 @@ fn test_easy_lift_switch() -> crate::Result {
     crate::run_test(build, check)
 }
 
-// I don't understand this test at all, please bring this up in code review if it gets there
-// #[test]
-// fn test_lift_switch_through_switch() -> crate::Result {
-//     let build = &*"
-// (let id1 (Id (i64-fresh!)))
-// (let switch1
-//     (Switch
-//         (Num id1 0)
-//         (Pair
-//             (Switch (LessThan (Num id1 0) (Num id1 7)) (Cons (Num id1 11) (Nil)))
-//             (Switch (LessThan (Num id1 1) (Num id1 7)) (Cons (Num id1 11) (Nil)))
-//         )))
-// (ExprIsValid switch1)
-//     "
-//     .to_string();
-//     let check = "
-// (let all1-lifted-expected
-//     (Switch
-//         (LessThan
-//             (Switch
-//                 (Num id1 0)
-//                 (Pair
-//                     (Num id1 0)
-//                     (Num id1 1)
-//                 ))
-//             (Num id1 7))
-//         (Pair (Num id1 11) (Num id1 11))))
-// (run-schedule (saturate always-run))
-// (check (= switch1 all1-lifted-expected))
-// (extract switch1)
-// (extract all1-lifted-expected)
-//     ";
-//     crate::run_test(build, check)
-// }
+#[test]
+fn test_lift_switch_through_switch() -> crate::Result {
+    let build = &*"
+(let id1 (Id (i64-fresh!)))
+(let switch1
+    (Switch
+        (Num id1 0)
+        (Pair
+            (Switch (LessThan (Num id1 0) (Num id1 -7)) (Cons (Num id1 11) (Nil)))
+            (Switch (LessThan (Num id1 1) (Num id1 -7)) (Cons (Num id1 11) (Nil)))
+        )))
+(ExprIsValid switch1)
+    "
+    .to_string();
+    let check = "
+(let all1-lifted-expected
+    (Switch
+        (LessThan
+            (Switch
+                (Num id1 0)
+                (Pair
+                    (Num id1 0)
+                    (Num id1 1)
+                ))
+            (Num id1 -7))
+        (Cons (Num id1 11) (Nil))))
+(run-schedule (saturate always-run))
+(check (= switch1 all1-lifted-expected))
+(extract switch1)
+(extract all1-lifted-expected)
+    ";
+    crate::run_test(build, check)
+}

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -82,7 +82,7 @@ fn var_names_available() {
 }
 
 #[test]
-fn test_easy_lift_switch() -> Result<(), egglog::Error> {
+fn test_easy_lift_switch() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let switch1
@@ -107,12 +107,14 @@ fn test_easy_lift_switch() -> Result<(), egglog::Error> {
         (Num id1 7)))
 (run-schedule (saturate always-run))
 (check (= switch1 switch1-lifted-expected))
+(extract switch1)
+(extract switch1-lifted-expected)
     ";
     crate::run_test(build, check)
 }
 
 #[test]
-fn test_lift_switch_through_switch() -> Result<(), egglog::Error> {
+fn test_lift_switch_through_switch() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let switch1
@@ -139,6 +141,8 @@ fn test_lift_switch_through_switch() -> Result<(), egglog::Error> {
         (Cons (Num id1 11) (Nil))))
 (run-schedule (saturate always-run))
 (check (= all1 all1-lifted-expected))
+(extract all1)
+(extract all1-lifted-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -121,8 +121,8 @@ fn test_lift_switch_through_switch() -> crate::Result {
     (Switch
         (Num id1 0)
         (Pair
-            (Switch (LessThan (Num id1 0) (Num id1 -7)) (Cons (Num id1 11) (Nil)))
-            (Switch (LessThan (Num id1 1) (Num id1 -7)) (Cons (Num id1 11) (Nil)))
+            (Switch (LessThan (Num id1 0) (Num id1 -7)) (Cons (Num id1 12) (Cons (Num id1 11) (Nil))))
+            (Switch (LessThan (Num id1 1) (Num id1 -7)) (Cons (Num id1 12) (Cons (Num id1 11) (Nil))))
         )))
 (ExprIsValid switch1)
 (extract switch1)
@@ -139,7 +139,7 @@ fn test_lift_switch_through_switch() -> crate::Result {
                     (Num id1 1)
                 ))
             (Num id1 -7))
-        (Cons (Num id1 11) (Nil))))
+        (Cons (Num id1 12) (Cons (Num id1 11) (Nil)))))
 (extract all1-lifted-expected)
 (run-schedule (saturate always-run))
 (check (= switch1 all1-lifted-expected))

--- a/tree_unique_args/src/conditional_invariant_code_motion.rs
+++ b/tree_unique_args/src/conditional_invariant_code_motion.rs
@@ -89,8 +89,8 @@ fn test_easy_lift_switch() -> crate::Result {
     (Switch
         (Num id1 1)
         (Pair
-            (LessThan (Get (Arg id1) 0) (Num id1 7))
-            (LessThan (Get (Arg id1) 1) (Num id1 7))
+            (LessThan (Num id1 0) (Num id1 7))
+            (LessThan (Num id1 1) (Num id1 7))
         )))
 (ExprIsValid switch1)
     "
@@ -101,8 +101,8 @@ fn test_easy_lift_switch() -> crate::Result {
         (Switch
             (Num id1 1)
             (Pair
-                (Get (Arg id1) 0)
-                (Get (Arg id1) 1)
+                (Num id1 0)
+                (Num id1 1)
             ))
         (Num id1 7)))
 (run-schedule (saturate always-run))
@@ -113,36 +113,37 @@ fn test_easy_lift_switch() -> crate::Result {
     crate::run_test(build, check)
 }
 
-#[test]
-fn test_lift_switch_through_switch() -> crate::Result {
-    let build = &*"
-(let id1 (Id (i64-fresh!)))
-(let switch1
-    (Switch
-        (Num id1 0)
-        (Pair
-            (Switch (LessThan (Get (Arg id1) 0) (Num id1 7)) (Cons (Num id1 11) (Nil)))
-            (Switch (LessThan (Get (Arg id1) 1) (Num id1 7)) (Cons (Num id1 11) (Nil)))
-        )))
-(ExprIsValid switch1)
-    "
-    .to_string();
-    let check = "
-(let all1-lifted-expected
-    (Switch
-        (LessThan
-            (Switch
-                (Num id1 0)
-                (Pair
-                    (Get (Arg id1) 0)
-                    (Get (Arg id1) 1)
-                ))
-            (Num id1 7))
-        (Cons (Num id1 11) (Nil))))
-(run-schedule (saturate always-run))
-(check (= all1 all1-lifted-expected))
-(extract all1)
-(extract all1-lifted-expected)
-    ";
-    crate::run_test(build, check)
-}
+// I don't understand this test at all, please bring this up in code review if it gets there
+// #[test]
+// fn test_lift_switch_through_switch() -> crate::Result {
+//     let build = &*"
+// (let id1 (Id (i64-fresh!)))
+// (let switch1
+//     (Switch
+//         (Num id1 0)
+//         (Pair
+//             (Switch (LessThan (Num id1 0) (Num id1 7)) (Cons (Num id1 11) (Nil)))
+//             (Switch (LessThan (Num id1 1) (Num id1 7)) (Cons (Num id1 11) (Nil)))
+//         )))
+// (ExprIsValid switch1)
+//     "
+//     .to_string();
+//     let check = "
+// (let all1-lifted-expected
+//     (Switch
+//         (LessThan
+//             (Switch
+//                 (Num id1 0)
+//                 (Pair
+//                     (Num id1 0)
+//                     (Num id1 1)
+//                 ))
+//             (Num id1 7))
+//         (Pair (Num id1 11) (Num id1 11))))
+// (run-schedule (saturate always-run))
+// (check (= switch1 all1-lifted-expected))
+// (extract switch1)
+// (extract all1-lifted-expected)
+//     ";
+//     crate::run_test(build, check)
+// }

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -60,7 +60,7 @@ fn test_deep_copy() -> crate::Result {
 (let id-outer (Id (i64-fresh!)))
 (let loop
     (Loop id1
-        (All (Parallel) (Pair (Arg id-outer) (Num id-outer 0)))
+        (All (Parallel) (Pair (Num id-outer 17) (Num id-outer 0)))
         (All (Sequential) (Pair
             ; pred
             (LessThan (Get (Arg id1) 0) (Get (Arg id1) 1))
@@ -75,7 +75,7 @@ fn test_deep_copy() -> crate::Result {
     let check = "
 (let loop-copied-expected
     (Loop (Id 4)
-        (All (Parallel) (Pair (Arg (Id 3)) (Num (Id 3) 0)))
+        (All (Parallel) (Pair (Num (Id 3) 17) (Num (Id 3) 0)))
         (All (Sequential) (Pair
             ; pred
             (LessThan (Get (Arg (Id 4)) 0) (Get (Arg (Id 4)) 1))

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -73,6 +73,7 @@ fn test_deep_copy() -> crate::Result {
 (let loop-copied (DeepCopyExpr loop (Id (i64-fresh!))))
     ";
     let check = "
+(extract loop-copied)
 (let loop-copied-expected
     (Loop (Id 4)
         (All (Parallel) (Pair (Num (Id 3) 17) (Num (Id 3) 0)))
@@ -85,10 +86,9 @@ fn test_deep_copy() -> crate::Result {
                     (Add (Get (Arg (Id 4)) 0) (Num (Id 4) 1))
                     (Sub (Get (Arg (Id 4)) 1) (Num (Id 4) 1))))
                 (Arg (Id 5)))))))
+(extract loop-copied-expected)
 (run-schedule (saturate always-run))
 (check (= loop-copied loop-copied-expected))
-(extract loop-copied)
-(extract loop-copied-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/deep_copy.rs
+++ b/tree_unique_args/src/deep_copy.rs
@@ -53,7 +53,7 @@ fn var_names_available() {
 }
 
 #[test]
-fn test_deep_copy() -> Result<(), egglog::Error> {
+fn test_deep_copy() -> crate::Result {
     let build = "
 (let id1 (Id (i64-fresh!)))
 (let id2 (Id (i64-fresh!)))
@@ -87,6 +87,8 @@ fn test_deep_copy() -> Result<(), egglog::Error> {
                 (Arg (Id 5)))))))
 (run-schedule (saturate always-run))
 (check (= loop-copied loop-copied-expected))
+(extract loop-copied)
+(extract loop-copied-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/function_inlining.rs
+++ b/tree_unique_args/src/function_inlining.rs
@@ -1,5 +1,5 @@
 #[test]
-fn function_inlining() -> Result<(), egglog::Error> {
+fn function_inlining() -> crate::Result {
     let build = "
         (let outer-id (Id (i64-fresh!)))
         (let func-id (Id (i64-fresh!)))
@@ -31,6 +31,7 @@ fn function_inlining() -> Result<(), egglog::Error> {
             )
         
         )
+        (extract call)
     ";
 
     crate::run_test(build, check)

--- a/tree_unique_args/src/function_inlining.rs
+++ b/tree_unique_args/src/function_inlining.rs
@@ -31,7 +31,6 @@ fn function_inlining() -> crate::Result {
             )
         
         )
-        (extract call)
     ";
 
     crate::run_test(build, check)

--- a/tree_unique_args/src/id_analysis.rs
+++ b/tree_unique_args/src/id_analysis.rs
@@ -46,7 +46,7 @@ pub(crate) fn id_analysis_rules() -> Vec<String> {
 }
 
 #[test]
-fn test_id_analysis() -> Result<(), egglog::Error> {
+fn test_id_analysis() -> crate::Result {
     let build = "
         (let outer-id (Id (i64-fresh!)))
         (let let0-id (Id (i64-fresh!)))

--- a/tree_unique_args/src/interpreter.rs
+++ b/tree_unique_args/src/interpreter.rs
@@ -106,9 +106,16 @@ pub fn typecheck(e: &Expr, arg_ty: &Option<Type>) -> Result<Type, TypeError> {
     }
 }
 
+#[derive(Clone, PartialEq)]
 pub struct VirtualMachine {
-    mem: HashMap<usize, Value>,
-    log: Vec<i64>,
+    pub mem: HashMap<usize, Value>,
+    pub log: Vec<i64>,
+}
+
+impl std::fmt::Debug for VirtualMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "\n{:?}\n{:?}", self.mem, self.log)
+    }
 }
 
 // TODO: refactor to return a Result<Value, RuntimeError>

--- a/tree_unique_args/src/interpreter.rs
+++ b/tree_unique_args/src/interpreter.rs
@@ -32,12 +32,12 @@ pub fn typecheck(e: &Expr, arg_ty: &Option<Type>) -> Result<Type, TypeError> {
             Ok(Type::Boolean)
         }
         Expr::And(e1, e2) | Expr::Or(e1, e2) => {
-            expect_type(e1, Type::Num)?;
-            expect_type(e2, Type::Num)?;
+            expect_type(e1, Type::Boolean)?;
+            expect_type(e2, Type::Boolean)?;
             Ok(Type::Boolean)
         }
         Expr::Not(e1) => {
-            expect_type(e1, Type::Num)?;
+            expect_type(e1, Type::Boolean)?;
             Ok(Type::Boolean)
         }
         Expr::Get(tuple, i) => {

--- a/tree_unique_args/src/is_valid.rs
+++ b/tree_unique_args/src/is_valid.rs
@@ -30,7 +30,7 @@ pub(crate) fn rules() -> Vec<String> {
 }
 
 #[test]
-fn test_is_valid() -> Result<(), egglog::Error> {
+fn test_is_valid() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))

--- a/tree_unique_args/src/lib.rs
+++ b/tree_unique_args/src/lib.rs
@@ -135,7 +135,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
     if results.len() >= 2 {
         for result in &results[1..] {
             if result != &results[0] {
-                return Err(Error::Assert(result.clone(), results[0].clone()));
+                return Err(Error::Assert(results[0].clone(), result.clone()));
             }
         }
     }

--- a/tree_unique_args/src/lib.rs
+++ b/tree_unique_args/src/lib.rs
@@ -36,7 +36,7 @@ pub enum Order {
     Sequential,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Id(i64);
 
 #[derive(Clone, Debug, PartialEq)]
@@ -60,7 +60,6 @@ pub enum Expr {
     Loop(Id, Box<Expr>, Box<Expr>),
     Let(Id, Box<Expr>, Box<Expr>),
     Arg(Id),
-    Function(Id, Box<Expr>),
     Call(Id, Box<Expr>),
 }
 
@@ -119,11 +118,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
 
     let mut results = Vec::new();
     for line in lines {
-        let mut vm = interpreter::VirtualMachine {
-            mem: std::collections::HashMap::new(),
-            log: vec![],
-        };
-
+        let mut vm = interpreter::VirtualMachine::new();
         let expr = line.parse::<Expr>().map_err(Error::Parse)?;
         interpreter::typecheck(&expr, &None).map_err(Error::Type)?;
         let value = interpreter::interpret(&expr, &None, &mut vm);

--- a/tree_unique_args/src/purity_analysis.rs
+++ b/tree_unique_args/src/purity_analysis.rs
@@ -54,7 +54,7 @@ pub(crate) fn purity_analysis_rules() -> Vec<String> {
 }
 
 #[test]
-fn test_purity_analysis() -> Result<(), egglog::Error> {
+fn test_purity_analysis() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))

--- a/tree_unique_args/src/purity_analysis.rs
+++ b/tree_unique_args/src/purity_analysis.rs
@@ -99,7 +99,7 @@ fn test_purity_analysis() -> crate::Result {
 }
 
 #[test]
-fn test_purity_function() -> Result<(), egglog::Error> {
+fn test_purity_function() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id2 (Id (i64-fresh!)))

--- a/tree_unique_args/src/simple.rs
+++ b/tree_unique_args/src/simple.rs
@@ -7,13 +7,13 @@ fn test_simple_bool_rules() -> crate::Result {
     (let lhs1 (Not (Or a b)))
     (let lhs2 (Not (And a b)))
     (let lhs3 (Not (Not a)))
+    (extract lhs3)
+    (extract a)
   ";
     let check = "
     (check (= lhs1 (And (Not a) (Not b))))
     (check (= lhs2 (Or (Not a) (Not b))))
     (check (= lhs3 a))
-    (extract lhs3)
-    (extract a)
   ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/simple.rs
+++ b/tree_unique_args/src/simple.rs
@@ -1,5 +1,5 @@
 #[test]
-fn test_simple_bool_rules() -> Result<(), egglog::Error> {
+fn test_simple_bool_rules() -> crate::Result {
     let build = "
     (let id1 (Id (i64-fresh!)))
     (let id2 (Id (i64-fresh!)))
@@ -13,6 +13,8 @@ fn test_simple_bool_rules() -> Result<(), egglog::Error> {
     (check (= lhs1 (And (Not a) (Not b))))
     (check (= lhs2 (Or (Not a) (Not b))))
     (check (= lhs3 a))
+    (extract lhs3)
+    (extract a)
   ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/subst.rs
+++ b/tree_unique_args/src/subst.rs
@@ -64,6 +64,7 @@ fn test_subst() -> crate::Result {
     "
     .to_string();
     let check = "
+(extract loop1-substed)
 (let loop1-substed-expected
     (Loop id1
         (All (Parallel) (Pair (Num id-outer 7) (Num id-outer 0)))
@@ -74,10 +75,9 @@ fn test_subst() -> crate::Result {
             (All (Parallel) (Pair
                 (Add (Get (Arg id1) 0) (Num id1 1))
                 (Sub (Get (Arg id1) 1) (Num id1 1))))))))
+(extract loop1-substed-expected)
 (run-schedule (saturate always-run))
 (check (= loop1-substed loop1-substed-expected))
-(extract loop1-substed)
-(extract loop1-substed-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/subst.rs
+++ b/tree_unique_args/src/subst.rs
@@ -46,7 +46,7 @@ fn var_names_available() {
 }
 
 #[test]
-fn test_subst() -> Result<(), egglog::Error> {
+fn test_subst() -> crate::Result {
     let build = &*"
 (let id1 (Id (i64-fresh!)))
 (let id-outer (Id (i64-fresh!)))
@@ -76,6 +76,7 @@ fn test_subst() -> Result<(), egglog::Error> {
                 (Sub (Get (Arg id1) 1) (Num id1 1))))))))
 (run-schedule (saturate always-run))
 (check (= loop1-substed loop1-substed-expected))
+(extract loop1-substed loop1-substed-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/subst.rs
+++ b/tree_unique_args/src/subst.rs
@@ -76,7 +76,8 @@ fn test_subst() -> crate::Result {
                 (Sub (Get (Arg id1) 1) (Num id1 1))))))))
 (run-schedule (saturate always-run))
 (check (= loop1-substed loop1-substed-expected))
-(extract loop1-substed loop1-substed-expected)
+(extract loop1-substed)
+(extract loop1-substed-expected)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -136,10 +136,11 @@ fn test_constant_condition() -> crate::Result {
 #[test]
 fn switch_pull_in_below() -> crate::Result {
     let build = "
-    (let c (Read (Num (Id (i64-fresh!)) 3)))
-    (let s1 (Read (Num (Id (i64-fresh!)) 4)))
-    (let s2 (Read (Num (Id (i64-fresh!)) 5)))
-    (let s3 (Read (Num (Id (i64-fresh!)) 6)))
+    (let id (Id (i64-fresh!)))
+    (let c (Add (Num id 0) (Num id 1)))
+    (let s1 (Add (Num id 4) (Num id 1)))
+    (let s2 (Add (Num id 5) (Num id 1)))
+    (let s3 (Add (Num id 6) (Num id 1)))
 
     (let switch (Switch c (Cons s1 (Cons s2 (Nil)))))
     (let lhs (All (Sequential) (Cons switch (Cons s3 (Nil)))))

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -199,3 +199,24 @@ fn switch_interval2() -> crate::Result {
     ";
     crate::run_test(build, check)
 }
+
+// #[test]
+// fn single_branch_switch() -> crate::Result {
+//     let build = &*"
+// (let id1 (Id (i64-fresh!)))
+// (let switch1
+//     (Switch
+//         (Num id1 1)
+//         (Pair
+//             (Switch (Boolean id1 false) (Cons (Num id1 12) (Nil)))
+//             (Switch (Boolean id1 false) (Cons (Num id1 12) (Nil)))
+//         )))
+// (ExprIsValid switch1)
+// (extract switch1)
+//     "
+//     .to_string();
+//     let check = "
+// (extract switch1)
+//     ";
+//     crate::run_test(build, check)
+// }

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -71,6 +71,7 @@ fn switch_rewrite_or() -> crate::Result {
                          (Pair (Num id 1)
                                (Switch (Boolean id true)
                                        (Pair (Num id 1) (Num id 2)))))))
+(extract switch)
     ";
     crate::run_test(build, check)
 }
@@ -106,12 +107,13 @@ fn switch_rewrite_purity() -> crate::Result {
                                (Pair (Switch (Get impure 0)
                                              (Pair (Num switch-id 1) (Num switch-id 2)))
                                      (Num switch-id 2)))))
+(extract switch)
     ";
     crate::run_test(build, check)
 }
 
 #[test]
-fn test_constant_condition() -> Result<(), egglog::Error> {
+fn test_constant_condition() -> crate::Result {
     let build = "
     (let t (Boolean (Id (i64-fresh!)) true))
     (let f (Boolean (Id (i64-fresh!)) false))
@@ -125,12 +127,14 @@ fn test_constant_condition() -> Result<(), egglog::Error> {
     let check = "
     (check (= switch_t a))
     (check (= switch_f b))
+    (extract switch_t)
+    (extract a)
   ";
     crate::run_test(build, check)
 }
 
 #[test]
-fn switch_pull_in_below() -> Result<(), egglog::Error> {
+fn switch_pull_in_below() -> crate::Result {
     let build = "
     (let c (Read (Num (Id (i64-fresh!)) 3)))
     (let s1 (Read (Num (Id (i64-fresh!)) 4)))
@@ -145,6 +149,8 @@ fn switch_pull_in_below() -> Result<(), egglog::Error> {
     (let s2s3 (All (Sequential) (Cons s2 (Cons s3 (Nil)))))
     (let expected (Switch c (Cons s1s3 (Cons s2s3 (Nil)))))
     (check (= lhs expected))
+    (extract lhs)
+    (extract expected)
   ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -24,11 +24,11 @@ pub(crate) fn rules() -> String {
 
         ; Constant condition elimination
         (rewrite (Switch (Boolean id true) (Cons A (Cons B (Nil))))
-                 A
+                 B
                  :when ((ExprIsValid (Switch (Boolean id true) (Cons A (Cons B (Nil))))))
                  :ruleset switch-rewrites)
         (rewrite (Switch (Boolean id false) (Cons A (Cons B (Nil))))
-                 B
+                 A
                  :when ((ExprIsValid (Switch (Boolean id false) (Cons A (Cons B (Nil))))))
                  :ruleset switch-rewrites)
     
@@ -65,13 +65,13 @@ fn switch_rewrite_or() -> crate::Result {
 (let switch (Switch (Or (Boolean id false) (Boolean id true))
                     (Pair (Num id 1) (Num id 2))))
 (ExprIsValid switch)
+(extract switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean id false)
                          (Pair (Num id 1)
                                (Switch (Boolean id true)
                                        (Pair (Num id 1) (Num id 2)))))))
-(extract switch)
     ";
     crate::run_test(build, check)
 }
@@ -101,13 +101,13 @@ fn switch_rewrite_purity() -> crate::Result {
 (let switch (Switch (And (Boolean switch-id false) (Get impure 0))
                     (Pair (Num switch-id 1) (Num switch-id 2))))
 (ExprIsValid switch)
+(extract switch)
     ";
     let check = "
 (check (= switch (Switch (Boolean switch-id false)
                                (Pair (Switch (Get impure 0)
                                              (Pair (Num switch-id 1) (Num switch-id 2)))
                                      (Num switch-id 2)))))
-(extract switch)
     ";
     crate::run_test(build, check)
 }
@@ -124,12 +124,12 @@ fn test_constant_condition() -> crate::Result {
     (let switch_f (Switch f (Cons a (Cons b (Nil)))))
     (ExprIsValid switch_t)
     (ExprIsValid switch_f)
+    (extract switch_t)
+    (extract b)
   ";
     let check = "
-    (check (= switch_t a))
-    (check (= switch_f b))
-    (extract switch_t)
-    (extract a)
+    (check (= switch_t b))
+    (check (= switch_f a))
   ";
     crate::run_test(build, check)
 }
@@ -145,14 +145,14 @@ fn switch_pull_in_below() -> crate::Result {
 
     (let switch (Switch c (Cons s1 (Cons s2 (Nil)))))
     (let lhs (All (Sequential) (Cons switch (Cons s3 (Nil)))))
+    (extract lhs)
   ";
     let check = "
     (let s1s3 (All (Sequential) (Cons s1 (Cons s3 (Nil)))))
     (let s2s3 (All (Sequential) (Cons s2 (Cons s3 (Nil)))))
     (let expected (Switch c (Cons s1s3 (Cons s2s3 (Nil)))))
-    (check (= lhs expected))
-    (extract lhs)
     (extract expected)
+    (check (= lhs expected))
   ";
     crate::run_test(build, check)
 }
@@ -169,11 +169,11 @@ fn switch_interval() -> crate::Result {
     (let cc (LessThan two three))
     (let switch (Switch cc (Cons four (Cons five (Nil)))))
     (ExprIsValid switch)
+    (extract switch)
+    (extract five)
     ";
     let check = "
-    (check (= switch four))
-    (extract switch)
-    (extract four)
+    (check (= switch five))
     ";
     crate::run_test(build, check)
 }
@@ -196,8 +196,6 @@ fn switch_interval2() -> crate::Result {
     ";
     let check = "
     (check (= switch two))
-    (extract switch)
-    (extract two)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/switch_rewrites.rs
+++ b/tree_unique_args/src/switch_rewrites.rs
@@ -158,7 +158,7 @@ fn switch_pull_in_below() -> crate::Result {
 }
 
 #[test]
-fn switch_interval() -> Result<(), egglog::Error> {
+fn switch_interval() -> crate::Result {
     let build = "
     (let id (Id (i64-fresh!)))
     (let one   (Num id 1))
@@ -172,12 +172,14 @@ fn switch_interval() -> Result<(), egglog::Error> {
     ";
     let check = "
     (check (= switch four))
+    (extract switch)
+    (extract four)
     ";
     crate::run_test(build, check)
 }
 
 #[test]
-fn switch_interval2() -> Result<(), egglog::Error> {
+fn switch_interval2() -> crate::Result {
     let build = "
     (let id (Id (i64-fresh!)))
     (let one   (Num id  1))
@@ -194,6 +196,8 @@ fn switch_interval2() -> Result<(), egglog::Error> {
     ";
     let check = "
     (check (= switch two))
+    (extract switch)
+    (extract two)
     ";
     crate::run_test(build, check)
 }

--- a/tree_unique_args/src/type_analysis.rs
+++ b/tree_unique_args/src/type_analysis.rs
@@ -1,5 +1,5 @@
 #[test]
-fn simple_types() -> Result<(), egglog::Error> {
+fn simple_types() -> crate::Result {
     let build = "
         (let id1 (Id (i64-fresh!)))
         (let id2 (Id (i64-fresh!)))
@@ -26,7 +26,7 @@ fn simple_types() -> Result<(), egglog::Error> {
 }
 
 #[test]
-fn switch_boolean() -> Result<(), egglog::Error> {
+fn switch_boolean() -> crate::Result {
     let build = "
   (let b1 (Boolean (Id (i64-fresh!)) true))
   (let n1 (Num (Id (i64-fresh!)) 1))
@@ -49,7 +49,7 @@ fn switch_boolean() -> Result<(), egglog::Error> {
 }
 
 #[test]
-fn switch_int() -> Result<(), egglog::Error> {
+fn switch_int() -> crate::Result {
     let build = "
   (let n1 (Num (Id (i64-fresh!)) 1))
   (let n2 (Num (Id (i64-fresh!)) 2))
@@ -77,7 +77,7 @@ fn switch_int() -> Result<(), egglog::Error> {
 }
 
 #[test]
-fn tuple() -> Result<(), egglog::Error> {
+fn tuple() -> crate::Result {
     let build = "
   (let n (Add (Num (Id (i64-fresh!)) 1) (Num (Id (i64-fresh!)) 2)))
         (let m (Mul n n))

--- a/tree_unique_args/src/type_analysis.rs
+++ b/tree_unique_args/src/type_analysis.rs
@@ -129,7 +129,7 @@ fn lets() -> crate::Result {
 }
 
 #[test]
-fn loops() -> Result<(), egglog::Error> {
+fn loops() -> crate::Result {
     let build = "
   (let ctx (Id 0))
   (let loop-id (Id 1))

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -4,12 +4,12 @@ fn test_list_util() -> crate::Result {
         (let id (Id 1))
         (let list (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Cons (Num id 3) (Cons (Num id 4) (Nil)))))))
         (let t (All (Sequential) list))
+        (extract t)
     ".to_string();
     let check = &*"
         (check (= (ListExpr-ith list 1) (Num id 1)))
         (check (= (ListExpr-ith list 4) (Num id 4)))
         (check (= (ListExpr-length list) 5))
-        (extract t)
     "
     .to_string();
     crate::run_test(build, check)

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -1,5 +1,5 @@
 #[test]
-fn test_list_util() -> Result<(), egglog::Error> {
+fn test_list_util() -> crate::Result {
     let build = &*"
         (let id (Id 1))
         (let list (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Cons (Num id 3) (Cons (Num id 4) (Nil)))))))
@@ -9,14 +9,14 @@ fn test_list_util() -> Result<(), egglog::Error> {
         (check (= (ListExpr-ith list 1) (Num id 1)))
         (check (= (ListExpr-ith list 4) (Num id 4)))
         (check (= (ListExpr-length list) 5))
-        
+        (extract t)
     "
     .to_string();
     crate::run_test(build, check)
 }
 
 #[test]
-fn append_test() -> Result<(), egglog::Error> {
+fn append_test() -> crate::Result {
     let build = "
         (let id (Id (i64-fresh!)))
         (let appended
@@ -31,6 +31,7 @@ fn append_test() -> Result<(), egglog::Error> {
             (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Nil))))
             appended
         ))
+        (extract appended)
     ";
 
     crate::run_test(build, check)

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -84,7 +84,7 @@ fn append_test() -> crate::Result {
 }
 
 #[test]
-fn ast_size_test() -> Result<(), egglog::Error> {
+fn ast_size_test() -> crate::Result {
     let build = "
     (let id1 (Id (i64-fresh!)))
     (let id-outer (Id (i64-fresh!)))

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -31,7 +31,6 @@ fn append_test() -> crate::Result {
             (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Nil))))
             appended
         ))
-        (extract appended)
     ";
 
     crate::run_test(build, check)


### PR DESCRIPTION
Changes `run_test` to interpret any expressions that are extracted from a test.

Also fixes the interpreter to fail to deal with functions correctly.

Closes #276