### PR TITLE
Add Expr-size

### DIFF
--- a/tree_unique_args/src/lib.rs
+++ b/tree_unique_args/src/lib.rs
@@ -84,7 +84,7 @@ pub fn run_test(build: &str, check: &str) -> Result {
             &subst::subst_rules().join("\n"),
             &deep_copy::deep_copy_rules().join("\n"),
             include_str!("sugar.egg"),
-            include_str!("util.egg"),
+            &util::rules().join("\n"),
             &id_analysis::id_analysis_rules().join("\n"),
             // optimizations
             include_str!("simple.egg"),

--- a/tree_unique_args/src/sugar.egg
+++ b/tree_unique_args/src/sugar.egg
@@ -4,6 +4,18 @@
          (Cons a (Cons b (Nil)))
          :ruleset always-run)
 
+(function list3 (Expr Expr Expr) ListExpr)
+(rewrite (list3 a b c)
+         (Cons a (Cons b (Cons c (Nil)))) :ruleset always-run)
+
+(function list4 (Expr Expr Expr Expr) ListExpr)
+(rewrite (list4 a b c d)
+         (Cons a (Cons b (Cons c (Cons d (Nil))))) :ruleset always-run)
+
+(function list5 (Expr Expr Expr Expr Expr) ListExpr)
+(rewrite (list5 a b c d e)
+         (Cons a (Cons b (Cons c (Cons d (Cons e (Nil)))))) :ruleset always-run)
+
 (function IgnoreFirst (Expr Expr) Expr)
 (rewrite (IgnoreFirst a b)
          (Get

--- a/tree_unique_args/src/util.egg
+++ b/tree_unique_args/src/util.egg
@@ -18,3 +18,14 @@
 (rewrite (Append (Nil) e)
     (Cons e (Nil))
     :ruleset always-run)
+
+;; get the ith output of a loop
+(function get-loop-outputs-ith (Expr i64) Expr :unextractable)
+(rule ((= loop (Loop id inputs pred-outputs))
+       (= pred-outputs (All ord1 pred-out-list))
+       (= (All ord2 outputs-list) (ListExpr-ith pred-out-list 1))
+       (= ith-outputs (ListExpr-ith outputs-list i)))
+    ((union (get-loop-outputs-ith loop i) ith-outputs)) :ruleset always-run)
+
+(function Expr-size (Expr) i64 :merge(min old new))
+(function ListExpr-size (ListExpr) i64 :merge(min old new))

--- a/tree_unique_args/src/util.egg
+++ b/tree_unique_args/src/util.egg
@@ -19,5 +19,5 @@
     (Cons e (Nil))
     :ruleset always-run)
 
-(function Expr-size (Expr) i64 :merge(min old new))
-(function ListExpr-size (ListExpr) i64 :merge(min old new))
+(function Expr-size (Expr) i64 :merge (min old new))
+(function ListExpr-size (ListExpr) i64 :merge (min old new))

--- a/tree_unique_args/src/util.egg
+++ b/tree_unique_args/src/util.egg
@@ -19,13 +19,5 @@
     (Cons e (Nil))
     :ruleset always-run)
 
-;; get the ith output of a loop
-(function get-loop-outputs-ith (Expr i64) Expr :unextractable)
-(rule ((= loop (Loop id inputs pred-outputs))
-       (= pred-outputs (All ord1 pred-out-list))
-       (= (All ord2 outputs-list) (ListExpr-ith pred-out-list 1))
-       (= ith-outputs (ListExpr-ith outputs-list i)))
-    ((union (get-loop-outputs-ith loop i) ith-outputs)) :ruleset always-run)
-
 (function Expr-size (Expr) i64 :merge(min old new))
 (function ListExpr-size (ListExpr) i64 :merge(min old new))

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -13,7 +13,7 @@ fn ast_size_for_ctor(ctor: Constructor) -> String {
         Constructor::Get => format!("(rule ((= expr (Get tup i)) (= n (Expr-size tup))) ((set (Expr-size expr) n)) {ruleset})"),
         Constructor::All => format!("(rule ((= expr (All ord list)) (= n (ListExpr-size list))) ((set (Expr-size expr) n)) {ruleset})"),
         _ => {
-            let field_pattern = ctor.fields().iter().filter_map(|field| {
+            let field_pattern = ctor.filter_map_fields(|field| {
                 let sort = field.sort().name();
                 let var = field.var();
                 match field.purpose {
@@ -23,7 +23,7 @@ fn ast_size_for_ctor(ctor: Constructor) -> String {
                         Some(format!("({sort}-size {var})")),
                     _ => None
                 }
-            }).collect::<Vec<_>>();
+            });
 
             let len = field_pattern.len();
             let result_str = field_pattern.join(" ");

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -83,40 +83,6 @@ fn append_test() -> Result<(), egglog::Error> {
     crate::run_test(build, check)
 }
 
-#[test]
-fn get_loop_output_ith_test() -> Result<(), egglog::Error> {
-    let build = "
-    (let id1 (Id (i64-fresh!)))
-    (let id-outer (Id (i64-fresh!)))
-    (let loop1
-        (Loop id1
-            (All (Parallel) (Pair (Arg id-outer) (Num id-outer 0)))
-            (All (Sequential) (Pair
-                ; pred
-                (LessThan (Get (Arg id1) 0) (Get (Arg id1) 1))
-                ; output
-                (All (Parallel) (Pair
-                    (Add (Get (Arg id1) 0) (Num id1 1))
-                    (Sub (Get (Arg id1) 1) (Num id1 1))))))))
-    (let out0 (Add (Get (Arg id1) 0) (Num id1 1)))
-    (let out1 (Sub (Get (Arg id1) 1) (Num id1 1)))
-    ";
-
-    let check = "
-        (check (
-            =
-            (get-loop-outputs-ith loop 0)
-            out0
-        ))
-        (check (
-            =
-            (get-loop-outputs-ith loop 1)
-            out1
-        ))
-    ";
-
-    crate::run_test(build, check)
-}
 
 #[test]
 fn ast_size_test() -> Result<(), egglog::Error> {

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -1,3 +1,50 @@
+use crate::ir::{Constructor, Purpose};
+use std::iter;
+use strum::IntoEnumIterator;
+
+fn ast_size_for_ctor(ctor: Constructor) -> String {
+    let ctor_pattern = ctor.construct(|field| field.var());
+    let ruleset = " :ruleset always-run";
+    match ctor {
+        // List itself don't count size
+        Constructor::Nil =>  format!("(rule ({ctor_pattern}) ((set (ListExpr-size {ctor_pattern}) 0)) {ruleset})"),
+        Constructor::Cons => format!("(rule ((= list (Cons expr xs)) (= a (Expr-size expr)) (= b (ListExpr-size xs))) ((set (ListExpr-size list) (+ a b))){ruleset})"), 
+        // let Get and All's size = children's size (I prefer not +1 here)
+        Constructor::Get => format!("(rule ((= expr (Get tup i)) (= n (Expr-size tup))) ((set (Expr-size expr) n)) {ruleset})"),
+        Constructor::All => format!("(rule ((= expr (All ord list)) (= n (ListExpr-size list))) ((set (Expr-size expr) n)) {ruleset})"),
+        _ => {
+            let field_pattern = ctor.fields().iter().filter_map(|field| {
+                let sort = field.sort().name();
+                let var = field.var();
+                match field.purpose {
+                    Purpose::CapturedExpr
+                    | Purpose::SubExpr
+                    | Purpose::SubListExpr =>
+                        Some(format!("({sort}-size {var})")),
+                    _ => None
+                }
+            }).collect::<Vec<_>>();
+
+            let len = field_pattern.len();
+            let result_str = field_pattern.join(" ");
+
+            match len {
+                // Num, Bool Arg, UnitExpr for 0
+                0 => format!("(rule ((= expr {ctor_pattern})) ((set (Expr-size expr) 1)) {ruleset})"),
+                1 => format!("(rule ((= expr {ctor_pattern}) (= n {result_str})) ((set (Expr-size expr) (+ 1 n))){ruleset})"),
+                2 => format!("(rule ((= expr {ctor_pattern}) (= sum (+ {result_str}))) ((set (Expr-size expr) (+ 1 sum))){ruleset})"),
+                _ => panic!("Unimplemented") // we don't have ast take three Expr
+            }
+        },
+    }
+}
+
+pub(crate) fn rules() -> Vec<String> {
+    iter::once(include_str!("util.egg").to_string())
+        .chain(Constructor::iter().map(ast_size_for_ctor))
+        .collect::<Vec<_>>()
+}
+
 #[test]
 fn test_list_util() -> Result<(), egglog::Error> {
     let build = &*"
@@ -31,6 +78,87 @@ fn append_test() -> Result<(), egglog::Error> {
             (Cons (Num id 0) (Cons (Num id 1) (Cons (Num id 2) (Nil))))
             appended
         ))
+    ";
+
+    crate::run_test(build, check)
+}
+
+#[test]
+fn get_loop_output_ith_test() -> Result<(), egglog::Error> {
+    let build = "
+    (let id1 (Id (i64-fresh!)))
+    (let id-outer (Id (i64-fresh!)))
+    (let loop1
+        (Loop id1
+            (All (Parallel) (Pair (Arg id-outer) (Num id-outer 0)))
+            (All (Sequential) (Pair
+                ; pred
+                (LessThan (Get (Arg id1) 0) (Get (Arg id1) 1))
+                ; output
+                (All (Parallel) (Pair
+                    (Add (Get (Arg id1) 0) (Num id1 1))
+                    (Sub (Get (Arg id1) 1) (Num id1 1))))))))
+    (let out0 (Add (Get (Arg id1) 0) (Num id1 1)))
+    (let out1 (Sub (Get (Arg id1) 1) (Num id1 1)))
+    ";
+
+    let check = "
+        (check (
+            =
+            (get-loop-outputs-ith loop 0)
+            out0
+        ))
+        (check (
+            =
+            (get-loop-outputs-ith loop 1)
+            out1
+        ))
+    ";
+
+    crate::run_test(build, check)
+}
+
+#[test]
+fn ast_size_test() -> Result<(), egglog::Error> {
+    let build = "
+    (let id1 (Id (i64-fresh!)))
+    (let id-outer (Id (i64-fresh!)))
+    (let inv 
+        (Sub (Get (Arg id1) 4)
+            (Mul (Get (Arg id1) 2) 
+                (Switch (Num id1 1) (list4 (Num id1 1)
+                                        (Num id1 2)
+                                        (Num id1 3)
+                                        (Num id1 4))
+                )
+            )
+        ))
+    
+    (let loop
+        (Loop id1
+            (All (Parallel) (list5 (Num id-outer 0)
+                                    (Num id-outer 1)
+                                    (Num id-outer 2)
+                                    (Num id-outer 3)
+                                    (Num id-outer 4)))
+            (All (Sequential) (Pair
+                ; pred
+                (LessThan (Get (Arg id1) 0) (Get (Arg id1) 4))
+                ; output
+                (All (Parallel) 
+                    (list5
+                        (Add (Get (Arg id1) 0) 
+                            inv
+                        )
+                        (Get (Arg id1) 1)
+                        (Get (Arg id1) 2)
+                        (Get (Arg id1) 3)
+                        (Get (Arg id1) 4) ))))))
+    ";
+
+    let check = "
+       (check (= 10 (Expr-size inv)))
+       (check (= 25 (Expr-size loop)))
     ";
 
     crate::run_test(build, check)

--- a/tree_unique_args/src/util.rs
+++ b/tree_unique_args/src/util.rs
@@ -83,7 +83,6 @@ fn append_test() -> Result<(), egglog::Error> {
     crate::run_test(build, check)
 }
 
-
 #[test]
 fn ast_size_test() -> Result<(), egglog::Error> {
     let build = "


### PR DESCRIPTION
This PR add Expr-size rules that compute the size of a Expr, which Loop invariant hoisting depends on.
Something I'm concerning is what should be counted. I don't count the Cons and Nil constructor in List, and also don't count the Get and All constructor. Alternative interpretations could be:

- Any constructor is counted. 
- Only things that have cost of computation will be counted, which will remove the size of Let, Num, Bool, Arg, and cost of Switch should be size (or cost?) of pred + max cost of branches.
- It could also change to Expr-cost instead of size, which give each operation different cost. (or have Expr-size and Expr-cost at same time)

