### PR TITLE
Translate a single region from RVSDG to tree encoding

### DIFF
--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -38,11 +38,13 @@ struct RegionTranslator<'a> {
     /// to the index in the argument
     /// where the value is stored.
     /// After evaluating a node, do not evaluate it again.
-    /// Instead find it's index here.
+    /// Instead find its index here.
     index_of: HashMap<Id, usize>,
     nodes: &'a Vec<RvsdgBody>,
 }
 
+/// helper that binds a new expression, adding it
+/// to the environment using concat
 fn cbind(expr: Expr, body: Expr) -> Expr {
     tlet(concat(arg(), expr), body)
 }
@@ -53,7 +55,11 @@ impl<'a> RegionTranslator<'a> {
     fn add_binding(&mut self, expr: Expr, id: Id) -> usize {
         self.bindings.push(expr);
         let res = self.bindings.len() - 1 + self.num_args;
-        assert_eq!(self.index_of.insert(id, res), None);
+        assert_eq!(
+            self.index_of.insert(id, res),
+            None,
+            "Node already evaluated. Cycle in the RVSDG or similar bug."
+        );
         res
     }
 

--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -48,6 +48,7 @@ impl RvsdgFunction {
 
 #[test]
 fn simple_translation() {
+    use Expr::*;
     const PROGRAM: &str = r#"
     @sub() {
         v0: int = const 1;
@@ -62,5 +63,5 @@ fn simple_translation() {
     let cfg = program_to_cfg(&prog);
     let rvsdg = cfg_to_rvsdg(&cfg).unwrap();
 
-    assert_eq!(rvsdg.to_tree_encoding(), Expr::Num(3));
+    assert_eq!(rvsdg.to_tree_encoding(), Program(vec![]));
 }

--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -14,28 +14,8 @@ use crate::{cfg::program_to_cfg, rvsdg::cfg_to_rvsdg, util::parse_from_string};
 use crate::rvsdg::{RvsdgFunction, RvsdgProgram};
 use tree_unique_args::Expr;
 
-struct FreshIdGen {
-    counter: i64,
-}
-
-impl FreshIdGen {
-    fn new() -> Self {
-        Self { counter: 0 }
-    }
-
-    fn fresh(&mut self) -> i64 {
-        let id = self.counter;
-        self.counter += 1;
-        id
-    }
-}
-
 impl RvsdgProgram {
     pub fn to_tree_encoding(&self) -> Expr {
-        self.to_tree_encoding_helper(&mut FreshIdGen::new())
-    }
-
-    fn to_tree_encoding_helper(&self, idgen: &mut FreshIdGen) -> Expr {
         unimplemented!()
     }
 }
@@ -48,7 +28,7 @@ impl RvsdgFunction {
 
 #[test]
 fn simple_translation() {
-    use Expr::*;
+    use tree_unique_args::ast::*;
     const PROGRAM: &str = r#"
     @sub() {
         v0: int = const 1;
@@ -63,5 +43,10 @@ fn simple_translation() {
     let cfg = program_to_cfg(&prog);
     let rvsdg = cfg_to_rvsdg(&cfg).unwrap();
 
-    assert_eq!(rvsdg.to_tree_encoding(), Program(vec![]));
+    rvsdg
+        .to_tree_encoding()
+        .assert_eq_ignoring_ids(&program(vec![function(tlet(
+            concat(arg(), num(1)),
+            unit(),
+        ))]));
 }

--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -34,9 +34,11 @@ struct RegionTranslator<'a> {
     num_args: usize,
     /// a stack of let bindings to generate
     bindings: Vec<Expr>,
-    /// a map from the rvsdg node id
+    /// A map from the rvsdg node id
     /// to the index in the argument
-    /// where the value is stored
+    /// where the value is stored.
+    /// After evaluating a node, do not evaluate it again.
+    /// Instead find it's index here.
     index_of: HashMap<Id, usize>,
     nodes: &'a Vec<RvsdgBody>,
 }
@@ -90,7 +92,9 @@ impl<'a> RegionTranslator<'a> {
         }
     }
 
-    /// Translate a node or return the index of the already-translated node.
+    /// Translate a node or return the index of the already evaluated node.
+    /// It's important not to evaluate a node twice, instead using the cached index
+    /// in `self.index_of`
     fn translate_node(&mut self, id: Id) -> usize {
         if let Some(index) = self.index_of.get(&id) {
             *index

--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -11,26 +11,186 @@
 #[cfg(test)]
 use crate::{cfg::program_to_cfg, rvsdg::cfg_to_rvsdg, util::parse_from_string};
 
-use crate::rvsdg::{RvsdgFunction, RvsdgProgram};
-use tree_unique_args::Expr;
+use crate::rvsdg::{BasicExpr, Id, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram};
+use bril_rs::{Literal, ValueOps};
+use hashbrown::HashMap;
+use tree_unique_args::{
+    ast::{add, arg, concat, function, get, num, print, program, sequence, tfalse, tlet, ttrue},
+    Expr,
+};
 
 impl RvsdgProgram {
     pub fn to_tree_encoding(&self) -> Expr {
-        unimplemented!()
+        program(
+            self.functions
+                .iter()
+                .map(|f| f.to_tree_encoding())
+                .collect(),
+        )
+    }
+}
+
+struct RegionTranslator<'a> {
+    /// The number of arguments to this region
+    num_args: usize,
+    /// a stack of let bindings to generate
+    bindings: Vec<Expr>,
+    /// a map from the rvsdg node id
+    /// to the index in the argument
+    /// where the value is stored
+    index_of: HashMap<Id, usize>,
+    nodes: &'a Vec<RvsdgBody>,
+}
+
+fn cbind(expr: Expr, body: Expr) -> Expr {
+    tlet(concat(arg(), expr), body)
+}
+
+impl<'a> RegionTranslator<'a> {
+    /// Adds a binding and returns its index
+    /// into the argument list.
+    fn add_binding(&mut self, expr: Expr, id: Id) -> usize {
+        self.bindings.push(expr);
+        let res = self.bindings.len() - 1 + self.num_args;
+        assert_eq!(self.index_of.insert(id, res), None);
+        res
+    }
+
+    /// Build a translator and translate
+    /// the operands to the tree encoding.
+    /// Produces a tree-encoded term that evaluates
+    /// to a tuple containing results.
+    fn translate(num_args: usize, nodes: &'a Vec<RvsdgBody>, results: Vec<Operand>) -> Expr {
+        let mut translator = RegionTranslator {
+            num_args,
+            bindings: Vec::new(),
+            index_of: HashMap::new(),
+            nodes,
+        };
+
+        let mut result_indices = Vec::new();
+        for result in results {
+            result_indices.push(translator.translate_operand(result));
+        }
+
+        let mut expr = sequence(result_indices.iter().map(|i| get(arg(), *i)).collect());
+
+        for binding in translator.bindings.into_iter().rev() {
+            expr = cbind(binding, expr);
+        }
+        expr
+    }
+
+    fn translate_operand(&mut self, operand: Operand) -> usize {
+        match operand {
+            Operand::Arg(index) => index,
+            Operand::Id(id) => self.translate_node(id),
+            Operand::Project(_id, _indexx) => {
+                todo!("Doesn't handle subregions yet");
+            }
+        }
+    }
+
+    /// Translate a node or return the index of the already-translated node.
+    fn translate_node(&mut self, id: Id) -> usize {
+        if let Some(index) = self.index_of.get(&id) {
+            *index
+        } else {
+            let node = &self.nodes[id];
+            match node {
+                RvsdgBody::BasicOp(expr) => self.translate_basic_expr(expr.clone(), id),
+                _ => todo!("Doesn't handle subregions yet"),
+            }
+        }
+    }
+
+    /// Translate this expression at the given id,
+    /// return the newly created index.
+    fn translate_basic_expr(&mut self, expr: BasicExpr<Operand>, id: Id) -> usize {
+        match expr {
+            BasicExpr::Op(op, children, _ty) => {
+                let children = children
+                    .iter()
+                    .map(|c| get(arg(), self.translate_operand(*c)))
+                    .collect::<Vec<_>>();
+                let expr = match (op, children.as_slice()) {
+                    (ValueOps::Add, [a, b]) => add(a.clone(), b.clone()),
+                    _ => todo!("handle other ops"),
+                };
+                self.add_binding(expr, id)
+            }
+            BasicExpr::Call(..) => {
+                todo!("handle calls");
+            }
+            BasicExpr::Const(_op, literal, _ty) => match literal {
+                Literal::Int(n) => {
+                    let expr = num(n);
+                    self.add_binding(expr, id)
+                }
+                Literal::Bool(b) => {
+                    let expr = if b { ttrue() } else { tfalse() };
+                    self.add_binding(expr, id)
+                }
+                _ => todo!("handle other literals"),
+            },
+            BasicExpr::Print(args) => {
+                assert!(args.len() == 2, "print should have 2 arguments");
+                let arg1 = self.translate_operand(args[0]);
+                let _arg2 = self.translate_operand(args[1]);
+                let expr = print(get(arg(), arg1));
+                self.add_binding(expr, id)
+            }
+        }
     }
 }
 
 impl RvsdgFunction {
+    /// Translates an RVSDG function to the
+    /// tree encoding.
+    /// It generates one let binding per
+    /// node in the RVSDG, adding the value
+    /// for that node to the end of the argument
+    /// using the `concat` constructor.
+    /// In the inner-most scope, the value of
+    /// all nodes is available.
     pub fn to_tree_encoding(&self) -> Expr {
-        unimplemented!()
+        function(RegionTranslator::translate(
+            self.args.len(),
+            &self.nodes,
+            self.results.iter().map(|r| r.1).collect(),
+        ))
     }
 }
 
 #[test]
 fn simple_translation() {
-    use tree_unique_args::ast::*;
     const PROGRAM: &str = r#"
-    @sub() {
+  @add(): int {
+    v0: int = const 1;
+    res: int = add v0 v0;
+    ret res;
+  }
+  "#;
+
+    let prog = parse_from_string(PROGRAM);
+    let cfg = program_to_cfg(&prog);
+    let rvsdg = cfg_to_rvsdg(&cfg).unwrap();
+
+    rvsdg
+        .to_tree_encoding()
+        .assert_eq_ignoring_ids(&program(vec![function(cbind(
+            num(1),
+            cbind(
+                add(get(arg(), 1), get(arg(), 1)),
+                sequence(vec![get(arg(), 2), get(arg(), 0)]), // returns res and print state (unit)
+            ),
+        ))]));
+}
+
+#[test]
+fn two_print_translation() {
+    const PROGRAM: &str = r#"
+    @add() {
         v0: int = const 1;
         v1: int = const 2;
         v2: int = add v0 v1;
@@ -45,8 +205,17 @@ fn simple_translation() {
 
     rvsdg
         .to_tree_encoding()
-        .assert_eq_ignoring_ids(&program(vec![function(tlet(
-            concat(arg(), num(1)),
-            unit(),
+        .assert_eq_ignoring_ids(&program(vec![function(cbind(
+            num(2),
+            cbind(
+                num(1),
+                cbind(
+                    add(get(arg(), 2), get(arg(), 1)),
+                    cbind(
+                        print(get(arg(), 3)),
+                        cbind(print(get(arg(), 1)), sequence(vec![get(arg(), 5)])),
+                    ),
+                ),
+            ),
         ))]));
 }

--- a/tree_unique_args/src/ast.rs
+++ b/tree_unique_args/src/ast.rs
@@ -1,5 +1,26 @@
 use crate::{Expr, Expr::*, Id, Order};
 
+impl Expr {
+    pub fn eq_ignoring_ids(&self, other: &Expr) -> bool {
+        let mut copy = other.clone();
+        give_fresh_ids(&mut copy);
+        self == &copy
+    }
+
+    pub fn assert_eq_ignoring_ids(&self, other: &Expr) {
+        let mut copy = other.clone();
+        give_fresh_ids(&mut copy);
+        if self != &copy {
+            panic!(
+                "assertion failed: `(left == right)`\n\
+                 left: `{:?}`\n\
+                 right: `{:?}`\n",
+                self, copy
+            );
+        }
+    }
+}
+
 pub fn give_fresh_ids(expr: &mut Expr) {
     let mut id = 1;
     give_fresh_ids_helper(expr, 0, &mut id);

--- a/tree_unique_args/src/ast.rs
+++ b/tree_unique_args/src/ast.rs
@@ -13,7 +13,7 @@ impl Expr {
         if self != &copy {
             panic!(
                 "assertion failed: `(left == right)`\n\
-                 left: `{:?}`\n\
+                 left:  `{:?}`\n\
                  right: `{:?}`\n",
                 self, copy
             );

--- a/tree_unique_args/src/ast.rs
+++ b/tree_unique_args/src/ast.rs
@@ -1,12 +1,18 @@
 use crate::{Expr, Expr::*, Id, Order};
 
 impl Expr {
+    /// Check that two expressions are the same ignoring their ids.
+    /// To do this, simply assign them all new ids.
+    /// If they are the same expression, they will get the same ids
+    /// since `give_fresh_ids` is deterministic.
     pub fn eq_ignoring_ids(&self, other: &Expr) -> bool {
         let mut copy = other.clone();
         give_fresh_ids(&mut copy);
         self == &copy
     }
 
+    /// Like [`Expr::eq_ignoring_ids`] but asserts
+    /// that they are equal with a good error message.
     pub fn assert_eq_ignoring_ids(&self, other: &Expr) {
         let mut copy = other.clone();
         give_fresh_ids(&mut copy);


### PR DESCRIPTION
This PR implements the translation of a function with a single region to the tree encoding. It doesn't run the interpreter or optimizations on the result yet.