### PR TITLE
Translate RVSDG loops to tree encoding 

### DIFF
--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -61,6 +61,8 @@ impl<'a> RegionTranslator<'a> {
         res
     }
 
+    /// Make a new translator for a region with
+    /// num_args and the given nodes.
     fn new(num_args: usize, nodes: &'a Vec<RvsdgBody>) -> RegionTranslator {
         RegionTranslator {
             num_args,
@@ -70,10 +72,8 @@ impl<'a> RegionTranslator<'a> {
         }
     }
 
-    /// Build a translator and translate
-    /// the operands to the tree encoding.
-    /// Produces a tree-encoded term that evaluates
-    /// to a tuple containing results.
+    /// Wrap the given expression in all the
+    /// bindings that have been generated.
     fn build_translation(&self, inner: Expr) -> Expr {
         let mut expr = inner;
 

--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -11,7 +11,7 @@
 #[cfg(test)]
 use crate::{cfg::program_to_cfg, rvsdg::cfg_to_rvsdg, util::parse_from_string};
 #[cfg(test)]
-use tree_unique_args::ast::{program, sequence};
+use tree_unique_args::ast::program;
 
 use crate::rvsdg::{BasicExpr, Id, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram};
 use bril_rs::{Literal, ValueOps};
@@ -303,7 +303,7 @@ fn simple_translation() {
             num(1),
             cbind(
                 add(get(arg(), 1), get(arg(), 1)),
-                sequence!(get(arg(), 2), get(arg(), 0)), // returns res and print state (unit)
+                parallel!(get(arg(), 2), get(arg(), 0)), // returns res and print state (unit)
             ),
         ))));
 }
@@ -334,7 +334,7 @@ fn two_print_translation() {
                     add(get(arg(), 2), get(arg(), 1)),
                     cbind(
                         print(get(arg(), 3)),
-                        cbind(print(get(arg(), 1)), sequence!(get(arg(), 5))),
+                        cbind(print(get(arg(), 1)), parallel!(get(arg(), 5))),
                     ),
                 ),
             ),

--- a/src/rvsdg/tree_unique/to_tree.rs
+++ b/src/rvsdg/tree_unique/to_tree.rs
@@ -92,6 +92,8 @@ impl<'a> RegionTranslator<'a> {
             Operand::Arg(index) => getarg(index),
             Operand::Id(id) => getarg(self.translate_node(id)),
             Operand::Project(p_index, id) => {
+                // Translated region becomes a tuple in the environment.
+                // This is the index of that tuple.
                 let index = self.translate_node(id);
                 get(getarg(index), p_index)
             }
@@ -99,6 +101,8 @@ impl<'a> RegionTranslator<'a> {
     }
 
     /// Translate a node or return the index of the already-translated node.
+    /// For regions, translates the region and returns the index of the
+    /// tuple containing the results.
     fn translate_node(&mut self, id: Id) -> usize {
         if let Some(index) = self.index_of.get(&id) {
             *index
@@ -166,8 +170,10 @@ impl<'a> RegionTranslator<'a> {
             BasicExpr::Print(args) => {
                 assert!(args.len() == 2, "print should have 2 arguments");
                 let arg1 = self.translate_operand(args[0]);
-                // should be unit
+                // argument 2 should have value unit, since it is
+                // the print buffer value.
                 let _arg2 = self.translate_operand(args[1]);
+                // print outputs a new unit value
                 let expr = print(arg1);
                 self.add_binding(expr, id)
             }

--- a/tree_unique_args/src/ast.rs
+++ b/tree_unique_args/src/ast.rs
@@ -116,6 +116,10 @@ pub fn not(a: Expr) -> Expr {
     Not(Box::new(a))
 }
 
+pub fn getarg(i: usize) -> Expr {
+    get(arg(), i)
+}
+
 pub fn get(a: Expr, i: usize) -> Expr {
     Get(Box::new(a), i)
 }
@@ -138,15 +142,15 @@ pub fn sequence_vec(args: Vec<Expr>) -> Expr {
     All(Order::Sequential, args)
 }
 
+pub fn parallel_vec(args: Vec<Expr>) -> Expr {
+    All(Order::Parallel, args)
+}
+
 #[macro_export]
 macro_rules! parallel {
     ($($x:expr),*) => (parallel_vec(vec![$($x),*]))
 }
 pub use parallel;
-
-pub fn parallel_vec(args: Vec<Expr>) -> Expr {
-    All(Order::Parallel, args)
-}
 
 #[macro_export]
 macro_rules! switch {
@@ -162,6 +166,8 @@ pub fn tloop(input: Expr, body: Expr) -> Expr {
     Loop(Id(0), Box::new(input), Box::new(body))
 }
 
+/// Let is reserved by rust, so we call it
+/// tlet for tree-let
 pub fn tlet(arg: Expr, body: Expr) -> Expr {
     Let(Id(0), Box::new(arg), Box::new(body))
 }

--- a/tree_unique_args/src/ast.rs
+++ b/tree_unique_args/src/ast.rs
@@ -59,10 +59,18 @@ fn give_fresh_ids_helper(expr: &mut Expr, current_id: i64, fresh_id: &mut i64) {
     }
 }
 
-pub fn program(args: Vec<Expr>) -> Expr {
-    let mut prog = Program(args);
-    give_fresh_ids(&mut prog);
-    prog
+/// a macro that wraps the children in
+/// a vec for program
+#[macro_export]
+macro_rules! program {
+    ($($x:expr),*) => (program_vec(vec![$($x),*]))
+}
+pub use program;
+
+pub fn program_vec(args: Vec<Expr>) -> Expr {
+    let mut res = Program(args);
+    give_fresh_ids(&mut res);
+    res
 }
 
 pub fn num(n: i64) -> Expr {
@@ -120,15 +128,33 @@ pub fn print(a: Expr) -> Expr {
     Print(Box::new(a))
 }
 
-pub fn sequence(args: Vec<Expr>) -> Expr {
+#[macro_export]
+macro_rules! sequence {
+    ($($x:expr),*) => (sequence_vec(vec![$($x),*]))
+}
+pub use sequence;
+
+pub fn sequence_vec(args: Vec<Expr>) -> Expr {
     All(Order::Sequential, args)
 }
 
-pub fn parallel(args: Vec<Expr>) -> Expr {
+#[macro_export]
+macro_rules! parallel {
+    ($($x:expr),*) => (parallel_vec(vec![$($x),*]))
+}
+pub use parallel;
+
+pub fn parallel_vec(args: Vec<Expr>) -> Expr {
     All(Order::Parallel, args)
 }
 
-pub fn switch(arg: Expr, cases: Vec<Expr>) -> Expr {
+#[macro_export]
+macro_rules! switch {
+    ($arg:expr, $($x:expr),*) => (switch_vec($arg, vec![$($x),*]))
+}
+pub use switch;
+
+pub fn switch_vec(arg: Expr, cases: Vec<Expr>) -> Expr {
     Switch(Box::new(arg), cases)
 }
 
@@ -184,21 +210,19 @@ fn test_gives_loop_ids() {
 fn test_complex_program_ids() {
     // test a program that includes
     // a let, a loop, a switch, and a call
-    let prog = program(vec![function(tlet(
+    let prog = program!(function(tlet(
         num(0),
         tloop(
             num(1),
-            switch(
+            switch!(
                 arg(),
-                vec![
-                    num(2),
-                    call(num(3)),
-                    tlet(num(4), num(5)),
-                    tloop(num(6), num(7)),
-                ],
+                num(2),
+                call(num(3)),
+                tlet(num(4), num(5)),
+                tloop(num(6), num(7))
             ),
         ),
-    ))]);
+    )));
     assert_eq!(
         prog,
         Program(vec![Function(

--- a/tree_unique_args/src/ast.rs
+++ b/tree_unique_args/src/ast.rs
@@ -63,7 +63,7 @@ fn give_fresh_ids_helper(expr: &mut Expr, current_id: i64, fresh_id: &mut i64) {
 /// a vec for program
 #[macro_export]
 macro_rules! program {
-    ($($x:expr),*) => (program_vec(vec![$($x),*]))
+    ($($x:expr),*) => ($crate::ast::program_vec(vec![$($x),*]))
 }
 pub use program;
 
@@ -132,15 +132,16 @@ pub fn print(a: Expr) -> Expr {
     Print(Box::new(a))
 }
 
-#[macro_export]
-macro_rules! sequence {
-    ($($x:expr),*) => (sequence_vec(vec![$($x),*]))
-}
-pub use sequence;
-
 pub fn sequence_vec(args: Vec<Expr>) -> Expr {
     All(Order::Sequential, args)
 }
+
+#[macro_export]
+macro_rules! sequence {
+    // use crate::ast::sequence_vec to resolve import errors
+    ($($x:expr),*) => ($crate::ast::sequence_vec(vec![$($x),*]))
+}
+pub use sequence;
 
 pub fn parallel_vec(args: Vec<Expr>) -> Expr {
     All(Order::Parallel, args)
@@ -148,13 +149,13 @@ pub fn parallel_vec(args: Vec<Expr>) -> Expr {
 
 #[macro_export]
 macro_rules! parallel {
-    ($($x:expr),*) => (parallel_vec(vec![$($x),*]))
+    ($($x:expr),*) => ($crate::ast::parallel_vec(vec![$($x),*]))
 }
 pub use parallel;
 
 #[macro_export]
 macro_rules! switch {
-    ($arg:expr, $($x:expr),*) => (switch_vec($arg, vec![$($x),*]))
+    ($arg:expr, $($x:expr),*) => ($crate::ast::switch_vec($arg, vec![$($x),*]))
 }
 pub use switch;
 


### PR DESCRIPTION
Extends the translation from RVSDG to translate loops, and adds two tests.
Makes some convenient macros for constructing asts.