### PR TITLE
Add rules that propogate assume nodes to create unique contexts

### DIFF
--- a/tree_assume/src/ast.rs
+++ b/tree_assume/src/ast.rs
@@ -210,6 +210,14 @@ pub fn inloop(e1: RcExpr, e2: RcExpr) -> Assumption {
     Assumption::InLoop(e1, e2)
 }
 
+pub fn inif(is_then: bool, pred: RcExpr) -> Assumption {
+    Assumption::InIf(is_then, pred)
+}
+
+pub fn infunc(name: &str) -> Assumption {
+    Assumption::InFunc(name.to_string())
+}
+
 pub fn assume(assumption: Assumption, body: RcExpr) -> RcExpr {
     RcExpr::new(Expr::Assume(assumption, body))
 }

--- a/tree_assume/src/ast.rs
+++ b/tree_assume/src/ast.rs
@@ -163,7 +163,12 @@ macro_rules! parallel {
 pub use parallel;
 
 pub fn parallel_vec(es: impl IntoIterator<Item = RcExpr>) -> RcExpr {
-    es.into_iter().fold(empty(), |acc, x| push_par(x, acc))
+    let mut iter = es.into_iter();
+    if let Some(e) = iter.next() {
+        iter.fold(single(e), |acc, x| push_par(x, acc))
+    } else {
+        empty()
+    }
 }
 
 pub fn tlet(lhs: RcExpr, rhs: RcExpr) -> RcExpr {

--- a/tree_assume/src/lib.rs
+++ b/tree_assume/src/lib.rs
@@ -30,7 +30,7 @@ pub fn egglog_test(
         let result = interpret(&prog, input.clone());
         assert_eq!(
             result, expected,
-            "Program {:?} produced {} instead of expected {}",
+            "Program {:?}\nproduced:\n{}\ninstead of expected:\n{}",
             prog, result, expected
         );
     }

--- a/tree_assume/src/lib.rs
+++ b/tree_assume/src/lib.rs
@@ -39,7 +39,8 @@ pub fn egglog_test(
         "{}\n{build}\n{}\n{check}\n",
         [
             include_str!("schema.egg"),
-            include_str!("optimizations/constant_fold.egg")
+            include_str!("optimizations/constant_fold.egg"),
+            include_str!("utility/assume.egg"),
         ]
         .join("\n"),
         include_str!("schedule.egg"),

--- a/tree_assume/src/lib.rs
+++ b/tree_assume/src/lib.rs
@@ -9,6 +9,7 @@ mod optimizations;
 pub mod schema;
 pub mod schema_helpers;
 mod to_egglog;
+pub(crate) mod utility;
 
 pub type Result = std::result::Result<(), egglog::Error>;
 

--- a/tree_assume/src/schedule.egg
+++ b/tree_assume/src/schedule.egg
@@ -1,6 +1,6 @@
 (run-schedule
   (repeat 6
-    (saturate assume)
+    (repeat 100 assume)
     (saturate always-run)
     (saturate error-checking)
-    (run constant_fold)))
+    (saturate constant_fold)))

--- a/tree_assume/src/schedule.egg
+++ b/tree_assume/src/schedule.egg
@@ -1,6 +1,6 @@
 (run-schedule
   (repeat 6
+    (saturate assume)
     (saturate always-run)
     (saturate error-checking)
-    (run constant_fold)
-    ))
+    (run constant_fold)))

--- a/tree_assume/src/schema.egg
+++ b/tree_assume/src/schema.egg
@@ -173,7 +173,8 @@
   ; The term is in a loop with `input` and `pred_output`.
   ;      input    pred_output
   (InLoop Expr     Expr)
-  (InFunc String Expr)
+  ; name of the function
+  (InFunc String)
   ; Branch of the switch and the predicate
   (InSwitch i64 Expr)
   ; If the predicate was true, and the predicate
@@ -188,7 +189,6 @@
 ; Assume allows creating context-specific terms.
 ; e.g. (Assume (InLet (Const (Int 2))) (Arg)) is equal to (Const (Int 2))
 (function Assume (Assumption Expr) Expr)
-(function AssumeList (Assumption ListExpr) ListExpr)
 
 
 ; =================================

--- a/tree_assume/src/schema.egg
+++ b/tree_assume/src/schema.egg
@@ -173,6 +173,11 @@
   ; The term is in a loop with `input` and `pred_output`.
   ;      input    pred_output
   (InLoop Expr     Expr)
+  (InFunc String Expr)
+  ; Branch of the switch and the predicate
+  (InSwitch i64 Expr)
+  ; If the predicate was true, and the predicate
+  (InIf bool Expr)
   ; Other assumptions are possible, but not supported yet.
   ; For example:
   ;      A boolean predicate is true.
@@ -183,6 +188,7 @@
 ; Assume allows creating context-specific terms.
 ; e.g. (Assume (InLet (Const (Int 2))) (Arg)) is equal to (Const (Int 2))
 (function Assume (Assumption Expr) Expr)
+(function AssumeList (Assumption ListExpr) ListExpr)
 
 
 ; =================================

--- a/tree_assume/src/schema.rs
+++ b/tree_assume/src/schema.rs
@@ -59,6 +59,8 @@ pub type RcExpr = Rc<Expr>;
 pub enum Assumption {
     InLet(RcExpr),
     InLoop(RcExpr, RcExpr),
+    InFunc(String),
+    InIf(bool, RcExpr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tree_assume/src/schema_helpers.rs
+++ b/tree_assume/src/schema_helpers.rs
@@ -35,14 +35,20 @@ impl Expr {
     }
 
     pub fn to_program(self: &RcExpr, input_ty: Type, output_ty: Type) -> TreeProgram {
-        TreeProgram {
-            entry: RcExpr::new(Expr::Function(
-                "main".to_string(),
-                input_ty,
-                output_ty,
-                self.clone(),
-            )),
-            functions: vec![],
+        match self.as_ref() {
+            Expr::Function(..) => TreeProgram {
+                entry: self.clone(),
+                functions: vec![],
+            },
+            _ => TreeProgram {
+                entry: RcExpr::new(Expr::Function(
+                    "main".to_string(),
+                    input_ty,
+                    output_ty,
+                    self.clone(),
+                )),
+                functions: vec![],
+            },
         }
     }
 }

--- a/tree_assume/src/to_egglog.rs
+++ b/tree_assume/src/to_egglog.rs
@@ -66,6 +66,15 @@ impl Assumption {
                 let rhs = rhs.to_egglog_internal(term_dag);
                 term_dag.app("InLoop".into(), vec![lhs, rhs])
             }
+            Assumption::InFunc(name) => {
+                let name_lit = term_dag.lit(Literal::String(name.into()));
+                term_dag.app("InFunc".into(), vec![name_lit])
+            }
+            Assumption::InIf(is_then, pred) => {
+                let pred = pred.to_egglog_internal(term_dag);
+                let is_then = term_dag.lit(Literal::Bool(*is_then));
+                term_dag.app("InIf".into(), vec![is_then, pred])
+            }
         }
     }
 }

--- a/tree_assume/src/utility/assume.egg
+++ b/tree_assume/src/utility/assume.egg
@@ -1,0 +1,111 @@
+; This file propogates assume nodes top-down from functions.
+; It gives each program path a unique equality relation.
+; This can be quite expensive, so be careful running these rules.
+
+(ruleset assume)
+
+(sort AssumeList)
+; We collect multiple assumes into one AssumeMulti.
+; These happen when there are nested `If` or `Switch` statements.
+; When it gets to the bottom, we flatten it back out to multiple `Assume` nodes
+; for the convenience of other analyses.
+(function AssumeMulti (AssumeList Expr) Expr :unextractable)
+
+(function AssumeCons (Assumption AssumeList) AssumeList :unextractable)
+(function AssumeNil () AssumeList :unextractable)
+
+; ################### start top-down assumptions
+
+(rewrite
+ (Function name in_ty out_ty output)
+ (Function name in_ty out_ty
+   (AssumeMulti (AssumeCons (InFunction name) (AssumeNil))
+               output))
+ :ruleset assume)
+
+
+; ################### operations
+(rewrite (AssumeMulti asum (Bop op c1 c2))
+         (Bop op (AssumeMulti asum c1) (AssumeMulti asum c2))
+         :ruleset assume)
+(rewrite (AssumeMulti assum (Uop op c1))
+         (Uop op (AssumeMulti assum c1))
+         :ruleset assume)
+(rewrite (AssumeMulti assum (Get expr index))
+         (Get (AssumeMulti assum expr) index)
+         :ruleset assume)
+(rewrite (AssumeMulti assum (Alloc expr ty))
+         (Alloc (AssumeMulti assum expr) ty)
+         :ruleset assume)
+(rewrite (AssumeMulti assum (Call name expr))
+         (Call name (AssumeMulti assum expr))
+         :ruleset assume)
+
+; ################### tuple operations
+(rewrite (AssumeMulti assum (Single expr))
+         (Single (AssumeMulti assum expr))
+         :ruleset assume)
+(rewrite (AssumeMulti assum (Concat order e1 e2))
+         (Concat order (AssumeMulti assum e1) (AssumeMulti assum e2))
+         :ruleset assume)
+
+; #################### control flow
+
+;                       assumptions, predicate, cases,   current case
+(function SwitchAssume (AssumeList   Expr       ExprList i64) ExprList :unextractable) 
+
+(rewrite (AssumeMulti assum (Switch pred cases))
+         (Switch (AssumeMulti assum pred)
+                 (SwitchAssume assum 
+                               (AssumeMulti assum pred)
+                               cases
+                               0))
+         :ruleset assume)
+
+(rewrite (SwitchAssume pred assum (Nil) current_case)
+         (AssumeMulti assum (Nil))
+         :ruleset assume)
+
+(rewrite (SwitchAssume pred
+                       assum 
+                       (Cons current rest)
+                       current_case)
+         (Cons
+           (AssumeMulti
+             (AssumeCons (InSwitch current_case pred) assum)
+             current)
+           (SwitchAssume
+             pred
+             assum 
+             rest
+             (+ current_case 1)))
+          :ruleset assume)
+
+(rewrite (AssumeMulti assum (If pred then else))
+         (If (AssumeMulti assum pred)
+             (AssumeMulti
+               (Cons (InIf true (AssumeMulti assum pred)) assum) then)
+             (AssumeMulti
+               (Cons (InIf false (AssumeMulti assum pred)) assum) else))
+         :ruleset assume)
+
+(rewrite (AssumeMulti assum (Let inputs body))
+         (Let
+           (AssumeMulti assum inputs)
+           (AssumeMulti
+             ; new context, make a list with one assumption in it
+             (Cons (InLet (AssumeMulti assum inputs)) (Nil))
+             body))
+          :ruleset assume)
+
+
+(rewrite (AssumeMulti assum (DoWhile inputs pred_outputs))
+         (DoWhile
+           (AssumeMulti assum inputs)
+           (AssumeMulti
+             (Cons (InLoop (AssumeMulti assum inputs) pred_outputs)
+                   (Nil))
+              pred_outputs))
+        :ruleset assume)
+                   
+

--- a/tree_assume/src/utility/assume.egg
+++ b/tree_assume/src/utility/assume.egg
@@ -71,11 +71,12 @@
           :ruleset assume)
 
 
-(rewrite (Assume assum (DoWhile inputs pred_outputs))
+(rule ((= lhs (Assume assum (DoWhile inputs pred_outputs))))
+      ((union lhs
          (DoWhile
            (Assume assum inputs)
            (Assume
              (InLoop (Assume assum inputs) pred_outputs)
-              pred_outputs))
+              pred_outputs))))
         :ruleset assume)
                    

--- a/tree_assume/src/utility/assume.egg
+++ b/tree_assume/src/utility/assume.egg
@@ -5,107 +5,77 @@
 (ruleset assume)
 
 (sort AssumeList)
-; We collect multiple assumes into one AssumeMulti.
-; These happen when there are nested `If` or `Switch` statements.
-; When it gets to the bottom, we flatten it back out to multiple `Assume` nodes
-; for the convenience of other analyses.
-(function AssumeMulti (AssumeList Expr) Expr :unextractable)
 
-(function AssumeCons (Assumption AssumeList) AssumeList :unextractable)
-(function AssumeNil () AssumeList :unextractable)
+; In order to saturate and not create unecessary contexts, we need to collapse
+; duplicate assumptions.
+; For example, the rewrite over `Function` could create many
+; `(Assume (InFunc name) (Assume (InFunc name) ...))` nestings
+(rewrite (Assume assumption (Assume assumption rest))
+         (Assume assumption rest)
+         :ruleset assume)
 
 ; ################### start top-down assumptions
 
 (rewrite
- (Function name in_ty out_ty output)
+ (Function name in_ty out_ty out)
  (Function name in_ty out_ty
-   (AssumeMulti (AssumeCons (InFunction name) (AssumeNil))
-               output))
+   (Assume (InFunc  name)
+               out))
  :ruleset assume)
 
 
 ; ################### operations
-(rewrite (AssumeMulti asum (Bop op c1 c2))
-         (Bop op (AssumeMulti asum c1) (AssumeMulti asum c2))
+(rewrite (Assume asum (Bop op c1 c2))
+         (Bop op (Assume asum c1) (Assume asum c2))
          :ruleset assume)
-(rewrite (AssumeMulti assum (Uop op c1))
-         (Uop op (AssumeMulti assum c1))
+(rewrite (Assume assum (Uop op c1))
+         (Uop op (Assume assum c1))
          :ruleset assume)
-(rewrite (AssumeMulti assum (Get expr index))
-         (Get (AssumeMulti assum expr) index)
+(rewrite (Assume assum (Get expr index))
+         (Get (Assume assum expr) index)
          :ruleset assume)
-(rewrite (AssumeMulti assum (Alloc expr ty))
-         (Alloc (AssumeMulti assum expr) ty)
+(rewrite (Assume assum (Alloc expr ty))
+         (Alloc (Assume assum expr) ty)
          :ruleset assume)
-(rewrite (AssumeMulti assum (Call name expr))
-         (Call name (AssumeMulti assum expr))
+(rewrite (Assume assum (Call name expr))
+         (Call name (Assume assum expr))
          :ruleset assume)
 
 ; ################### tuple operations
-(rewrite (AssumeMulti assum (Single expr))
-         (Single (AssumeMulti assum expr))
+(rewrite (Assume assum (Single expr))
+         (Single (Assume assum expr))
          :ruleset assume)
-(rewrite (AssumeMulti assum (Concat order e1 e2))
-         (Concat order (AssumeMulti assum e1) (AssumeMulti assum e2))
+(rewrite (Assume assum (Concat order e1 e2))
+         (Concat order (Assume assum e1) (Assume assum e2))
          :ruleset assume)
 
 ; #################### control flow
 
 ;                       assumptions, predicate, cases,   current case
-(function SwitchAssume (AssumeList   Expr       ExprList i64) ExprList :unextractable) 
+(function SwitchAssume (AssumeList   Expr       ListExpr i64) ListExpr :unextractable) 
 
-(rewrite (AssumeMulti assum (Switch pred cases))
-         (Switch (AssumeMulti assum pred)
-                 (SwitchAssume assum 
-                               (AssumeMulti assum pred)
-                               cases
-                               0))
+(rewrite (Assume assum (If pred then else))
+         (If (Assume assum pred)
+             (Assume
+               (InIf true (Assume assum pred)) then)
+             (Assume
+               (InIf false (Assume assum pred)) else))
          :ruleset assume)
 
-(rewrite (SwitchAssume pred assum (Nil) current_case)
-         (AssumeMulti assum (Nil))
-         :ruleset assume)
-
-(rewrite (SwitchAssume pred
-                       assum 
-                       (Cons current rest)
-                       current_case)
-         (Cons
-           (AssumeMulti
-             (AssumeCons (InSwitch current_case pred) assum)
-             current)
-           (SwitchAssume
-             pred
-             assum 
-             rest
-             (+ current_case 1)))
-          :ruleset assume)
-
-(rewrite (AssumeMulti assum (If pred then else))
-         (If (AssumeMulti assum pred)
-             (AssumeMulti
-               (Cons (InIf true (AssumeMulti assum pred)) assum) then)
-             (AssumeMulti
-               (Cons (InIf false (AssumeMulti assum pred)) assum) else))
-         :ruleset assume)
-
-(rewrite (AssumeMulti assum (Let inputs body))
+(rewrite (Assume assum (Let inputs body))
          (Let
-           (AssumeMulti assum inputs)
-           (AssumeMulti
-             ; new context, make a list with one assumption in it
-             (Cons (InLet (AssumeMulti assum inputs)) (Nil))
+           (Assume assum inputs)
+           (Assume
+             (InLet (Assume assum inputs))
              body))
           :ruleset assume)
 
 
-(rewrite (AssumeMulti assum (DoWhile inputs pred_outputs))
+(rewrite (Assume assum (DoWhile inputs pred_outputs))
          (DoWhile
-           (AssumeMulti assum inputs)
-           (AssumeMulti
-             (Cons (InLoop (AssumeMulti assum inputs) pred_outputs)
-                   (Nil))
+           (Assume assum inputs)
+           (Assume
+             (InLoop (Assume assum inputs) pred_outputs)
               pred_outputs))
         :ruleset assume)
                    
-

--- a/tree_assume/src/utility/assume.rs
+++ b/tree_assume/src/utility/assume.rs
@@ -2,13 +2,48 @@
 use crate::{egglog_test, interpreter::Value, schema::Constant};
 
 #[test]
+fn test_assume_in_func() -> crate::Result {
+    use crate::ast::*;
+    let expr = function("main", intt(), intt(), int(2));
+    let expected = function("main", intt(), intt(), assume(infunc("main"), int(2)));
+    egglog_test(
+        &format!("{expr}"),
+        &format!("(check (= {expr} {expected}))"),
+        vec![
+            expr.to_program(emptyt(), intt()),
+            expected.to_program(emptyt(), intt()),
+        ],
+        Value::Tuple(vec![]),
+        Value::Const(Constant::Int(2)),
+    )
+}
+
+#[test]
 fn test_assume_two_lets() -> crate::Result {
     use crate::ast::*;
-    let expr = tlet(int(1), tlet(add(arg(), arg()), mul(arg(), int(2))));
-    let arg1 = assume(inlet(int(1)), arg());
+    let expr = function(
+        "main",
+        intt(),
+        intt(),
+        tlet(int(1), tlet(add(arg(), arg()), mul(arg(), int(2)))),
+    );
+    let int1 = assume(infunc("main"), int(1));
+    let arg1 = assume(inlet(int1.clone()), arg());
     let addarg1 = add(arg1.clone(), arg1.clone());
-    let arg2 = assume(inlet(addarg1), arg());
-    let expr2 = tlet(int(1), tlet(add(arg1.clone(), arg1), mul(arg2, int(2))));
+    let int2 = assume(inlet(addarg1.clone()), int(2));
+    let arg2 = assume(inlet(addarg1.clone()), arg());
+    let expr2 = function(
+        "main",
+        intt(),
+        intt(),
+        tlet(
+            int1,
+            tlet(
+                add(arg1.clone(), arg1.clone()),
+                mul(arg2.clone(), int2.clone()),
+            ),
+        ),
+    );
 
     egglog_test(
         &format!("{expr}"),
@@ -19,5 +54,32 @@ fn test_assume_two_lets() -> crate::Result {
         ],
         Value::Tuple(vec![]),
         Value::Const(Constant::Int(4)),
+    )
+}
+
+#[test]
+fn test_switch_contexts() -> crate::Result {
+    use crate::ast::*;
+    let expr = function("main", intt(), intt(), tif(ttrue(), int(1), int(2)));
+    let pred = assume(infunc("main"), ttrue());
+    let expr2 = function(
+        "main",
+        intt(),
+        intt(),
+        tif(
+            pred.clone(),
+            assume(inif(true, pred.clone()), int(1)),
+            assume(inif(false, pred.clone()), int(2)),
+        ),
+    );
+    egglog_test(
+        &format!("{expr}"),
+        &format!("(check (= {expr} {expr2}))"),
+        vec![
+            expr.to_program(emptyt(), intt()),
+            expr2.to_program(emptyt(), intt()),
+        ],
+        Value::Tuple(vec![]),
+        Value::Const(Constant::Int(1)),
     )
 }

--- a/tree_assume/src/utility/assume.rs
+++ b/tree_assume/src/utility/assume.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+use crate::{egglog_test, interpreter::Value, schema::Constant};
+
+#[test]
+fn test_assume_two_lets() -> crate::Result {
+    use crate::ast::*;
+    let expr = tlet(int(1), tlet(add(arg(), arg()), mul(arg(), int(2))));
+    let arg1 = assume(inlet(int(1)), arg());
+    let addarg1 = add(arg1.clone(), arg1.clone());
+    let arg2 = assume(inlet(addarg1), arg());
+    let expr2 = tlet(int(1), tlet(add(arg1.clone(), arg1), mul(arg2, int(2))));
+
+    egglog_test(
+        &format!("{expr}"),
+        &format!("(check (= {expr} {expr2}))"),
+        vec![
+            expr.to_program(emptyt(), intt()),
+            expr2.to_program(emptyt(), intt()),
+        ],
+        Value::Tuple(vec![]),
+        Value::Const(Constant::Int(4)),
+    )
+}

--- a/tree_assume/src/utility/mod.rs
+++ b/tree_assume/src/utility/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod assume;


### PR DESCRIPTION
This PR adds some elegant rules that propagate assume nodes down from a top-level function. It also adds a couple of tests.

Not included is rules for `Switch`, which are a little harder.

This PR changes `Assumption` to have *three* new variants: `InIf` and `InFunction`, and `InSwitch`.
I realized that our previous plan of using a strait up boolean condition isn't quite right due to effects. For example, if an `If` statement reads from memory, the value it reads is whatever was in memory at the execution time of the predicate. 