### PR TITLE
[Tree assume] Print schema on test failure and `cargo run`

### DIFF
--- a/tree_assume/src/lib.rs
+++ b/tree_assume/src/lib.rs
@@ -61,8 +61,8 @@ pub fn egglog_test(
         });
 
     if res.is_err() {
-        println!("{:?}", res);
         println!("{}", program);
+        println!("{:?}", res);
     }
 
     res

--- a/tree_assume/src/lib.rs
+++ b/tree_assume/src/lib.rs
@@ -14,6 +14,16 @@ pub(crate) mod utility;
 
 pub type Result = std::result::Result<(), egglog::Error>;
 
+pub fn prologue() -> String {
+    [
+        include_str!("schema.egg"),
+        include_str!("type_analysis.egg"),
+        include_str!("optimizations/constant_fold.egg"),
+        include_str!("utility/assume.egg"),
+    ]
+    .join("\n")
+}
+
 /// Runs an egglog test.
 /// `build` is egglog code that runs before the running rules.
 /// `check` is egglog code that runs after the running rules.
@@ -38,23 +48,22 @@ pub fn egglog_test(
 
     let program = format!(
         "{}\n{build}\n{}\n{check}\n",
-        [
-            include_str!("schema.egg"),
-            include_str!("type_analysis.egg"),
-            include_str!("optimizations/constant_fold.egg"),
-            include_str!("utility/assume.egg"),
-        ]
-        .join("\n"),
+        prologue(),
         include_str!("schedule.egg"),
     );
 
-    println!("{}", program);
-
-    egglog::EGraph::default()
+    let res = egglog::EGraph::default()
         .parse_and_run_program(&program)
         .map(|lines| {
             for line in lines {
                 println!("{}", line);
             }
-        })
+        });
+
+    if res.is_err() {
+        println!("{:?}", res);
+        println!("{}", program);
+    }
+
+    res
 }

--- a/tree_assume/src/main.rs
+++ b/tree_assume/src/main.rs
@@ -1,0 +1,7 @@
+use tree_assume::egglog_test;
+use tree_assume::interpreter::Value;
+use tree_assume::Result;
+
+fn main() -> Result {
+    egglog_test("", "", vec![], Value::Tuple(vec![]), Value::Tuple(vec![]))
+}

--- a/tree_assume/src/main.rs
+++ b/tree_assume/src/main.rs
@@ -1,7 +1,5 @@
-use tree_assume::egglog_test;
-use tree_assume::interpreter::Value;
-use tree_assume::Result;
+use tree_assume::prologue;
 
-fn main() -> Result {
-    egglog_test("", "", vec![], Value::Tuple(vec![]), Value::Tuple(vec![]))
+fn main() -> () {
+    println!("{}", prologue());
 }

--- a/tree_assume/src/main.rs
+++ b/tree_assume/src/main.rs
@@ -1,5 +1,5 @@
 use tree_assume::prologue;
 
-fn main() -> () {
+fn main() {
     println!("{}", prologue());
 }


### PR DESCRIPTION
Improve test debugging workflow by printing both schema and error on test failure, and printing schema on `cargo run`.

---

PR stack:
1. #336
2. #337 
3. #338 
3. #339