### PR TITLE
Fix bug in HasArgType

### DIFF
--- a/tree_in_context/src/type_analysis.egg
+++ b/tree_in_context/src/type_analysis.egg
@@ -35,7 +35,8 @@
 
 (relation HasArgType (Expr Type))
 
-(rule ((HasArgType e t1) (HasArgType e t2) (!= t1 t2))
+(rule ((HasArgType (Arg t1) t2)
+       (!= t1 t2))
       ((panic "arg type mismatch"))
       :ruleset type-analysis)
 

--- a/tree_in_context/src/type_analysis.rs
+++ b/tree_in_context/src/type_analysis.rs
@@ -397,3 +397,13 @@ fn funcs_and_calls() -> crate::Result {
         vec![],
     )
 }
+
+#[test]
+fn repro_argtype_bug() -> crate::Result {
+    type_test(
+        concat_par(tlet(int(1), empty()), tlet(ttrue(), empty())),
+        emptyt(),
+        val_empty(),
+        val_empty(),
+    )
+}


### PR DESCRIPTION
This PR fixes a bug in `HasArgType`.
For expressions that don't reference arg, they may have any arg type. I added a test case that demonstrates this.
The fix is to only have an error when we infer a different arg type for a reference to the argument.