### PR TITLE
Create new contexts with only context-free children

### DIFF
--- a/tree_in_context/src/interpreter.rs
+++ b/tree_in_context/src/interpreter.rs
@@ -296,8 +296,9 @@ impl<'a> VirtualMachine<'a> {
                     else {
                         panic!("expected tuple for pred_output in do-while")
                     };
-                    assert!(
-                        pred_output_val.len() == 1 + vals.len(),
+                    assert_eq!(
+                        pred_output_val.len(),
+                        1 + vals.len(),
                         "expected pred_output to have one more element than input in {:?}",
                         pred_output
                     );

--- a/tree_in_context/src/lib.rs
+++ b/tree_in_context/src/lib.rs
@@ -28,6 +28,7 @@ pub fn prologue() -> String {
         include_str!("optimizations/constant_fold.egg"),
         include_str!("type_analysis.egg"),
         include_str!("utility/util.egg"),
+        include_str!("optimizations/loop_simplify.egg"),
     ]
     .join("\n")
 }
@@ -85,6 +86,7 @@ pub fn egglog_test(
         prologue(),
         include_str!("schedule.egg"),
     );
+    eprintln!("{}", program);
 
     let res = egglog::EGraph::default()
         .parse_and_run_program(&program)

--- a/tree_in_context/src/lib.rs
+++ b/tree_in_context/src/lib.rs
@@ -86,7 +86,6 @@ pub fn egglog_test(
         prologue(),
         include_str!("schedule.egg"),
     );
-    eprintln!("{}", program);
 
     let res = egglog::EGraph::default()
         .parse_and_run_program(&program)

--- a/tree_in_context/src/optimizations/loop_simplify.egg
+++ b/tree_in_context/src/optimizations/loop_simplify.egg
@@ -4,7 +4,7 @@
 ;; TODO generalize for more inputs
 (rewrite
  (DoWhile (Arg ty)
-  (Concat (Parallel) (Const (Bool false))
+  (Concat (Parallel) (Single (Const (Bool false)))
     body))
  body
  :ruleset loop-simplify)

--- a/tree_in_context/src/optimizations/loop_simplify.egg
+++ b/tree_in_context/src/optimizations/loop_simplify.egg
@@ -1,0 +1,10 @@
+;; Some simple simplifications of loops
+(ruleset loop-simplify)
+
+;; TODO generalize for more inputs
+(rewrite
+ (DoWhile (Arg ty)
+  (Concat (Parallel) (Const (Bool false))
+    body))
+ body
+ :ruleset loop-simplify)

--- a/tree_in_context/src/schedule.egg
+++ b/tree_in_context/src/schedule.egg
@@ -1,11 +1,14 @@
 (run-schedule
+  (saturate
+   (saturate always-run)
+   context_creation
+   (saturate context_propagate))
   (repeat 6
-    (saturate always-run)
-    (repeat 20 in_context)
     (saturate always-run)
     (saturate error-checking)
     (saturate
       (saturate type-helpers)
       type-analysis
     )
-    (saturate constant_fold)))
+    (saturate constant_fold)
+    loop-simplify))

--- a/tree_in_context/src/typechecker.rs
+++ b/tree_in_context/src/typechecker.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::{
     ast::emptyt,
-    schema::{Assumption, BaseType, BinaryOp, Constant, Expr, RcExpr, TreeProgram, Type, UnaryOp},
+    schema::{BaseType, BinaryOp, Constant, Expr, RcExpr, TreeProgram, Type, UnaryOp},
 };
 
 impl TreeProgram {

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -2,54 +2,41 @@
 ; It gives each program path a unique equality relation.
 ; This can be quite expensive, so be careful running these rules.
 
-(ruleset in_context)
+(ruleset context_propagate)
+(ruleset context_creation)
 
 (sort InContextList)
 
-; In order to saturate and not create unecessary contexts, we need to collapse
-; duplicate assumptions.
-; For example, the rewrite over `Function` could create many
-; `(InContext (InFunc name) (InContext (InFunc name) ...))` nestings
-(rewrite (InContext assumption (InContext assumption rest))
+; Here's a helpful rule that chooses a more specific context over
+; an inner, less specific one.
+(rewrite (InContext assumption (InContext assumption2 rest))
          (InContext assumption rest)
-         :ruleset in_context)
-
-; ################### start top-down assumptions
-
-(rewrite
- (Function name in_ty out_ty out)
- (Function name in_ty out_ty
-   (InContext (InFunc  name)
-               out))
- :ruleset in_context)
-
+         :ruleset context_propagate)
 
 ; ################### operations
 (rewrite (InContext asum (Bop op c1 c2))
          (Bop op (InContext asum c1) (InContext asum c2))
-         :ruleset in_context)
+         :ruleset context_propagate)
 (rewrite (InContext assum (Uop op c1))
          (Uop op (InContext assum c1))
-         :ruleset in_context)
+         :ruleset context_propagate)
 (rewrite (InContext assum (Get expr index))
          (Get (InContext assum expr) index)
-         :ruleset in_context)
+         :ruleset context_propagate)
 (rewrite (InContext assum (Alloc expr ty))
          (Alloc (InContext assum expr) ty)
-         :ruleset in_context)
+         :ruleset context_propagate)
 (rewrite (InContext assum (Call name expr))
          (Call name (InContext assum expr))
-         :ruleset in_context)
+         :ruleset context_propagate)
 
 ; ################### tuple operations
 (rewrite (InContext assum (Single expr))
          (Single (InContext assum expr))
-         :ruleset in_context)
+         :ruleset context_propagate)
 (rewrite (InContext assum (Concat order e1 e2))
          (Concat order (InContext assum e1) (InContext assum e2))
-         :ruleset in_context)
-
-; #################### control flow
+         :ruleset context_propagate)
 
 ;                       assumptions, predicate, cases,   current case
 (function SwitchInContext (InContextList   Expr       ListExpr i64) ListExpr :unextractable) 
@@ -60,23 +47,100 @@
                (InIf true (InContext assum pred)) then)
              (InContext
                (InIf false (InContext assum pred)) else))
-         :ruleset in_context)
+         :ruleset context_propagate)
 
-(rewrite (InContext assum (Let inputs body))
-         (Let
+
+
+; ###########################  Context creation
+
+(relation ContextLess (Expr))
+(relation ContextLessList (ListExpr))
+
+
+;; check that term has no context to ensure saturation
+(rule
+ ((= lhs (Function name in_ty out_ty out))
+  (ContextLess out))
+ ((union lhs
+   (Function name in_ty out_ty
+      (InContext (InFunc  name)
+               out))))
+ :ruleset context_creation)
+
+(rule ((= lhs (InContext assum (Let inputs body)))
+       (ContextLess inputs)
+       (ContextLess body))
+      ((union lhs
+        (Let
            (InContext assum inputs)
            (InContext
              (InLet (InContext assum inputs))
-             body))
-          :ruleset in_context)
+             body))))
+          :ruleset context_creation)
 
 
-(rule ((= lhs (InContext assum (DoWhile inputs pred_outputs))))
+(rule ((= lhs (InContext assum (DoWhile inputs pred_outputs)))
+       (ContextLess inputs)
+       (ContextLess pred_outputs))
       ((union lhs
          (DoWhile
            (InContext assum inputs)
            (InContext
              (InLoop (InContext assum inputs) pred_outputs)
               pred_outputs))))
-        :ruleset in_context)
-                   
+        :ruleset context_creation)
+
+
+
+
+(rule ((Arg ty)) ((ContextLess (Arg ty))) :ruleset context_propagate)
+(rule ((Const c)) ((ContextLess (Const c))) :ruleset context_propagate)
+(rule ((Empty)) ((ContextLess (Empty))) :ruleset context_propagate)
+(rule ((Bop op a b)
+       (ContextLess a)
+        (ContextLess b))
+      ((ContextLess (Bop op a b))) :ruleset context_propagate)
+(rule ((Uop op a)
+       (ContextLess a))
+      ((ContextLess (Uop op a))) :ruleset context_propagate)
+(rule ((Get a i)
+       (ContextLess a))
+      ((ContextLess (Get a i))) :ruleset context_propagate)
+(rule ((Alloc a ty)
+       (ContextLess a))
+      ((ContextLess (Alloc a ty))) :ruleset context_propagate)
+(rule ((Call name a)
+       (ContextLess a))
+      ((ContextLess (Call name a))) :ruleset context_propagate)
+(rule ((Single a)
+       (ContextLess a))
+      ((ContextLess (Single a))) :ruleset context_propagate)
+(rule ((Concat order a b)
+       (ContextLess a)
+       (ContextLess b))
+      ((ContextLess (Concat order a b))) :ruleset context_propagate)
+(rule ((If pred then else)
+       (ContextLess pred)
+       (ContextLess then)
+       (ContextLess else))
+      ((ContextLess (If pred then else))) :ruleset context_propagate)
+(rule ((Switch pred cases)
+       (ContextLess pred)
+       (ContextLessList cases))
+      ((ContextLess (Switch pred cases))) :ruleset context_propagate)
+(rule ((Let inputs body)
+       (ContextLess inputs)
+       (ContextLess body))
+      ((ContextLess (Let inputs body))) :ruleset context_propagate)
+(rule ((DoWhile inputs pred_outputs)
+       (ContextLess inputs)
+       (ContextLess pred_outputs))
+      ((ContextLess (DoWhile inputs pred_outputs))) :ruleset context_propagate)
+(rule ((Nil)) ((ContextLessList (Nil))) :ruleset context_propagate)
+(rule ((Cons a b)
+       (ContextLess a)
+       (ContextLessList b))
+      ((ContextLessList (Cons a b))) :ruleset context_propagate)
+(rule ((Function name in_ty out_ty out)
+       (ContextLess out))
+      ((ContextLess (Function name in_ty out_ty out))) :ruleset context_propagate)

--- a/tree_in_context/src/utility/in_context.rs
+++ b/tree_in_context/src/utility/in_context.rs
@@ -94,36 +94,42 @@ fn test_switch_contexts() -> crate::Result {
 fn test_dowhile_cycle_in_context() -> crate::Result {
     use crate::ast::*;
     // loop runs one iteration and returns 3
-    let myloop = dowhile(single(int(2)), parallel!(tfalse(), int(3)));
-    let expr = function("main", intt(), tuplet!(intt()), myloop);
+    let myloop = dowhile(arg(), parallel!(tfalse(), int(3)));
+    let expr = function("main", tuplet!(intt()), tuplet!(intt()), myloop).func_with_arg_types();
+    let int3 = single(int(3));
 
-    let int2 = single(in_context(infunc("main"), int(2)));
-    let inner_in_context = inloop(int2.clone(), parallel!(tfalse(), int(3)));
+    let fargincontext = in_context(
+        infunc("main"),
+        arg().with_arg_types(tuplet!(intt()), tuplet!(intt())),
+    );
+    let inner_in_context = inloop(fargincontext.clone(), parallel!(tfalse(), int(3)));
     let expr2 = function(
         "main",
-        intt(),
+        tuplet!(intt()),
         tuplet!(intt()),
         dowhile(
-            int2.clone(),
+            fargincontext.clone(),
             parallel!(
                 in_context(inner_in_context.clone(), tfalse()),
                 in_context(inner_in_context.clone(), int(3)),
             ),
         ),
-    );
+    )
+    .func_with_arg_types();
 
     egglog_test(
+        &format!("{expr}",),
         &format!(
-            "{expr}
-(union {} {expr})",
-            single(int(3))
+            "
+(check (ContextLess {expr}))
+(check (= {expr} {expr2}))
+(check (= {expr} {int3}))"
         ),
-        &format!("(check (= {expr} {expr2}))"),
         vec![
-            expr.to_program(emptyt(), tuplet!(intt())),
-            expr2.to_program(emptyt(), tuplet!(intt())),
+            expr.to_program(tuplet!(intt()), tuplet!(intt())),
+            expr2.to_program(tuplet!(intt()), tuplet!(intt())),
         ],
-        Value::Tuple(vec![]),
+        Value::Tuple(vec![Value::Const(Constant::Int(3))]),
         Value::Tuple(vec![Value::Const(Constant::Int(3))]),
         vec![],
     )

--- a/tree_in_context/src/utility/in_context.rs
+++ b/tree_in_context/src/utility/in_context.rs
@@ -96,13 +96,22 @@ fn test_dowhile_cycle_in_context() -> crate::Result {
     // loop runs one iteration and returns 3
     let myloop = dowhile(arg(), parallel!(tfalse(), int(3)));
     let expr = function("main", tuplet!(intt()), tuplet!(intt()), myloop).func_with_arg_types();
-    let int3 = single(int(3));
+    let int3func = function("main", tuplet!(intt()), tuplet!(intt()), single(int(3)));
 
     let fargincontext = in_context(
         infunc("main"),
         arg().with_arg_types(tuplet!(intt()), tuplet!(intt())),
     );
     let inner_in_context = inloop(fargincontext.clone(), parallel!(tfalse(), int(3)));
+    let expr_intermediate = function(
+        "main",
+        tuplet!(intt()),
+        tuplet!(intt()),
+        dowhile(
+            fargincontext.clone(),
+            in_context(inner_in_context.clone(), parallel!(tfalse(), int(3))),
+        ),
+    );
     let expr2 = function(
         "main",
         tuplet!(intt()),
@@ -122,8 +131,9 @@ fn test_dowhile_cycle_in_context() -> crate::Result {
         &format!(
             "
 (check (ContextLess {expr}))
+(check (= {expr} {expr_intermediate}))
 (check (= {expr} {expr2}))
-(check (= {expr} {int3}))"
+(check (= {expr} {int3func}))"
         ),
         vec![
             expr.to_program(tuplet!(intt()), tuplet!(intt())),


### PR DESCRIPTION
Creating new contexts is a subtle thing to get right.
This PR proposes that the automatic rules only create contexts with context-free children. Without this change, rules never saturate even for non-cyclic egraphs due to InLoop.

We should keep thinking about what contexts to create and how rules can indicate contexts to create.