### PR TITLE
Add pen-and-paper semantics

### DIFF
--- a/writing/.gitignore
+++ b/writing/.gitignore
@@ -1,0 +1,17 @@
+# latex stuff
+
+*.aux
+*.log
+*.out
+*.synctex.gz
+*.fls
+*.fdb_latexmk
+*.bbl
+*.blg
+*.pdf
+
+# mac trash
+.DS_Store
+
+_build/
+*.drawio.bkp

--- a/writing/Makefile
+++ b/writing/Makefile
@@ -1,0 +1,11 @@
+BUILD_MAIN_TEX := pdflatex -file-line-error -interaction=nonstopmode main.tex
+
+main.pdf: main.tex semantics.tex macros.tex bcprules.sty
+	$(BUILD_MAIN_TEX)
+
+force: .FORCE
+	$(BUILD_MAIN_TEX)
+
+.PHONY: force .FORCE
+.FORCE:
+

--- a/writing/bcprules.sty
+++ b/writing/bcprules.sty
@@ -1,0 +1,317 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%                                                                   %%%
+%%%        BCP's latex tricks for typesetting inference rules         %%%
+%%%                                                                   %%%
+%%%                         Version 1.4                               %%%
+%%%                                                                   %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%
+%%% This package supports two styles of rules: named and unnamed.  
+%%% Unnamed rules are centered on the page.  Named rules are set so
+%%% that a series of them will have the rules centered in a vertical
+%%% column taking most of the page and the labels right-justified.
+%%% When a label would overlap its rule, the label is moved down.  
+%%% 
+%%% The width of the column of labels can be varied using a command of the
+%%% form 
+%%% 
+%%%   \typicallabel{T-Arrow-I}
+%%% 
+%%% The default setting is:
+%%%
+%%%   \typicallabel{}
+%%%
+%%% In other words, the column of rules takes up the whole width of
+%%% the page: rules are centered on the centerline of the text, and no
+%%% extra space is left for the labels.
+%%%
+%%% The minimum distance between a rule and its label can be altered by a
+%%% command of the form
+%%% 
+%%%   \setlength{\labelminsep}{0.5em}
+%%% 
+%%% (This is the default value.)
+%%% 
+%%% Examples:
+%%% 
+%%% An axiom with a label in the right-hand column:
+%%% 
+%%%   \infax[The name]{x - x = 0}
+%%% 
+%%% An inference rule with a name:
+%%% 
+%%%   \infrule[Another name]
+%%%     {\mbox{false}}
+%%%     {x - x = 1}
+%%% 
+%%% A rule with multiple premises on the same line:
+%%% 
+%%%   \infrule[Wide premises]
+%%%     {x > 0  \andalso y > 0  \andalso z > 0}
+%%%     {x + y + z > 0}
+%%%   
+%%% A rule with several lines of premises:
+%%% 
+%%%   \infrule[Long premises]
+%%%     {x > 0  \\ y > 0  \\ z > 0}
+%%%     {x + y + z > 0}
+%%%   
+%%% A rule without a name, but centered on the same vertical line as rules
+%%% and axioms with names:
+%%% 
+%%%   \infrule[]
+%%%     {x - y = 5}
+%%%     {y - x = -5}
+%%% 
+%%% A rule without a name, centered on the page:
+%%% 
+%%%   \infrule
+%%%     {x = 5}
+%%%     {x - 1 > 0}
+%%%
+%%%
+%%% Setting the flag \indexrulestrue causes an index entry to be 
+%%% generated for each named rule.
+%%%
+%%% Setting the flag \suppressrulenamestrue causes the names of all rules
+%%% to be left blank
+%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%% A switch controlling the sizes of rule names
+\newif\ifsmallrulenames  \smallrulenamesfalse
+\newcommand{\smallrulenames}{\smallrulenamestrue}
+\newcommand{\choosernsize}[2]{\ifsmallrulenames#1\else#2\fi}
+
+%%% The font for setting inference rule names
+\newcommand{\rn}[1]{%
+  \ifmmode 
+    \mathchoice
+      {\mbox{\choosernsize{\small}{}\sc #1}}
+      {\mbox{\choosernsize{\small}{}\sc #1}}
+      {\mbox{\choosernsize{\tiny}{\small}\sc #1}}
+      {\mbox{\choosernsize{\tiny}{\tiny}\uppercase{#1}}}%
+  \else
+    \hbox{\choosernsize{\small}{}\sc #1}%
+  \fi}
+
+\newif\ifsuppressrulenames  
+\suppressrulenamesfalse
+
+\newif\ifbcprulessavespace
+\bcprulessavespacefalse
+
+\newif\ifbcprulestwocol
+\bcprulestwocolfalse
+
+%%% How to display a rule's name to the right of the rule
+\newcommand{\inflabel}[1]{%
+  \ifsuppressrulenames\else
+    \def\lab{#1}%
+    \ifx\lab\empty
+      \relax
+    \else
+      (\rn{\lab})%
+  \fi\fi
+}
+
+%%% Amount of extra space to add before and after a rule
+\newlength{\afterruleskip}
+\setlength{\afterruleskip}{\bigskipamount}
+
+%%% Minimum distance between a rule and its label
+\newlength{\labelminsep}
+\setlength{\labelminsep}{0.2em}
+
+%%% The ``typical'' width of the column of labels: labels are allowed
+%%% to project further to the left if necessary; the rules will be
+%%% centered in a column of width \linewidth - \labelcolwidth
+\newdimen\labelcolwidth
+
+%%% Set the label column width by providing a ``typical'' label --
+%%% i.e. a label of average length
+\newcommand{\typicallabel}[1]{
+  \setbox \@tempboxa \hbox{\inflabel{#1}}
+  \labelcolwidth \wd\@tempboxa
+  }
+\typicallabel{}
+
+%%% A flag controlling generation of index entries
+\newif  \ifindexrules   \indexrulesfalse
+
+%%% Allocate some temporary registers
+\newbox\@labelbox
+\newbox\rulebox
+\newdimen\ruledim
+\newdimen\labeldim
+
+%%% Put a rule and its label on the same line if this can be done
+%%% without overlapping them; otherwise, put the label on the next
+%%% line.  Put a small amount of vertical space above and below.
+\newcommand{\layoutruleverbose}[2]%
+  {\unvbox\voidb@x  % to make sure we're in vmode
+   \addvspace{\afterruleskip}%
+
+   \setbox \rulebox \hbox{$\displaystyle #2$}
+
+   \setbox \@labelbox \hbox{#1}
+   \ruledim \wd \rulebox
+   \labeldim \wd \@labelbox
+
+   %%% Will it all fit comfortably on one line?
+   \@tempdima \linewidth
+   \advance \@tempdima -\labelcolwidth
+   \ifdim \@tempdima < \ruledim
+     \@tempdima \ruledim
+   \else
+     \advance \@tempdima by \ruledim
+     \divide \@tempdima by 2
+   \fi
+   \advance \@tempdima by \labelminsep
+   \advance \@tempdima by \labeldim
+   \ifdim \@tempdima < \linewidth
+     % Yes, everything fits on a line
+     \@tempdima \linewidth
+     \advance \@tempdima -\labelcolwidth
+     \hbox to \linewidth{%
+       \hbox to \@tempdima{%
+         \hfil
+         \box\rulebox
+         \hfil}%
+       \hfill
+       \hbox to 0pt{\hss\box\@labelbox}%
+     }%
+   \else
+   %
+   % Will it all fit _UN_comfortably on one line?
+   \@tempdima 0pt
+   \advance \@tempdima by \ruledim
+   \advance \@tempdima by \labelminsep
+   \advance \@tempdima by \labeldim
+   \ifdim \@tempdima < \linewidth
+     % Yes, everything fits, but not centered
+     \hbox to \linewidth{%
+         \hfil
+         \box\rulebox
+         \hskip \labelminsep
+         \box\@labelbox}%
+   \else
+   %
+   % Better put the label on the next line
+     \@tempdima \linewidth
+     \advance \@tempdima -\labelcolwidth
+     \hbox to \linewidth{%
+       \hbox to \@tempdima{%
+          \hfil
+          \box\rulebox
+          \hfil}
+       \hfil}%
+     \penalty10000
+     \hbox to \linewidth{%
+         \hfil
+         \box\@labelbox}%
+   \fi\fi
+
+   \addvspace{\afterruleskip}%
+   \@doendpe  % use LaTeX's trick of inhibiting paragraph indent for
+              % text immediately following a rule
+   \ignorespaces
+   }
+
+% Simplified form for when there is no label
+\newcommand{\layoutrulenolabel}[1]%
+  {\unvbox\voidb@x  % to make sure we're in vmode
+   \addvspace{\afterruleskip}%
+
+   \setbox \rulebox \hbox{$\displaystyle #1$}
+
+   \@tempdima \linewidth
+   \advance \@tempdima -\labelcolwidth
+   \hbox to \@tempdima{%
+      \hfil 
+      \box\rulebox
+      \hfil}%
+
+   \addvspace{\afterruleskip}%
+   \@doendpe  % use LaTeX's trick of inhibiting paragraph indent for
+              % text immediately following a rule
+   \ignorespaces
+   }
+
+% Alternate form, for when we need to save space
+%\newcommand{\layoutruleterse}[2]%
+%  {\noindent
+%   \parbox[b]{0.5\linewidth}{\layoutruleverbose{#1}{#2}}}
+
+\newcommand{\layoutruleterse}[2]%
+  {\setbox \rulebox \hbox{$\displaystyle #2$}
+   \noindent
+   \parbox[b]{0.5\linewidth}
+    {\vspace*{0.4em} \hfill\box\rulebox\hfill~}
+   }
+
+%%% Select low-level layout driver based on \bcprulessavespace flag
+\newcommand{\layoutrule}[2]{%
+      \ifbcprulessavespace 
+        \layoutruleterse{#1}{#2}
+      \else
+        \layoutruleverbose{#1}{#2}
+      \fi
+}
+
+%%% Highlighting for new versions of rules
+\newif\ifnewrule   \newrulefalse
+\newcommand{\setrulebody}[1]{%
+  \ifnewrule
+     \@ifundefined{HIGHLIGHT}{%
+        \fbox{\ensuremath{#1}}%
+     }{%
+        \HIGHLIGHT{#1}}%
+  \else
+     #1
+  \fi
+}
+
+%%% Commands for setting axioms and rules
+\newcommand{\typesetax}[1]{%
+   \setrulebody{%
+     \begin{array}{@{}c@{}}#1\end{array}}}
+\newcommand{\typesetrule}[2]{%
+   \setrulebody{%
+      \frac{\begin{array}{@{}c@{}}#1\end{array}}%
+           {\begin{array}{@{}c@{}}#2\end{array}}}}
+
+%%% Indexing
+\newcommand{\ruleindexprefix}[1]{%
+  \gdef\ruleindexprefixstring{#1}}
+\ruleindexprefix{}
+\newcommand{\maybeindex}[1]{%
+  \ifindexrules
+    \index{\ruleindexprefixstring#1@\rn{#1}}%
+  \fi}
+
+%%% Setting axioms, with or without names
+\def\infax{\@ifnextchar[{\@infaxy}{\@infaxx}}
+\def\@infaxx#1{%
+  \ifbcprulessavespace $\typesetax{#1}$%
+  \else \layoutrulenolabel{\typesetax{#1}}%
+  \fi\newrulefalse\ignorespaces}
+\def\@infaxy[#1]{\maybeindex{#1}\@infax{\inflabel{#1}}}
+\def\@infax#1#2{\layoutrule{#1}{\typesetax{#2}}\ignorespaces}
+
+%%% Setting rules, with or without names
+\def\infrule{\@ifnextchar[{\@infruley}{\@infrulex}}
+\def\@infrulex#1#2{%
+  \ifbcprulessavespace $\typesetrule{#1}{#2}$%
+  \else \layoutrulenolabel{\typesetrule{#1}{#2}}%
+  \fi\newrulefalse\ignorespaces}
+\def\@infruley[#1]{\maybeindex{#1}\@infrule{\inflabel{#1}}}
+\def\@infrule#1#2#3{\layoutrule{#1}{\typesetrule{#2}{#3}}\ignorespaces}
+
+%%% Miscellaneous helpful definitions
+\newcommand{\andalso}{\quad\quad}
+
+% Abbreviations
+\newcommand{\infabbrev}[2]{\infax{#1 \quad\eqdef\quad #2}}
+

--- a/writing/macros.tex
+++ b/writing/macros.tex
@@ -1,0 +1,97 @@
+\newcommand{\todo}[1]{{\color{red}[#1]}}
+\newcommand{\red}[1]{{\color{red}#1}}
+
+\newcommand{\no}{\xspace\faThumbsODown\xspace}
+
+%\newcommand{\change}[1]{{\color{blue} #1}}
+\newcommand{\change}[1]{{#1}}
+
+\definecolor{bp}{rgb}{0.2, 0.2, 0.6}
+
+% enumo macros
+\newcommand{\sexp}{s-expression\xspace}
+\newcommand{\sexps}{s-expressions\xspace}
+\newcommand{\enumo}{\textsc{Enumo}\xspace}
+\newcommand{\ints}{ℤ}
+\newcommand{\reals}{ℝ}
+
+\newcommand{\egg}{\texorpdfstring{\MakeLowercase{\texttt{egg}}}{\texttt{egg}}\xspace}
+\newcommand{\egraph}{\mbox{e-graph}\xspace}
+\newcommand{\egraphs}{\mbox{e-graphs}\xspace}
+\newcommand{\Egraph}{\mbox{E-graph}\xspace}
+\newcommand{\Egraphs}{\mbox{E-graphs}\xspace}
+\newcommand{\Eclass}{\mbox{E-class}\xspace}
+\newcommand{\Eclasses}{\mbox{E-classes}\xspace}
+\newcommand{\eclass}{\mbox{e-class}\xspace}
+\newcommand{\eclasses}{\mbox{e-classes}\xspace}
+\newcommand{\ematching}{\mbox{e-matching}\xspace}
+\newcommand{\Ematching}{\mbox{E-matching}\xspace}
+\newcommand{\Enode}{\mbox{E-node}\xspace}
+\newcommand{\Enodes}{\mbox{E-nodes}\xspace}
+\newcommand{\enode}{\mbox{e-node}\xspace}
+\newcommand{\enodes}{\mbox{e-nodes}\xspace}
+\newcommand{\Cvec}{Cvec\xspace}
+\newcommand{\signature}{Signature\xspace}
+\newcommand{\signatures}{Signatures\xspace}
+\newcommand{\Cvecs}{Cvecs\xspace}
+\newcommand{\cvec}{cvec\xspace}
+\newcommand{\cvecmatch}{cvec\_match\xspace}
+\newcommand{\Meta}{Metadata\xspace}
+\newcommand{\meta}{metadata\xspace}
+\newcommand{\cvecs}{cvecs\xspace}
+\newcommand{\EqSat}{Equality Saturation\xspace}
+\newcommand{\Eqsat}{Equality saturation\xspace}
+\newcommand{\eqsat}{equality saturation\xspace}
+\newcommand{\lifting}{{\color{red}rule lifting}\xspace}
+\newcommand{\ff}{fast-forwarding\xspace}
+\newcommand{\recipe}{recipe\xspace}
+\newcommand{\lhs}{\T{LHS}\xspace}
+\newcommand{\lhsandrhs}{\T{LHS-RHS}\xspace}
+\newcommand{\all}{\T{all}\xspace}
+
+\newcommand{\rationals}{{rationals}\xspace}
+\newcommand{\bfour}{{bitvector-4}\xspace}
+\newcommand{\bthreetwo}{{bitvector-32}\xspace}
+\newcommand{\booleans}{{booleans}\xspace}
+
+\newcommand{\problem}[1]{\smallskip\noindent\emph{#1.}\xspace}
+
+\newcommand{\mypara}[1]{{\noindent \textit{#1}}}
+%\newcommand{\mypara}[1]{\paragraph{#1}}
+\newcommand{\denote}{$\llbracket \cdot \rrbracket$\xspace}
+
+\newcommand{\dnt}[1]{$\llbracket #1 \rrbracket$\xspace}
+
+\newcommand\flow{$\mathsf{flow}$\xspace}
+\newcommand{\C}[1]{\texttt{#1}\xspace}
+\newcommand{\M}[1]{$\mathsf{#1}$\xspace}
+\newcommand{\B}[1]{$\mathbb{#1}$\xspace}
+\newcommand{\G}[1]{$\mathcal{#1}$\xspace}
+\newcommand{\W}{\ensuremath{\mathcal{W}}}
+\newcommand{\N}{$\mathbb{N}$}
+\newcommand{\F}[1]{$\mathsf{[#1]}$}
+\newcommand{\T}[1]{\textsf{#1}}
+
+\newcommand{\foottt}[1]{{\footnotesize \texttt{#1}}}
+\newcommand{\cis}{\mathrm{cis}}
+
+\newcommand\rewritename[1]{
+  \multicolumn{3}{l}{\footnotesize \textbf{\textsf{#1}}}
+  \vspace{1mm}
+}
+\newcommand\rewritenamecond[2]{
+  \multicolumn{3}{l}{\footnotesize \textbf{\textsf{#1}} \textsf{#2}}
+  \vspace{1mm}
+}
+\newcommand\rewritespace{\vspace{2mm}}
+\newcommand\rewritesto{\ensuremath{\rightsquigarrow}}
+\newcommand\rewritesboth{\ensuremath{\leftrightsquigarrow}}
+
+\newcommand\Rewritename[1]{
+  \footnotesize \textbf{\textsf{#1}}
+  \vspace{0mm}
+}
+\newcommand\Rewritenamecond[2]{
+  \footnotesize \textbf{\textsf{#1}} \textsf{#2}
+  \vspace{0mm}
+}

--- a/writing/main.tex
+++ b/writing/main.tex
@@ -1,0 +1,67 @@
+\documentclass{article}
+
+% from CS 231 hw
+\usepackage[parfill]{parskip}
+\usepackage{times}
+\usepackage{bcprules}
+\usepackage{ebproof}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{stmaryrd}
+\usepackage{verbatim}
+\usepackage{verbatimbox}
+\usepackage{listings}
+\usepackage{graphicx}\usepackage{graphics}
+\newcommand{\step}[2]{{\tt #1} $\longrightarrow$ {\tt #2}}
+
+\usepackage[utf8]{inputenc}
+% from enumo paper
+\usepackage{balance}
+\usepackage{pifont}
+\usepackage{wrapfig}
+\usepackage{hyperref}
+\usepackage{fancyvrb}
+\usepackage{xspace}
+\usepackage{algorithmicx}
+\usepackage{algpseudocode}
+\usepackage{algorithm}
+\usepackage{amsfonts}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{semantic}
+\usepackage{listings}
+\usepackage{array}
+\usepackage{fancyvrb}
+\usepackage{mathpartir}
+\usepackage{stmaryrd}
+\usepackage{graphicx}
+\usepackage{caption}
+\usepackage{syntax, etoolbox}
+\usepackage{tikz}
+\usepackage{proof}
+\usepackage{color}
+\usepackage{mathtools}
+\usepackage{adjustbox}
+\usepackage{multirow}
+\usepackage{bbding}
+\usepackage{soul} % for \hl
+\usepackage{multirow}
+\usepackage{fontawesome}
+
+\usepackage[
+  left=1in,
+  right=1in,
+  top=0.5in,
+  bottom=0.5in
+]{geometry}
+\begin{document}
+
+\include{macros}
+
+\renewcommand\denote[1]{\ensuremath{\left\llbracket #1 \right\rrbracket}}
+\newcommand\set[2]{\ensuremath{\left\{#1 \hspace{3pt} \left\vert \hspace{3pt} #2 \right.\right\}}}
+\newcommand\plugsexp{\ensuremath{\mathsf{plug\_sexp}}}
+
+\include{semantics}
+
+\end{document}

--- a/writing/semantics.tex
+++ b/writing/semantics.tex
@@ -1,0 +1,385 @@
+\newcommand{\inferax}[2]{\infrule[#1]{\mbox{}}{\mbox{$#2$}}}
+\renewcommand{\inferrule}[3]{\infrule[#1]{\mbox{$#2$}}{\mbox{$#3$}}}
+\newcommand{\bigstep}[2]{#1 \Downarrow #2}
+\newcommand{\ang}[1]{\langle #1 \rangle}
+\newcommand{\spair}[2]{\ang{#1, #2}}
+\newcommand{\strip}[3]{\ang{#1, #2, #3}}
+
+\newcommand{\targ}{\alpha}
+\newcommand{\tmem}{\sigma}
+
+\newcommand{\uop}[2]{\operatorname{#1}\ #2}
+\newcommand{\bop}[3]{\operatorname{#1}\ #2\ #3}
+\newcommand{\trop}[4]{\operatorname{#1}\ #2\ #3\ #4}
+
+% (expression, arg, state) to (value, state)
+\newcommand{\easvs}[5]{\bigstep{\strip{#1}{#2}{#3}}{\spair{#4}{#5}}}
+
+% "definition" version of easvs
+\newcommand{\easvsd}[5]{\easvs{#1}{#2}{#3}{#4}{#5}}
+
+\newcommand{\append}[2]{#1\ \texttt{+\hspace{-1pt}+}\ #2}
+
+\clearpage
+
+\newpage
+
+\subsection*{Denotational semantics}
+
+\renewcommand{\denote}[1]{\left\llbracket #1 \right\rrbracket}
+\newcommand{\denotesub}[2]{\left\llbracket #2 \right\rrbracket_{#1}}
+\newcommand{\denotevalue}[1]{\denotesub{v}{#1}}
+\newcommand{\denotestate}[1]{\denotesub{s}{#1}}
+
+% denote called as a function
+\newcommand{\denotef}[2]{\denote{#1}\hspace{-.1em}\left(#2\right)}
+
+\newcommand{\denotefv}[2]{\denotevalue{#1}\hspace{-.2em}\left(#2\right)}
+\newcommand{\denotefs}[2]{\denotestate{#1}\hspace{-.2em}\left(#2\right)}
+\newcommand{\denotefsub}[3]{\denotesub{#1}{#2}\hspace{-.2em}\left(#3\right)}
+
+\newcommand{\eqdef}{\triangleq}
+
+%% $\denote{\cdot} : \mathrm{Value} \times \mathrm{State} \to \mathrm{Value} \times \mathrm{State}$
+
+%% $\easvs{e}{\targ}{\tmem}{v}{\tmem'}$ means: with argument $\targ$ and state $\tmem$, $e$ evaluates to $v$ and the resulting state is $\tmem'$.
+
+%% $\denotevalue{\cdot} : \mathrm{Value} \times \mathrm{State} \to \mathrm{Value} \triangleq \mathrm{fst} \circ \denote{\cdot}$
+
+Evaluating $e$ with argument $\targ$ and state $\tmem$ results in the value $\denotefv{e}{\targ,\tmem}$ and the updated state $\denotefs{e}{\targ,\tmem}$.\\
+$\denotevalue{\cdot} : \mathrm{Value} \times \mathrm{State} \to \mathrm{Value}$\quad\quad
+$\denotestate{\cdot} : \mathrm{Value} \times \mathrm{State} \to \mathrm{State}$\quad\quad
+$\denotef{e}{\targ,\tmem} \eqdef \left(\denotefv{e}{\targ,\tmem},\denotefs{e}{\targ,\tmem}\right)$
+
+$\mathrm{State} \eqdef \mathrm{Memory} \times \mathrm{Log}$\quad\quad
+$\denotesub{m}{\cdot} \triangleq \mathrm{fst} \circ \denotestate{\cdot}$\quad\quad
+$\denotesub{l}{\cdot} \triangleq \mathrm{snd} \circ \denotestate{\cdot}$
+
+$\operatorname{malloc}$ takes a state and number of bytes $n$, finds a contiguous region of free memory starting at address $p$, and returns $p$ and an updated state where addresses $[p,p+n)$ are marked as used.
+\begin{align*}
+\denotef{\uop{Num}{n}}{\targ,\tmem} &\eqdef
+  \left(n,\tmem\right)\\
+%
+\denotef{\uop{Bool}{b}}{\targ,\tmem} &\eqdef
+  \left(b,\tmem\right)\\
+%
+\denotef{\mathrm{Arg}}{\targ,\tmem} &\eqdef
+  \left(\targ,\tmem\right)\\
+%
+\denotefv{\bop{Add}{e_1}{e_2}}{\targ,\tmem} &\eqdef
+  \denotefv{e_1}{\targ,\tmem} +
+  \denotefv{e_2}{\targ,\denotefs{e_1}{\targ,\tmem}}\\
+%
+\denotefs{\bop{Add}{e_1}{e_2}}{\targ,\tmem} &\eqdef
+  \denotefs{e_2}{\targ,\denotefs{e_1}{\targ,\tmem}}\\
+%
+\denotef{\trop{If}{e_c}{e_t}{e_e}}{\targ,\tmem} &\eqdef
+  \begin{cases}
+    \denotef{e_t}{\targ,\denotefs{e_c}{\targ,\tmem}} &
+      \denotefv{e_c}{\targ,\tmem} = \top\\
+    \denotef{e_e}{\targ,\denotefs{e_c}{\targ,\tmem}} &
+      \denotefv{e_c}{\targ,\tmem} = \bot
+  \end{cases}\\
+%
+\denotef{\bop{Switch}{e_{pred}}{\Vec{e}\ }}{\targ,\tmem} &\eqdef
+  \denotef{\Vec{e}\ [\denotefv{e_{pred}}{\targ,\tmem}]}{\targ,\denotefs{e_{pred}}{\targ,\tmem}}\\
+\begin{aligned}
+\denote{\bop{Let}{e_{in}}{e_{out}}}&\\
+\denotef{\bop{Let}{e_{in}}{e_{out}}}{\targ,\tmem}&
+\end{aligned}
+\ &\begin{aligned}
+  &\eqdef \denote{e_{out}} \circ \denote{e_{in}}
+  &&\text{\color{gray}(point-free version)}\\
+  &\eqdef \denotef{e_{out}}{\denotef{e_{in}}{\targ,\tmem}}
+  &&\text{\color{gray}($\eta$-expanded for clarity)}\\
+\end{aligned}\\
+%
+\denotefv{\uop{Print}{e}}{\targ,\tmem} &\eqdef []\\
+\denotefs{\uop{Print}{e}}{\targ,\tmem} &\eqdef
+  (\denotefsub{m}{e}{\targ,\tmem},\;
+   \append{\denotefsub{l}{e}{\targ,\tmem}}{\denotefv{e}{\targ,\tmem}})\\
+%
+\denotefv{\uop{Read}{e}}{\targ,\tmem} &\eqdef
+  \denotefsub{m}{e}{\targ,\tmem}[\denotefv{e}{\targ,\tmem}]\\
+%
+\denotestate{\uop{Read}{e}} &\eqdef \denotestate{e}\\
+%
+\denotef{\bop{Alloc}{e}{\tau}}{\targ,\tmem} &\eqdef \operatorname{malloc}(\denotefs{e}{\targ,\tmem},\; \denotefv{e}{\targ,\tmem} * \operatorname{sizeof}(\tau))\\
+%
+\denotefv{\bop{Write}{e_p}{e_d}}{\targ,\tmem} &\eqdef []\\
+%
+\denotefsub{m}{\bop{Write}{e_p}{e_d}}{\targ,\tmem} &\eqdef
+\denotefsub{m}{e_p}{\targ,\denotefs{e_d}{\targ,\tmem}}[\denotefv{e_p}{\targ,\tmem} \mapsto \denotefv{e_d}{\targ,\tmem}]\\
+%
+\denotefsub{l}{\bop{Write}{e_p}{e_d}}{\targ,\tmem} &\eqdef
+\denotefsub{l}{e_p}{\targ,\denotefs{e_d}{\targ,\tmem}}\\
+%
+\denotefv{\uop{Single}e}{\targ,\tmem} &\eqdef [\denotefv{e}{\targ,\tmem}]\\
+\denotestate{\uop{Single}e} &\eqdef \denotestate{e} \\
+%
+\denotefv{\bop{Concat\ Sequential}{e_1}{e_2}}{\targ,\tmem} &\eqdef
+\append{\denotefv{e_1}{\targ,\tmem}}{\denotefv{e_2}{\targ,\denotefs{e_1}{\targ,\tmem}}}\\
+%
+\denotefs{\bop{Concat\ Sequential}{e_1}{e_2}}{\targ,\tmem} &\eqdef
+\denotefs{e_2}{\targ,\denotefs{e_1}{\targ,\tmem}}\\
+%
+%% \mathrm{NextArgState_{e_{po}}}(\targ,\tmem) &\eqdef (\denotefv{e_{po}}(\targ,\tmem)[1], \denotefs{e_{po}}(\targ,\tmem))\\
+\denotef{\bop{DoWhile}{e_{in}}{e_{po}}}{\targ,\tmem} &\eqdef
+\mathrm{let}\ (v_{in},\tmem') = \denotef{e_{in}}{\targ,\tmem}\ \mathrm{in}\\
+&\hspace{1.3em}\mathrm{let}\ ((v_{pred}, v_{out}), \tmem'') = \denotef{e_{po}}{v_{in},\tmem'}\ \mathrm{in}\\
+&\hspace{1.3em}\begin{cases}
+   (v_{out}, \tmem'')
+   & v_{pred} = \bot\\
+   \denotef{\bop{DoWhile}{\mathrm{Arg}\ }{e_{po}}}{v_{out},\tmem''}
+   & v_{pred} = \top\\
+\end{cases}\\
+&\hspace{1.3em}\text{\color{gray}(this should be written as a fixpoint instead)}\\
+\denotef{\bop{Context}{(\uop{InLet}{e_{in}})}{e}}{\targ,\tmem} &\eqdef
+\begin{cases}
+  \denotef{e}{\targ,\tmem} & \exists \targ', \tmem' . \; \denotefv{e_{in}}{\targ',\tmem'} = \targ
+  %% \\ \mathrm{undefined} & \text{otherwise}
+\end{cases}\\
+%
+\denotef{\bop{Context}{(\bop{AfterWrite}{e_p}{e_d})}{e}}{\targ,\tmem} &\eqdef
+\begin{cases}
+  \denotef{e}{\targ,\tmem} & \exists \targ', \tmem' . \; \denotefs{\bop{Write}{e_p}{e_d}}{\targ',\tmem'} = \tmem
+  %% \\ \mathrm{undefined} & \text{otherwise}
+\end{cases}\\
+%
+%% \operatorname{possibleargs}(e_{in},e_{po}) &\eqdef \{\denotefv{e_{in}}{\targ,\tmem} \ |\  \targ \in \mathrm{Value}, \tmem \in \mathrm{State} \}\\
+%% \denotef{\bop{Context}{(\bop{InLoop}{e_{in}}{e_{po}})}{e}}{\targ,\tmem} &\eqdef
+%% \begin{cases}
+%%   \denotef{e}{\targ,\tmem} &
+%%     \begin{aligned}
+%%       &\exists \targ', \tmem' . \\
+%%       &\denotefv{e_{in}}{\targ',\tmem'} = \targ \; \lor\\
+%%       &(\mathrm{let}\ (v_p, v_o) = \denotefv{e_{po}}{\targ',\tmem'} \mathrm{in}\\
+%%       &v_p = \top \land\\
+%%       & (v_o, \tmem') \in \operatorname{domain}(\denote{\bop{Context}{(\bop{InLoop}{\mathrm{Arg}}{e_{po}})}{e}}))
+%%     \end{aligned}
+%%   %% \\ \mathrm{undefined} & \text{otherwise}
+%% \end{cases}\\
+\denotef{\bop{Context}{(\bop{InLoop}{e_{in}}{e_{po}})}{e}}{\targ,\tmem} &\eqdef
+\begin{cases}
+  \denotef{e}{\targ,\tmem} &
+    \exists  \tmem' . \; (\targ,\tmem') \in  \operatorname{loop\_reachable}(e_{in},e_{po})
+\end{cases}
+%% \text{\color{gray}alternate version:}&\\
+%% \denotef{\bop{Context}{(\bop{InLoop}{e_{in}}{e_{po}})}{e}}{\targ,\tmem} &\eqdef
+%% \begin{cases}
+%%   \denotef{e}{\targ,\tmem} &
+%%     \begin{aligned}
+%%       &\exists \targ', \tmem' . \\
+%%       &\denotefv{e_{in}}{\targ',\tmem'} = \targ \; \lor\\
+%%       &(\mathrm{let}\ (v_p, v_o) = \denotefv{e_{po}}{\targ',\tmem'} \mathrm{in}\\
+%%       &v_p = \top \land\\
+%%       & (v_o, \tmem') \in \operatorname{domain}(\denote{\bop{Context}{(\bop{InLoop}{\mathrm{Arg}}{e_{po}})}{e}}))
+%%     \end{aligned}
+%%   %% \\ \mathrm{undefined} & \text{otherwise}
+%% \end{cases}\\
+\end{align*}
+\begin{lstlisting}[escapeinside={(*}{*)}]
+def loop_reachable((*$e_{in}$*), (*$e_{po}$*)):
+  res = {(*$\denotef{e_{in}}{\targ,\tmem} \mid \targ \in \mathrm{Value}, \tmem \in \mathrm{State}$*)}
+  fixpoint:
+    for (*$(\targ, \tmem) \in$*) res:
+      (*$(v_{pred}, v_{out}), \tmem' = \denotef{e_{po}}{\targ,\tmem}$*)
+      if (*$v_{pred}$*):
+        res.insert((*$(v_{out}, \tmem')$*))
+  return res
+\end{lstlisting}
+
+%% \begin{gather*}
+%% F_{(e_{in},e_{po})} : (\mathrm{Value} \times \mathrm{State} \to \mathrm{Value} \times \mathrm{State}) \to (\mathrm{Value} \times \mathrm{State} \to \mathrm{Value} \times \mathrm{State})\\
+%% F_{(e_{in},e_{po})}(f) \eqdef \lambda \targ. \tmem. \begin{cases}
+%%   (\denotefv{e_{po}}{\denotef{e_{in}}{\targ,\tmem}},
+%%    \denotefs{e_{po}}{\denotef{e_{in}}{\targ,\tmem}})
+%%    & \denotefv{e_{po}}{\targ,\tmem}[1] = \bot\\
+%%   (\denotefv{e_{po}}{\denotef{e_{in}}{\targ,\tmem}},
+%%    \denotefs{e_{po}}{\denotef{e_{in}}{\targ,\tmem}})
+%%    & \denotefv{e_{po}}{\targ,\tmem}[1] = \top\\
+%% \end{cases}
+%% \end{gather*}
+%% \begin{align*}
+%% \end{align*}
+
+\newpage
+
+\subsection*{Big-step operational semantics}
+
+$\bigstep{\strip{e}{\targ}{\tmem}}{\spair{v}{\tmem'}}$ means: with argument $\targ$ and state $\tmem$, $e$ evaluates to $v$ and the resulting state is $\tmem'$.
+
+A state is a pair $(M, L)$, containing memory and a print log.
+
+%% \inferax{E-Num}{\easvsd{\uop{Num}{n}}{\targ}{\tmem}{n}{\tmem}}
+
+%% \inferax{E-Bool}{\easvsd{\uop{Bool}{b}}{\targ}{\tmem}{b}{\tmem}}
+
+\inferrule{E-Add}{
+  \easvs{e_1}{\targ}{\tmem}{v_1}{\tmem'} \andalso
+  \easvs{e_2}{\targ}{\tmem'}{v_2}{\tmem''}}
+{\easvsd
+  {\bop{Add}{e_1}{e_2}}{\targ}{\tmem}
+  {v_1 + v_2}{\tmem''}}
+
+\inferrule{E-IfTrue}{
+  \easvs{e_c}{\targ}{\tmem}{\top}{\tmem'} \andalso
+  \easvs{e_t}{\targ}{\tmem'}{v_t}{\tmem''}}
+{\easvsd
+  {\trop{If}{e_c}{e_t}{e_e}}{\targ}{\tmem}
+  {v_t}{\tmem''}}
+
+\inferrule{E-IfFalse}{
+  \easvs{e_c}{\targ}{\tmem}{\bot}{\tmem'} \andalso
+  \easvs{e_e}{\targ}{\tmem'}{v_e}{\tmem''}}
+{\easvsd
+  {\trop{If}{e_c}{e_t}{e_e}}{\targ}{\tmem}
+  {v_e}{\tmem''}}
+
+\inferrule{E-Switch}{
+  \easvs{e_{pred}}{\targ}{\tmem}{i}{\sigma'} \andalso
+  \easvs{e_i}{\targ}{\sigma'}{v}{\sigma''}}
+{\easvsd
+  {\bop{Switch}{e_{pred}}{(e_1, \dots, e_n)}}{\targ}{\tmem}
+  {v}{\tmem''}}
+
+\inferrule{E-Let}{
+  \easvs{e_{in}}{\targ}{\tmem}{v_{in}}{\tmem'} \andalso
+  \easvs{e_{out}}{v_{in}}{\tmem'}{v_{out}}{\tmem''}}
+{\easvsd
+  {\bop{Let}{e_{in}}{e_{out}}}{\targ}{\tmem}
+  {v_{out}}{\tmem''}}
+
+\inferrule{E-Print}{
+  \easvs{e}{\targ}{\tmem}{v}{(M,L)}}
+{\easvsd
+  {\uop{Print}{e}}{\targ}{\tmem}
+  {[]}{(M,\append{L}{v})}}
+
+\inferrule{E-Read}{
+  \easvs{e}{\targ}{\tmem}{v}{(M,L)}}
+{\easvsd
+  {\uop{Read}{e}}{\targ}{\tmem}
+  {M[v]}{(M,L)}}
+
+\inferrule{E-Alloc}{
+  \easvs{e}{\targ}{\tmem}{n}{(M,L)} \andalso
+  (M', p) = \operatorname{malloc}(M, n * \operatorname{sizeof}(\tau))}
+{\easvsd
+  {\bop{Alloc}{e}{\tau}}{\targ}{\tmem}
+  {p}{(M',L)}}
+
+\inferrule{E-Write}{
+  \easvs{e_p}{\targ}{\tmem}{v_p}{\tmem'} \andalso
+  \easvs{e_d}{\targ}{\tmem'}{v_d}{(M,L)}}
+{\easvsd
+  {\bop{Write}{e_p}{e_d}}{\targ}{\tmem}
+  {[]}{(M[v_p \mapsto v_d], L)}}
+
+\inferrule{E-Single}{
+  \easvs{e}{\targ}{\tmem}{v}{\tmem'}}
+{\easvsd
+  {\uop{Single}{e}}{\targ}{\tmem}
+  {[v]}{\tmem'}}
+
+\inferrule{E-ConcatSeq}{
+  \easvs{e_1}{\targ}{\tmem}{v_1}{\tmem'} \andalso
+  \easvs{e_2}{\targ}{\tmem'}{v_2}{\tmem''}}
+{\easvsd
+  {\bop{Concat\ Sequential}{e_1}{e_2}}{\targ}{\tmem}
+  {\append{v_1}{v_2}}{\tmem''}}
+
+\inferrule{E-DoWhileFalse}{
+  \easvs{e_{in}}{\targ}{\tmem}{\targ'}{\tmem'} \andalso
+  \easvs{e_{po}}{\targ'}{\tmem'}{[\bot,v]}{\tmem''}}
+{\easvsd
+  {\bop{DoWhile}{e_{in}}{e_{out}}}{\targ}{\tmem}
+  {v}{\tmem''}}
+
+\inferrule{E-DoWhileTrue}{
+  \easvs{e_{in}}{\targ}{\tmem}{\targ'}{\tmem'} \andalso
+  \easvs{e_{po}}{\targ'}{\tmem'}{[\top,\targ'']}{\tmem''} \andalso
+  \easvs{\bop{DoWhile}{e_{in}}{e_{po}}}{\targ''}{\tmem''}{v}{\tmem'''}}
+{\easvsd
+  {\bop{DoWhile}{e_{in}}{e_{po}}}{\targ}{\tmem}
+  {v}{\tmem'''}}
+
+\inferrule{E-ContextInLet}{
+  \easvs{e}{\targ}{\tmem}{v}{\tmem'} \andalso
+  \exists\ \targ_2, \tmem_2, \tmem_3 .\;
+    \easvs{e_{in}}{\targ_2}{\tmem_2}{\targ}{\tmem_3}}
+{\easvsd
+  {\bop{Context}{(\uop{InLet}{e_{in}})}{e}}{\targ}{\tmem}
+  {v}{\tmem'}}
+
+\inferrule{E-ContextAfterWrite}{
+  \easvs{e}{\targ}{\tmem}{v}{\tmem'} \andalso
+  \exists\ \targ_2, v_2, \tmem_2 .\;
+    \easvs{\bop{Write}{e_p}{e_d}}{\targ_2}{\tmem_2}{v_2}{\tmem}}
+{\easvsd
+  {\bop{Context}{(\bop{AfterWrite}{e_p}{e_d})}{e}}{\targ}{\tmem}
+  {v}{\tmem'}}
+
+\inferrule{E-ContextInLoop}{
+  \easvs{e}{\targ}{\tmem}{v}{\tmem'} \andalso
+  \exists\ \tmem_2 .\;
+  (\targ, \tmem_2) \in \operatorname{loop\_reachable}(e_{in}, e_{out})}
+{\easvsd
+  {\bop{Context}{(\bop{InLoop}{e_{in}}{e_{po}})}{e}}{\targ}{\tmem}
+  {v}{\tmem'}}
+
+\newpage
+\subsection*{Abstract grammar}
+%% \begin{figure}%{\linewidth}
+  \begin{minipage}[t]{0.45\linewidth}
+    \begin{grammar}
+      <basetype> ::= IntT \alt BoolT
+
+      <type> ::= <basetype> \alt PointerT <type> \alt TupleT <basetype>*
+
+      <bool> ::= $\top$ \alt $\bot$
+
+      <order> ::= Parallel \alt Sequential
+
+      <function> ::= Function <type> <expr>
+
+      <assumption> ::= InLet <expr>
+      \alt InLoop <expr> <expr>
+      %% \alt InFunc <function>
+      %% \alt InSwitch <\N> <expr>
+      %% \alt InIf <bool> <expr>
+      \alt AfterWrite <expr> <expr>
+    \end{grammar}
+  \end{minipage}\hfill%
+  \begin{minipage}[t]{0.5\linewidth}
+    \begin{grammar}
+      <expr> ::= Arg <type>
+      \alt Int <\N>
+      \alt Bool <bool>
+      \alt Empty
+      \alt Add <expr> <expr>
+      \alt Sub <expr> <expr>
+      \alt Mul <expr> <expr>
+      \alt LessThan <expr> <expr>
+      \alt And <expr> <expr>
+      \alt Or <expr> <expr>
+      \alt Write <expr> <expr>
+      %% \alt PtrAdd <expr> <expr>
+      \alt Not <expr>
+      \alt Print <expr>
+      \alt Read <expr>
+      \alt Get <expr> <\N>
+      \alt Alloc <expr> <type>
+      \alt Call <function> <expr>
+      \alt Single <expr>
+      \alt Concat <order> <expr> <expr>
+      \alt Switch <expr> <expr>*
+      \alt If <expr> <expr> <expr>
+      \alt Let <expr> <expr>
+      \alt DoWhile <expr> <expr>
+      \alt Context <assumption> <expr>
+    \end{grammar}%
+    \end{minipage}%
+%%   \caption{expr abstract syntax.}
+%% \end{figure}
+


### PR DESCRIPTION
Adds big-step operational and denotational semantics, including restrictions on InContext nodes.

Pulls in contents from https://github.com/rtjoa/tree-assume-semantics at commit `ee09569`.