### PR TITLE
Implement Tree -> RVSDG Translation

### DIFF
--- a/infra/profile.sh
+++ b/infra/profile.sh
@@ -11,7 +11,7 @@ trap cleanup EXIT
 # TODO: take in file glob as command line argument
 PROFILES=(tests/*.bril tests/small/*.bril tests/brils/passing/**/*.bril)
 
-RUNMODES=("nothing" "rvsdg-round-trip")
+RUNMODES=("nothing" "rvsdg-round-trip" "optimize")
 
 # create temporary directory structure necessary for bench runs
 mkdir -p ./tmp/bench

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ struct Args {
     /// Configure the output of the tool, which can be an optimized bril program,
     /// an optimized CFG, or more.
     /// See documentation for [`RunType`] for different options.
-    #[clap(long, default_value_t = RunType::Nothing)]
+    #[clap(long, default_value_t = RunType::Optimize)]
     run_mode: RunType,
     /// Evaluate the resulting program and output
     /// the result.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ struct Args {
     /// the result.
     #[clap(long)]
     interp: bool,
-
     #[clap(long)]
     profile_out: Option<PathBuf>,
 

--- a/src/rvsdg/from_tree.rs
+++ b/src/rvsdg/from_tree.rs
@@ -1,7 +1,9 @@
 //! Convert tree programs to RVSDGs
 
-use bril_rs::{ConstOps, Literal};
-use tree_in_context::schema::{BaseType, Expr, RcExpr, TreeProgram, Type};
+use std::iter;
+
+use bril_rs::{ConstOps, EffectOps, Literal, ValueOps};
+use tree_in_context::schema::{BaseType, BinaryOp, Expr, RcExpr, TreeProgram, Type, UnaryOp};
 
 use super::{BasicExpr, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram, RvsdgType};
 
@@ -9,6 +11,7 @@ type Operands = Vec<Operand>;
 
 struct TreeToRvsdg {
     nodes: Vec<RvsdgBody>,
+    current_state_edge: Operand,
 }
 
 pub(crate) fn tree_to_rvsdg(tree: TreeProgram) -> RvsdgProgram {
@@ -35,46 +38,113 @@ fn bril_type_from_type(ty: Type) -> bril_rs::Type {
     }
 }
 
-fn rvsdg_types_from_tuple_type(ty: Type) -> Vec<RvsdgType> {
-    let Type::TupleT(tys) = ty else {
-        panic!("Expected tuple type in tree_type_to_rvsdg_types")
-    };
-    tys.into_iter()
-        .map(|ty| RvsdgType::Bril(bril_type_from_type(ty)))
-        .collect()
-}
-
 fn tree_func_to_rvsdg(func: RcExpr) -> RvsdgFunction {
-    let types = func.func_output_ty().expect("Expected function types");
+    let Type::TupleT(output_types) = func.func_output_ty().expect("Expected function types") else {
+        panic!("Expected tuple type in tree_func_to_rvsdg")
+    };
 
-    let mut converter = TreeToRvsdg { nodes: vec![] };
+    let Type::TupleT(input_types) = func.func_input_ty().expect("Expected function types") else {
+        panic!("Expected tuple type for inputs in tree_func_to_rvsdg")
+    };
+
+    // initial state edge is last argument
+    let state_edge = Operand::Arg(output_types.len());
+    let mut converter = TreeToRvsdg {
+        nodes: vec![],
+        current_state_edge: state_edge,
+    };
+
+    let output_rvsdg_types: Vec<RvsdgType> = output_types
+        .into_iter()
+        .map(|ty| RvsdgType::Bril(bril_type_from_type(ty)))
+        .chain(iter::once(RvsdgType::PrintState))
+        .collect();
 
     let converted = converter.convert_func(func.clone());
+
+    assert_eq!(
+        converted.len(),
+        output_rvsdg_types.len(),
+        "Expected same number of results as output types"
+    );
 
     RvsdgFunction {
         name: func
             .func_name()
             .expect("Expected function in tree_func_to_rvsdg"),
-        args: rvsdg_types_from_tuple_type(types),
+        // normal types and a state edge at the end
+        args: input_types
+            .into_iter()
+            .map(|ty| RvsdgType::Bril(bril_type_from_type(ty)))
+            .chain(iter::once(RvsdgType::PrintState))
+            .collect(),
         nodes: converter.nodes,
-        results: converted,
+        results: output_rvsdg_types.into_iter().zip(converted).collect(),
+    }
+}
+
+fn value_op_from_binary_op(bop: BinaryOp) -> Option<ValueOps> {
+    match bop {
+        BinaryOp::Add => Some(ValueOps::Add),
+        BinaryOp::Sub => Some(ValueOps::Sub),
+        BinaryOp::Mul => Some(ValueOps::Mul),
+        BinaryOp::Div => Some(ValueOps::Div),
+        BinaryOp::And => Some(ValueOps::And),
+        BinaryOp::Or => Some(ValueOps::Or),
+        BinaryOp::Eq => Some(ValueOps::Eq),
+        BinaryOp::LessThan => Some(ValueOps::Lt),
+        BinaryOp::GreaterThan => Some(ValueOps::Gt),
+        BinaryOp::Write => None,
+        BinaryOp::PtrAdd => Some(ValueOps::PtrAdd),
+    }
+}
+
+fn effect_op_from_binary_op(bop: BinaryOp) -> Option<EffectOps> {
+    match bop {
+        BinaryOp::Write => Some(EffectOps::Store),
+        _ => None,
+    }
+}
+
+fn value_op_from_unary_op(uop: UnaryOp) -> Option<ValueOps> {
+    match uop {
+        UnaryOp::Not => Some(ValueOps::Not),
+        UnaryOp::Print => None,
+        UnaryOp::Load => Some(ValueOps::Load),
+    }
+}
+
+fn effect_op_from_unary_op(uop: UnaryOp) -> Option<EffectOps> {
+    match uop {
+        UnaryOp::Not => None,
+        UnaryOp::Print => Some(EffectOps::Print),
+        UnaryOp::Load => None,
     }
 }
 
 impl TreeToRvsdg {
-    pub fn convert_func(&mut self, func: RcExpr) -> Vec<(RvsdgType, Operand)> {
+    pub fn convert_func(&mut self, func: RcExpr) -> Vec<Operand> {
         todo!()
     }
 
     fn push_basic(&mut self, basic: BasicExpr<Operand>) -> Vec<Operand> {
-        let new_id = self.nodes.len();
-        self.nodes.push(RvsdgBody::BasicOp(basic));
-        vec![Operand::Project(0, new_id)]
+        if let BasicExpr::Effect(effect, mut operands) = basic {
+            let new_id = self.nodes.len();
+            operands.push(self.current_state_edge.clone());
+            self.nodes
+                .push(RvsdgBody::BasicOp(BasicExpr::Effect(effect, operands)));
+            self.current_state_edge = Operand::Project(1, new_id);
+            vec![Operand::Project(0, new_id)]
+        } else {
+            let new_id = self.nodes.len();
+            self.nodes.push(RvsdgBody::BasicOp(basic));
+            vec![Operand::Project(0, new_id)]
+        }
     }
 
     fn convert_expr(&mut self, expr: RcExpr) -> Operands {
         match expr.as_ref() {
-            Expr::Const(constant) => match constant {
+            Expr::Const(constant, ty) => match constant {
                 tree_in_context::schema::Constant::Int(integer) => self.push_basic(
                     BasicExpr::Const(ConstOps::Const, Literal::Int(*integer), bril_rs::Type::Int),
                 ),
@@ -91,7 +161,48 @@ impl TreeToRvsdg {
                 let r = self.convert_expr(r.clone());
                 let l = l[0].clone();
                 let r = r[0].clone();
-                self.push_basic(BasicExpr::Op(*op, vec![l, r], bril_rs::Type::Int))
+                if let Some(vop) = value_op_from_binary_op(*op) {
+                    self.push_basic(BasicExpr::Op(vop, vec![l, r], bril_rs::Type::Int))
+                } else if let Some(eop) = effect_op_from_binary_op(*op) {
+                    self.push_basic(BasicExpr::Effect(eop, vec![l, r]))
+                } else {
+                    panic!("Unknown binary op {:?}", op)
+                }
+            }
+            Expr::Uop(op, child) => {
+                let child = self.convert_expr(child.clone());
+                let child = child[0].clone();
+                if let Some(vop) = value_op_from_unary_op(*op) {
+                    self.push_basic(BasicExpr::Op(vop, vec![child], bril_rs::Type::Int))
+                } else if let Some(eop) = effect_op_from_unary_op(*op) {
+                    self.push_basic(BasicExpr::Effect(eop, vec![child]))
+                } else {
+                    panic!("Unknown unary op {:?}", op)
+                }
+            }
+            Expr::Get(child, index) => {
+                let child = self.convert_expr(child.clone());
+                assert!(child.len() > *index, "Index out of bounds");
+                vec![child[*index].clone()]
+            }
+            Expr::Alloc(size, ty) => {
+                let size = self.convert_expr(size.clone());
+                let size = size[0].clone();
+                self.push_basic(BasicExpr::Op(
+                    ValueOps::Alloc,
+                    vec![size],
+                    bril_type_from_type(ty.clone()),
+                ))
+            }
+            Expr::Arg(ty) => {
+                let Type::TupleT(tys) = ty.clone() else {
+                    panic!("Expected tuple type in tree_type_to_rvsdg_types")
+                };
+                // One operand for each argument
+                tys.iter()
+                    .enumerate()
+                    .map(|(i, _ty)| Operand::Arg(i))
+                    .collect()
             }
         }
     }

--- a/src/rvsdg/from_tree.rs
+++ b/src/rvsdg/from_tree.rs
@@ -13,17 +13,18 @@ type Operands = Vec<Operand>;
 
 struct TreeToRvsdg<'a> {
     program: &'a TreeProgram,
-    nodes: Vec<RvsdgBody>,
+    nodes: &'a mut Vec<RvsdgBody>,
     current_state_edge: Operand,
     current_args: Vec<Operand>,
 }
 
 pub(crate) fn tree_to_rvsdg(tree: &TreeProgram) -> RvsdgProgram {
     let mut res = RvsdgProgram { functions: vec![] };
-    for func in tree.functions {
-        res.functions.push(tree_func_to_rvsdg(func, tree));
+    for func in &tree.functions {
+        res.functions.push(tree_func_to_rvsdg(func.clone(), tree));
     }
-    res.functions.push(tree_func_to_rvsdg(tree.entry, tree));
+    res.functions
+        .push(tree_func_to_rvsdg(tree.entry.clone(), tree));
     res
 }
 
@@ -63,16 +64,19 @@ fn tree_func_to_rvsdg(func: RcExpr, program: &TreeProgram) -> RvsdgFunction {
         panic!("Expected tuple type for inputs in tree_func_to_rvsdg")
     };
 
+    let mut nodes = vec![];
     // initial state edge is last argument
     let mut converter = TreeToRvsdg {
         program,
-        nodes: vec![],
+        nodes: &mut nodes,
         current_state_edge: Operand::Arg(input_types.len()),
         current_args: (0..input_types.len()).map(|i| Operand::Arg(i)).collect(),
     };
 
     let converted = converter.convert_func(func.clone());
 
+    let resulting_state_edge = converter.current_state_edge.clone();
+    drop(converter);
     RvsdgFunction {
         name: func
             .func_name()
@@ -83,18 +87,18 @@ fn tree_func_to_rvsdg(func: RcExpr, program: &TreeProgram) -> RvsdgFunction {
             .map(|ty| RvsdgType::Bril(bril_type_from_type(ty)))
             .chain(iter::once(RvsdgType::PrintState))
             .collect(),
-        nodes: converter.nodes,
+        nodes,
         results: match func_type_from_type(output_type) {
             Some(func_type) => {
                 assert!(converted.len() == 1, "Expected exactly one result");
                 vec![
                     (RvsdgType::Bril(func_type), converted[0].clone()),
-                    (RvsdgType::PrintState, converter.current_state_edge),
+                    (RvsdgType::PrintState, resulting_state_edge),
                 ]
             }
             None => {
                 assert!(converted.len() == 0, "Expected no results");
-                vec![(RvsdgType::PrintState, converter.current_state_edge)]
+                vec![(RvsdgType::PrintState, resulting_state_edge)]
             }
         },
     }
@@ -166,7 +170,7 @@ impl<'a> TreeToRvsdg<'a> {
     fn convert_expr(&mut self, expr: RcExpr) -> Operands {
         match expr.as_ref() {
             Expr::Function(..) => panic!("Expected non-function expr in convert_expr"),
-            Expr::Const(constant, ty) => match constant {
+            Expr::Const(constant, _ty) => match constant {
                 tree_in_context::schema::Constant::Int(integer) => self.push_basic(
                     BasicExpr::Const(ConstOps::Const, Literal::Int(*integer), bril_rs::Type::Int),
                 ),
@@ -183,9 +187,9 @@ impl<'a> TreeToRvsdg<'a> {
                 let r = self.convert_expr(r.clone());
                 let l = l[0].clone();
                 let r = r[0].clone();
-                if let Some(vop) = value_op_from_binary_op(*op) {
+                if let Some(vop) = value_op_from_binary_op(op.clone()) {
                     self.push_basic(BasicExpr::Op(vop, vec![l, r], bril_rs::Type::Int))
-                } else if let Some(eop) = effect_op_from_binary_op(*op) {
+                } else if let Some(eop) = effect_op_from_binary_op(op.clone()) {
                     self.push_basic(BasicExpr::Effect(eop, vec![l, r]))
                 } else {
                     panic!("Unknown binary op {:?}", op)
@@ -194,9 +198,9 @@ impl<'a> TreeToRvsdg<'a> {
             Expr::Uop(op, child) => {
                 let child = self.convert_expr(child.clone());
                 let child = child[0].clone();
-                if let Some(vop) = value_op_from_unary_op(*op) {
+                if let Some(vop) = value_op_from_unary_op(op.clone()) {
                     self.push_basic(BasicExpr::Op(vop, vec![child], bril_rs::Type::Int))
-                } else if let Some(eop) = effect_op_from_unary_op(*op) {
+                } else if let Some(eop) = effect_op_from_unary_op(op.clone()) {
                     self.push_basic(BasicExpr::Effect(eop, vec![child]))
                 } else {
                     panic!("Unknown unary op {:?}", op)
@@ -216,7 +220,7 @@ impl<'a> TreeToRvsdg<'a> {
                     bril_type_from_type(ty.clone()),
                 ))
             }
-            Expr::Arg(ty) => self.current_args,
+            Expr::Arg(_ty) => self.current_args.clone(),
             Expr::Call(name, args) => {
                 let func = self.program.get_function(name).expect("Function not found");
                 let func_ty =
@@ -247,7 +251,55 @@ impl<'a> TreeToRvsdg<'a> {
                 }
             },
             Expr::If(pred, then_branch, else_branch) => {
-                todo!()
+                let pred = self.convert_expr(pred.clone());
+                let args_and_state_edge = self
+                    .current_args
+                    .iter()
+                    .cloned()
+                    .chain(iter::once(self.current_state_edge))
+                    .collect();
+
+                let inner_args: Vec<Operand> = self
+                    .current_args
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| Operand::Arg(i))
+                    .collect();
+                let mut then_translator = TreeToRvsdg {
+                    program: self.program,
+                    nodes: self.nodes,
+                    current_state_edge: Operand::Arg(self.current_args.len()),
+                    current_args: inner_args.clone(),
+                };
+                let mut then_branch = then_translator.convert_expr(then_branch.clone());
+                then_branch.push(then_translator.current_state_edge.clone());
+
+                let mut else_translator = TreeToRvsdg {
+                    program: self.program,
+                    nodes: self.nodes,
+                    current_state_edge: Operand::Arg(self.current_args.len()),
+                    current_args: inner_args,
+                };
+                let mut else_branch = else_translator.convert_expr(else_branch.clone());
+                else_branch.push(else_translator.current_state_edge.clone());
+
+                let new_id = self.nodes.len();
+                assert_eq!(
+                    then_branch.len(),
+                    else_branch.len(),
+                    "Expected same number of values for then and else branches"
+                );
+                self.nodes.push(RvsdgBody::If {
+                    pred: pred[0].clone(),
+                    inputs: args_and_state_edge,
+                    then_branch,
+                    else_branch,
+                });
+
+                self.current_state_edge = Operand::Project(then_branch.len() - 1, new_id);
+                (0..(then_branch.len() - 1))
+                    .map(|i| Operand::Project(i, new_id))
+                    .collect()
             }
             Expr::Switch(pred, cases) => {
                 todo!()

--- a/src/rvsdg/from_tree.rs
+++ b/src/rvsdg/from_tree.rs
@@ -331,19 +331,19 @@ impl<'a> TreeToRvsdg<'a> {
                     "Expected same number of values for then and else branches"
                 );
 
-                self.current_state_edge = Operand::Project(then_branch.len() - 1, new_id);
-                let res = (0..(then_branch.len() - 1))
+                let res: Vec<Operand> = (0..(then_branch.len() - 1))
                     .map(|i| Operand::Project(i, new_id))
                     .collect();
                 self.nodes.push(RvsdgBody::If {
                     pred: pred[0],
-                    // inputs to the If node are just the
+                    // inputs to the If node are the
                     // current arguments, since in the tree IR
-                    // if doesn't bind anything
+                    // If doesn't bind anything
                     inputs: self.args_with_state_edge(),
                     then_branch,
                     else_branch,
                 });
+                self.current_state_edge = Operand::Project(res.len(), new_id);
 
                 res
             }
@@ -359,17 +359,17 @@ impl<'a> TreeToRvsdg<'a> {
                     "Expected at least one case for switch statement"
                 );
                 let new_id = self.nodes.len();
-                let res = (0..outputs[0].len())
+                let res: Vec<Operand> = (0..outputs[0].len())
                     .map(|i| Operand::Project(i, new_id))
                     .collect();
 
-                self.current_state_edge = Operand::Project(outputs[0].len() - 1, new_id);
                 self.nodes.push(RvsdgBody::Gamma {
                     pred: pred[0],
-                    // inputs to the Gamma node are just the
+                    // inputs to the Gamma node are the current arguments and state edge
                     inputs: self.args_with_state_edge(),
                     outputs,
                 });
+                self.current_state_edge = Operand::Project(res.len(), new_id);
                 res
             }
             Expr::DoWhile(inputs, body) => {

--- a/src/rvsdg/from_tree.rs
+++ b/src/rvsdg/from_tree.rs
@@ -187,6 +187,9 @@ impl<'a> TreeToRvsdg<'a> {
         results
     }
 
+    /// Creates a new node for a basic expression.
+    /// For nodes that require and return a state edge, adds the state edge
+    /// to the inputs remembers the newly returned state edge.
     fn push_basic(&mut self, mut basic: BasicExpr<Operand>) -> Vec<Operand> {
         match &basic {
             BasicExpr::Effect(..)

--- a/src/rvsdg/from_tree.rs
+++ b/src/rvsdg/from_tree.rs
@@ -1,0 +1,55 @@
+//! Convert tree programs to RVSDGs
+
+use tree_in_context::schema::{BaseType, RcExpr, TreeProgram, Type};
+
+use super::{RvsdgBody, RvsdgFunction, RvsdgProgram, RvsdgType};
+
+struct TreeToRvsdg {
+    nodes: Vec<RvsdgBody>,
+}
+
+pub(crate) fn tree_to_rvsdg(tree: TreeProgram) -> RvsdgProgram {
+    let mut res = RvsdgProgram { functions: vec![] };
+    for func in tree.functions {
+        res.functions.push(tree_func_to_rvsdg(func));
+    }
+    res.functions.push(tree_func_to_rvsdg(tree.entry));
+    res
+}
+
+fn bril_type_from_type(ty: Type) -> bril_rs::Type {
+    match ty {
+        Type::Base(base_ty) => match base_ty {
+            BaseType::IntT => bril_rs::Type::Int,
+            BaseType::BoolT => bril_rs::Type::Bool,
+        },
+        Type::PointerT(ty) => {
+            let base_ty = bril_type_from_type(Type::Base(ty));
+            bril_rs::Type::Pointer(Box::new(base_ty))
+        }
+        Type::TupleT(_) => panic!("Tuple types not supported in RVSDG"),
+        Type::Unknown => panic!("Unknown type in tree_type_to_rvsdg_types"),
+    }
+}
+
+fn rvsdg_types_from_tuple_type(ty: Type) -> Vec<RvsdgType> {
+    let Type::TupleT(tys) = ty else {
+        panic!("Expected tuple type in tree_type_to_rvsdg_types")
+    };
+    tys.into_iter()
+        .map(|ty| RvsdgType::Bril(bril_type_from_type(ty)))
+        .collect()
+}
+
+fn tree_func_to_rvsdg(func: RcExpr) -> RvsdgFunction {
+    let types = func.func_output_ty().expect("Expected function types");
+
+    let mut res = RvsdgFunction {
+        name: func
+            .func_name()
+            .expect("Expected function in tree_func_to_rvsdg"),
+        args: todo!(),
+        nodes: todo!(),
+        results: todo!(),
+    };
+}

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -29,6 +29,7 @@
 //! In addition to those papers, the Jamey Sharp's
 //! [optir](https://github.com/jameysharp/optir) project is a major inspiration.
 pub(crate) mod from_cfg;
+pub(crate) mod from_tree;
 pub(crate) mod live_variables;
 pub(crate) mod optimize_direct_jumps;
 pub(crate) mod restructure;

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -120,6 +120,15 @@ impl<Op> BasicExpr<Op> {
             BasicExpr::Effect(_, _) => 1,
         }
     }
+
+    pub(crate) fn push_operand(&mut self, op: Op) {
+        match self {
+            BasicExpr::Op(_, operands, _) => operands.push(op),
+            BasicExpr::Call(_, operands, _, _) => operands.push(op),
+            BasicExpr::Const(_, _, _) => panic!("Cannot push operand to const"),
+            BasicExpr::Effect(_, operands) => operands.push(op),
+        }
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]

--- a/src/rvsdg/to_cfg.rs
+++ b/src/rvsdg/to_cfg.rs
@@ -220,10 +220,18 @@ impl<'a> RvsdgToCfg<'a> {
                 },
             );
         }
-        TranslationResult {
-            start: results[0].start,
-            end: results.last().unwrap().end,
-            values: results[results.len() - 1].values.clone(),
+        if results.is_empty() {
+            TranslationResult {
+                start: self.make_block(vec![]),
+                end: self.make_block(vec![]),
+                values: vec![],
+            }
+        } else {
+            TranslationResult {
+                start: results[0].start,
+                end: results.last().unwrap().end,
+                values: results[results.len() - 1].values.clone(),
+            }
         }
     }
 
@@ -250,6 +258,7 @@ impl<'a> RvsdgToCfg<'a> {
         current_args: &Vec<RvsdgValue>,
         context: &RvsdgContext,
     ) -> TranslationResult {
+        eprintln!("translating operand {:?}", operand);
         if let Some(existing) = self.operand_cache.get(&(context.clone(), operand)).cloned() {
             // make an empty block
             let new_block = self.make_block(vec![]);
@@ -279,6 +288,7 @@ impl<'a> RvsdgToCfg<'a> {
             }
             Operand::Project(arg, id) => {
                 let res = self.body_to_bril(id, current_args, context);
+                eprintln!("projecting {:?}", res);
                 TranslationResult {
                     start: res.start,
                     end: res.end,

--- a/src/rvsdg/to_cfg.rs
+++ b/src/rvsdg/to_cfg.rs
@@ -258,7 +258,6 @@ impl<'a> RvsdgToCfg<'a> {
         current_args: &Vec<RvsdgValue>,
         context: &RvsdgContext,
     ) -> TranslationResult {
-        eprintln!("translating operand {:?}", operand);
         if let Some(existing) = self.operand_cache.get(&(context.clone(), operand)).cloned() {
             // make an empty block
             let new_block = self.make_block(vec![]);
@@ -288,7 +287,6 @@ impl<'a> RvsdgToCfg<'a> {
             }
             Operand::Project(arg, id) => {
                 let res = self.body_to_bril(id, current_args, context);
-                eprintln!("projecting {:?}", res);
                 TranslationResult {
                     start: res.start,
                     end: res.end,

--- a/src/util.rs
+++ b/src/util.rs
@@ -313,6 +313,7 @@ impl Run {
             RunType::TreeConversion,
             RunType::TreeOptimize,
             RunType::TreeRoundTrip,
+            RunType::TreeOptimize,
         ] {
             if prog.has_mem && !test_type.supports_memory() {
                 continue;

--- a/src/util.rs
+++ b/src/util.rs
@@ -165,6 +165,8 @@ pub enum RunType {
     /// Convert to RVSDG and back to Bril again,
     /// outputting the bril program.
     RvsdgRoundTrip,
+    /// Convert to tree encoding and back to RVSDG again.
+    TreeToRvsdg,
     /// Convert to Tree Encoding and back to Bril again,
     /// outputting the bril program.
     TreeRoundTrip,
@@ -196,6 +198,7 @@ impl RunType {
             RunType::Optimize => true,
             RunType::RvsdgConversion => false,
             RunType::RvsdgRoundTrip => true,
+            RunType::TreeToRvsdg => false,
             RunType::OptimizedRvsdg => false,
             RunType::TreeRoundTrip => true,
             RunType::ToCfg => true,
@@ -219,7 +222,8 @@ impl RunType {
             | RunType::TreeConversion
             | RunType::TreeConversionVerboseLets
             | RunType::OptimizedRvsdg
-            | RunType::Optimize => false,
+            | RunType::Optimize
+            | RunType::TreeToRvsdg => false,
             RunType::TreeOptimize | RunType::Egglog | RunType::TreeRoundTrip => false,
         }
     }
@@ -394,6 +398,19 @@ impl Run {
                         name: "".to_string(),
                     }],
                     Some(Interpretable::Bril(bril)),
+                )
+            }
+            RunType::TreeToRvsdg => {
+                let rvsdg = Optimizer::program_to_rvsdg(&self.prog_with_args.program)?;
+                let tree = rvsdg.to_tree_encoding(true);
+                let rvsdg2 = tree_to_rvsdg(&tree);
+                (
+                    vec![Visualization {
+                        result: rvsdg2.to_svg(),
+                        file_extension: ".svg".to_string(),
+                        name: "".to_string(),
+                    }],
+                    None,
                 )
             }
             RunType::Optimize => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -372,7 +372,7 @@ impl Run {
             RunType::TreeRoundTrip => {
                 let rvsdg = Optimizer::program_to_rvsdg(&self.prog_with_args.program)?;
                 let tree = rvsdg.to_tree_encoding(true);
-                let rvsdg2 = tree_to_rvsdg(tree);
+                let rvsdg2 = tree_to_rvsdg(&tree);
                 let cfg = rvsdg2.to_cfg();
                 let bril = cfg.to_bril();
                 (

--- a/tree_in_context/src/schema_helpers.rs
+++ b/tree_in_context/src/schema_helpers.rs
@@ -396,7 +396,7 @@ impl Constructor {
 
 impl BinaryOp {
     /// When a binary op has concrete input sorts, return them.
-    pub(crate) fn types(&self) -> Option<(Type, Type, Type)> {
+    pub fn types(&self) -> Option<(Type, Type, Type)> {
         match self {
             BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
                 Some((intt(), intt(), intt()))


### PR DESCRIPTION
This PR implements the last missing piece in the translation code, converting the Tree IR to an RVSDG.
It also runs all the tests (excluding ones involving memory) on the full compiler.