### PR TITLE
Rust context creation

### DIFF
--- a/tree_in_context/src/add_context.rs
+++ b/tree_in_context/src/add_context.rs
@@ -1,3 +1,7 @@
+//! Adds context to the tree program.
+//! The `add_context` method recursively adds context to all of the nodes in the tree program
+//! by remembering the most recent context (ex. Let or If).
+
 use crate::{
     ast::{in_context, infunc},
     schema::{Assumption, Expr, RcExpr, TreeProgram},
@@ -64,7 +68,7 @@ impl Expr {
                 let new_case_num = case_num.add_context(current_ctx.clone());
                 let new_branches = branches
                     .iter()
-                    .map(|b| b.clone().add_context(current_ctx.clone()))
+                    .map(|b| b.add_context(current_ctx.clone()))
                     .collect();
                 RcExpr::new(Expr::Switch(new_case_num, new_branches))
             }
@@ -86,8 +90,9 @@ impl Expr {
                 x.add_context(current_ctx.clone()),
                 y.add_context(current_ctx),
             )),
-            // overwrite old context with new, more specific one
-            Expr::InContext(_old_assumption, child) => child.add_context(current_ctx),
+            Expr::InContext(..) => {
+                panic!("add_context expects a term without context")
+            }
             Expr::Function(..) => panic!("Function should have been handled in func_add_context"),
         }
     }

--- a/tree_in_context/src/add_context.rs
+++ b/tree_in_context/src/add_context.rs
@@ -1,0 +1,14 @@
+impl TreeProgram {
+    pub fn add_context(&self) -> TreeProgram {
+        TreeProgram {
+            functions: self.functions.iter().map(|f| f.add_context()).collect(),
+            entry: self.entry.add_context(),
+        }
+    }
+}
+
+impl RcExpr {
+  pub(crate) fn func_add_context(&self) -> RcExpr {
+    
+  }
+}

--- a/tree_in_context/src/add_context.rs
+++ b/tree_in_context/src/add_context.rs
@@ -1,14 +1,94 @@
+use crate::{
+    ast::{in_context, infunc},
+    schema::{Assumption, Expr, RcExpr, TreeProgram},
+};
+
 impl TreeProgram {
     pub fn add_context(&self) -> TreeProgram {
         TreeProgram {
-            functions: self.functions.iter().map(|f| f.add_context()).collect(),
-            entry: self.entry.add_context(),
+            functions: self
+                .functions
+                .iter()
+                .map(|f| f.clone().func_add_context())
+                .collect(),
+            entry: self.entry.clone().func_add_context(),
         }
     }
 }
 
-impl RcExpr {
-  pub(crate) fn func_add_context(&self) -> RcExpr {
-    
-  }
+impl Expr {
+    pub(crate) fn func_add_context(self: RcExpr) -> RcExpr {
+        let Expr::Function(name, arg_ty, ret_ty, body) = &self.as_ref() else {
+            panic!("Expected Function, got {:?}", self);
+        };
+        let current_ctx = infunc(name);
+        RcExpr::new(Expr::Function(
+            name.clone(),
+            arg_ty.clone(),
+            ret_ty.clone(),
+            body.add_context(current_ctx),
+        ))
+    }
+
+    fn add_context(self: &RcExpr, current_ctx: Assumption) -> RcExpr {
+        match self.as_ref() {
+            // leaf nodes are constant, empty, and arg
+            Expr::Const(..) | Expr::Empty(..) | Expr::Arg(..) => {
+                in_context(current_ctx, self.clone())
+            }
+            // create new contexts for let, loop, and if
+            Expr::DoWhile(inputs, pred_and_body) => {
+                let new_inputs = inputs.add_context(current_ctx.clone());
+                let new_ctx = Assumption::InLoop(new_inputs.clone(), pred_and_body.clone());
+                RcExpr::new(Expr::DoWhile(
+                    new_inputs,
+                    pred_and_body.add_context(new_ctx),
+                ))
+            }
+            Expr::Let(inputs, body) => {
+                let new_inputs = inputs.add_context(current_ctx.clone());
+                let new_ctx = Assumption::InLet(new_inputs.clone());
+                RcExpr::new(Expr::Let(new_inputs, body.add_context(new_ctx)))
+            }
+            Expr::If(pred, then_case, else_calse) => {
+                let new_pred = pred.add_context(current_ctx.clone());
+                let then_ctx = Assumption::InIf(true, new_pred.clone());
+                let else_ctx = Assumption::InIf(false, new_pred.clone());
+                RcExpr::new(Expr::If(
+                    new_pred,
+                    then_case.add_context(then_ctx),
+                    else_calse.add_context(else_ctx),
+                ))
+            }
+            Expr::Switch(case_num, branches) => {
+                let new_case_num = case_num.add_context(current_ctx.clone());
+                let new_branches = branches
+                    .iter()
+                    .map(|b| b.clone().add_context(current_ctx.clone()))
+                    .collect();
+                RcExpr::new(Expr::Switch(new_case_num, new_branches))
+            }
+            // for all other nodes, just add the context to the children
+            Expr::Bop(op, x, y) => RcExpr::new(Expr::Bop(
+                op.clone(),
+                x.add_context(current_ctx.clone()),
+                y.add_context(current_ctx),
+            )),
+            Expr::Uop(op, x) => RcExpr::new(Expr::Uop(op.clone(), x.add_context(current_ctx))),
+            Expr::Get(e, i) => RcExpr::new(Expr::Get(e.add_context(current_ctx), *i)),
+            Expr::Alloc(e, ty) => RcExpr::new(Expr::Alloc(e.add_context(current_ctx), ty.clone())),
+            Expr::Call(f, arg) => {
+                RcExpr::new(Expr::Call(f.clone(), arg.add_context(current_ctx.clone())))
+            }
+            Expr::Single(e) => RcExpr::new(Expr::Single(e.add_context(current_ctx))),
+            Expr::Concat(order, x, y) => RcExpr::new(Expr::Concat(
+                order.clone(),
+                x.add_context(current_ctx.clone()),
+                y.add_context(current_ctx),
+            )),
+            // overwrite old context with new, more specific one
+            Expr::InContext(_old_assumption, child) => child.add_context(current_ctx),
+            Expr::Function(..) => panic!("Function should have been handled in func_add_context"),
+        }
+    }
 }

--- a/tree_in_context/src/lib.rs
+++ b/tree_in_context/src/lib.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+
+use egglog::{Term, TermDag};
 use from_egglog::FromEgglog;
 use interpreter::Value;
 use schema::{RcExpr, TreeProgram};
@@ -15,6 +18,7 @@ pub(crate) mod type_analysis;
 pub mod typechecker;
 pub(crate) mod utility;
 use main_error::MainError;
+pub(crate) mod add_context;
 
 pub type Result = std::result::Result<(), MainError>;
 
@@ -37,11 +41,54 @@ pub fn prologue() -> String {
     .join("\n")
 }
 
+// Returns a variable representing the
+fn print_with_intermediate_helper(
+    termdag: &TermDag,
+    term: Term,
+    cache: &mut HashMap<Term, String>,
+    res: &mut String,
+) -> String {
+    if let Some(var) = cache.get(&term) {
+        return var.clone();
+    }
+
+    let (converted, fresh_var) = match &term {
+        Term::Lit(_) => return termdag.to_string(&term),
+        Term::Var(_) => return termdag.to_string(&term),
+        Term::App(head, children) => {
+            let child_vars = children
+                .iter()
+                .map(|child| {
+                    print_with_intermediate_helper(termdag, termdag.get(*child), cache, res)
+                })
+                .collect::<Vec<String>>()
+                .join(" ");
+            let fresh_var = format!("__tmp{}", cache.len());
+            (
+                format!("(let {fresh_var} ({head} {child_vars}))"),
+                fresh_var,
+            )
+        }
+    };
+    cache.insert(term, fresh_var.clone());
+    res.push_str(&converted);
+    fresh_var
+}
+
+fn print_with_intermediate_vars(termdag: &TermDag, term: Term) -> String {
+    let mut printed = String::new();
+    let mut cache = HashMap::<Term, String>::new();
+    let res = print_with_intermediate_helper(termdag, term, &mut cache, &mut printed);
+    printed.push_str(&format!("(let PROG {res})\n"));
+    printed
+}
+
 pub fn build_program(program: &TreeProgram) -> String {
+    let (term, termdag) = program.to_egglog();
+    let printed = print_with_intermediate_vars(&termdag, term);
     format!(
-        "{}\n(let PROG {})\n{}\n",
+        "{}\n{printed}\n{}\n",
         prologue(),
-        program.pretty(),
         include_str!("schedule.egg"),
     )
 }

--- a/tree_in_context/src/schema_helpers.rs
+++ b/tree_in_context/src/schema_helpers.rs
@@ -25,7 +25,8 @@ impl Display for Type {
 
 impl Display for Expr {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        let (term, termdag) = self.to_egglog();
+        let rcexpr = RcExpr::new(self.clone());
+        let (term, termdag) = rcexpr.to_egglog();
         write!(f, "{}", termdag.to_string(&term))
     }
 }

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -38,7 +38,6 @@
          (Concat order (InContext assum e1) (InContext assum e2))
          :ruleset context_propagate)
 
-;                       assumptions, predicate, cases,   current case
 (function SwitchInContext (InContextList   Expr       ListExpr i64) ListExpr :unextractable) 
 
 (rewrite (InContext assum (If pred then else))

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -38,6 +38,7 @@
          (Concat order (InContext assum e1) (InContext assum e2))
          :ruleset context_propagate)
 
+;                       assumptions, predicate, cases,   current case
 (function SwitchInContext (InContextList   Expr       ListExpr i64) ListExpr :unextractable) 
 
 (rewrite (InContext assum (If pred then else))


### PR DESCRIPTION
This PR adds a rust function that adds context to the original program added to the egraph. This allows the first version of the program to have full contextual information.
We can then use egglog rules to create contexts we need later.

This also makes the generated egglog file much smaller by sharing common sub-expressions.