### PR TITLE
Context rules with fine-grained control of how deep to copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "egglog"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=7b41bb07e5e065928d653cb340a9a0dea0259466#7b41bb07e5e065928d653cb340a9a0dea0259466"
+source = "git+https://github.com/egraphs-good/egglog?rev=77ffa1f#77ffa1f7599b5e2d8936a5b78fa89bfa563bf2bc"
 dependencies = [
  "clap",
  "egraph-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "files"
 
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "7b41bb07e5e065928d653cb340a9a0dea0259466" }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "77ffa1f" }
 egraph-serialize = "0.1.0"
 log = "0.4.19"
 thiserror = "1"

--- a/tree_in_context/Cargo.toml
+++ b/tree_in_context/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "7b41bb07e5e065928d653cb340a9a0dea0259466" }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "77ffa1f" }
 strum = "0.25"
 strum_macros = "0.25"
 main_error = "0.1.2"

--- a/tree_in_context/src/schedule.egg
+++ b/tree_in_context/src/schedule.egg
@@ -1,10 +1,6 @@
 (run-schedule
-  (saturate
-   (saturate always-run)
-   context_creation
-   (saturate context_propagate))
   (repeat 6
-    (saturate ;; saturate all rulesets that we run to saturation
+    (saturate ;; saturate rulesets that we run to saturation
       (saturate always-run)
       (saturate error-checking)
       (saturate
@@ -12,7 +8,10 @@
         type-analysis
       )
       (saturate subst) ;; subst depends on type information for the argument
-      (saturate constant_fold))
+      (saturate constant_fold)
+      (saturate
+        (saturate context-helpers)
+        context))
     conditional-invariant-code-motion
     switch_rewrite
     loop-simplify))

--- a/tree_in_context/src/schema.egg
+++ b/tree_in_context/src/schema.egg
@@ -183,9 +183,9 @@
   (InLoop Expr     Expr)
   ; name of the function
   (InFunc String)
-  ; Branch of the switch and the predicate
+  ; Branch of the switch and what the predicate is
   (InSwitch i64 Expr)
-  ; If the predicate was true, and the predicate
+  ; If the predicate was true, and what the predicate is
   (InIf bool Expr)
   ; Other assumptions are possible, but not supported yet.
   ; For example:

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -17,6 +17,16 @@
   (PathNil)
   (PathCons Expr Expr ContextPath))
 
+
+;; For every path P in the database,
+;; we add a (Path-contains P S)
+;; for every subpath S with the same endpoint.
+;; We also include the empty path.
+;; Ex: for path P = (PathCons a (PathCons b (PathCons c (PathNil))))
+;; we have (Path-contains P P),
+;; (Path-contains P (PathCons b (PathCons c (PathNil)))),
+;; (Path-contains P (PathCons c (PathNil))),
+;; and (Path-contains P (PathNil)).
 (relation Path-contains (ContextPath ContextPath))
 
 (rule ((= lhs (PathCons hd1 hd2 tl)))
@@ -213,7 +223,4 @@
          (DoWhile new-inputs
            (DoAddContext newpath (InLoop new-inputs outputs) scope outputs))))
        :ruleset context)
-
-
-
 

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -23,7 +23,8 @@
       ((Path-contains lhs lhs))
       :ruleset context-helpers)
 (rule ((Path-contains top (PathCons hd1 hd2 tl)))
-      ((Path-contains top tl)) :ruleset context-helpers)
+      ((Path-contains top tl))
+      :ruleset context-helpers)
 
 
 (datatype ContextDepth
@@ -33,6 +34,10 @@
   (StopAtLoop)
   ;; Don't make any new contextx for loops or lets (still make new ones for if statements)
   (StopAtLoopOrLet))
+;; we need to add these to the database so we can match on them
+(Full)
+(StopAtLoop)
+(StopAtLoopOrLet)
 
 (function AddFuncContext (Expr) Expr :unextractable)
 (function AddContext (Assumption ContextDepth Expr) Expr :unextractable)
@@ -44,11 +49,10 @@
 
 ;; desugar add func context
 (rule ((= lhs (AddFuncContext (Function name inty outty body))))
-      ((union lhs
+      ((union (Function name inty outty body)
          (Function name inty outty
            (AddContext (InFunc name) (Full) body))))
        :ruleset context-helpers)
-
 
 
 ;; AddContext is sugar for DoAddContext
@@ -108,7 +112,8 @@
          :ruleset context)
 
 (rewrite (DoAddContext seen ctx scope (Empty ty))
-         (InContext ctx (Empty ty)))
+         (InContext ctx (Empty ty))
+         :ruleset context)
 
 
 ;; ######################################### Operators

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -1,146 +1,108 @@
-; This file propogates in_context nodes top-down from functions.
-; It gives each program path a unique equality relation.
-; This can be quite expensive, so be careful running these rules.
-
-(ruleset context_propagate)
-(ruleset context_creation)
-
-(sort InContextList)
-
-; Here's a helpful rule that chooses a more specific context over
-; an inner, less specific one.
-(rewrite (InContext assumption (InContext assumption2 rest))
-         (InContext assumption rest)
-         :ruleset context_propagate)
-
-; ################### operations
-(rewrite (InContext asum (Bop op c1 c2))
-         (Bop op (InContext asum c1) (InContext asum c2))
-         :ruleset context_propagate)
-(rewrite (InContext assum (Uop op c1))
-         (Uop op (InContext assum c1))
-         :ruleset context_propagate)
-(rewrite (InContext assum (Get expr index))
-         (Get (InContext assum expr) index)
-         :ruleset context_propagate)
-(rewrite (InContext assum (Alloc expr ty))
-         (Alloc (InContext assum expr) ty)
-         :ruleset context_propagate)
-(rewrite (InContext assum (Call name expr))
-         (Call name (InContext assum expr))
-         :ruleset context_propagate)
-
-; ################### tuple operations
-(rewrite (InContext assum (Single expr))
-         (Single (InContext assum expr))
-         :ruleset context_propagate)
-(rewrite (InContext assum (Concat order e1 e2))
-         (Concat order (InContext assum e1) (InContext assum e2))
-         :ruleset context_propagate)
-
-;                       assumptions, predicate, cases,   current case
-(function SwitchInContext (InContextList   Expr       ListExpr i64) ListExpr :unextractable) 
-
-(rewrite (InContext assum (If pred then else))
-         (If (InContext assum pred)
-             (InContext
-               (InIf true (InContext assum pred)) then)
-             (InContext
-               (InIf false (InContext assum pred)) else))
-         :ruleset context_propagate)
+; This file provides AddContext, a helpers that copies a sub-egraph into
+; a new one with context.
+; Users of AddContext can specify how deeply to do this copy.
 
 
-
-; ###########################  Context creation
-
-(relation ContextLess (Expr))
-(relation ContextLessList (ListExpr))
+(ruleset context)
+(ruleset context-helpers)
 
 
-;; check that term has no context to ensure saturation
+;; ################################ datatypes
+;; A context path is a list of (eclass, eclass) pairs.
+;; In substitution, the path is used to store every context-related eclass we have visited, 
+;; and the corresponding expression at that point.
+;; When we visit an eclass for the second time, we have found a cycle in the egraph.
+;; Then the corresponding eclasses are made equivalent.
+(datatype ContextPath
+  (PathNil)
+  (PathCons Expr Expr ContextPath))
+
+(relation Path-contains (ContextPath ContextPath))
+
+(rule ((= lhs (PathCons hd1 hd2 tl)))
+      ((Path-contains lhs lhs))
+      :ruleset context-helpers)
+(rule ((Path-contains top (PathCons hd1 hd2 tl)))
+      ((Path-contains top tl)) :ruleset context-helpers)
+
+
+(datatype ContextDepth
+  ;; Keep making new contexts for the entire reachable egraph
+  (Full)
+  ;; Don't make new contexts for sub-loops
+  (StopAtLoop)
+  ;; Don't make any new contextx for loops or lets (still make new ones for if statements)
+  (StopAtLoopOrLet))
+
+(function AddFuncContext (Expr) Expr :unextractable)
+(function AddContext (Assumption ContextDepth Expr) Expr :unextractable)
+(function DoAddContext (ContextPath Assumption ContextDepth Expr) Expr :unextractable)
+
+;; ###################### sugar
+
+
+;; desugar add func context
+(rule ((= lhs (AddFuncContext (Function name inty outty body))))
+      ((union lhs
+         (Function name inty outty
+           (AddContext (InFunc name) (Full) body))))
+       :ruleset context-helpers)
+
+
+
+;; AddContext is sugar for DoAddContext
+(rewrite (AddContext ctx depth expr)
+         (DoAddContext (PathNil) ctx depth expr)
+         :ruleset context-helpers)
+
+
+;; ################################ saturation
+
+;; Adding context a second time does nothing, so union
 (rule
- ((= lhs (Function name in_ty out_ty out))
-  (ContextLess out))
- ((union lhs
-   (Function name in_ty out_ty
-      (InContext (InFunc  name)
-               out))))
- :ruleset context_creation)
-
-(rule ((= lhs (InContext assum (Let inputs body)))
-       (ContextLess inputs)
-       (ContextLess body))
-      ((union lhs
-        (Let
-           (InContext assum inputs)
-           (InContext
-             (InLet (InContext assum inputs))
-             body))))
-          :ruleset context_creation)
+  ((= lhs (DoAddContext seen ctx (Full) inner))
+   (= inner (DoAddContext seen ctx (Full) expr)))
+  ((union lhs inner))
+  :ruleset context-helpers)
 
 
-(rule ((= lhs (InContext assum (DoWhile inputs pred_outputs)))
-       (ContextLess inputs)
-       (ContextLess pred_outputs))
-      ((union lhs
-         (DoWhile
-           (InContext assum inputs)
-           (InContext
-             (InLoop (InContext assum inputs) pred_outputs)
-              pred_outputs))))
-        :ruleset context_creation)
+;; Adding context may not saturate for loops.
+;; This is because a loop (DoWhile inputs outputs)
+;; can become equal to
+;; (DoWhile inputs ctx1)
+;; where ctx1 = (InContext (InLoop inputs outputs) outputs)
+;; Which we can add context to again:
+;; (DoWhile inputs (InContext (InLoop inputs ctx1) ctx1))
+;; These two contexts are equal, since the set of reachable
+;; values is the same.
+(rule ((= body_with_context (InContext (InLoop inputs outputs) body)) ;; a loop body with context
+       (InContext (InLoop inputs body_with_context) body_with_context) ;; a loop body whose context already has context
+       )
+      ((union (InLoop inputs outputs) (InLoop inputs old_body)))
+      :ruleset context-helpers)
+
+;; key rule that detects cycles
+;; It finds that we have already seen the eclass we are adding context to.
+;; The corresponding eclasses are unioned, and the cyclic
+;; substitution is subsumed to ensure saturation.
+(rule ((= lhs (DoAddContext seen ctx scope in))
+       (Path-contains seen
+         (PathCons in original ctx)))
+      ((union lhs original)
+       (subsume (DoAddContext seen ctx scope in) in))
+      :ruleset context-helpers)
 
 
 
 
-(rule ((Arg ty)) ((ContextLess (Arg ty))) :ruleset context_propagate)
-(rule ((Const c ty)) ((ContextLess (Const c ty))) :ruleset context_propagate)
-(rule ((Empty ty)) ((ContextLess (Empty ty))) :ruleset context_propagate)
-(rule ((Bop op a b)
-       (ContextLess a)
-        (ContextLess b))
-      ((ContextLess (Bop op a b))) :ruleset context_propagate)
-(rule ((Uop op a)
-       (ContextLess a))
-      ((ContextLess (Uop op a))) :ruleset context_propagate)
-(rule ((Get a i)
-       (ContextLess a))
-      ((ContextLess (Get a i))) :ruleset context_propagate)
-(rule ((Alloc a ty)
-       (ContextLess a))
-      ((ContextLess (Alloc a ty))) :ruleset context_propagate)
-(rule ((Call name a)
-       (ContextLess a))
-      ((ContextLess (Call name a))) :ruleset context_propagate)
-(rule ((Single a)
-       (ContextLess a))
-      ((ContextLess (Single a))) :ruleset context_propagate)
-(rule ((Concat order a b)
-       (ContextLess a)
-       (ContextLess b))
-      ((ContextLess (Concat order a b))) :ruleset context_propagate)
-(rule ((If pred then else)
-       (ContextLess pred)
-       (ContextLess then)
-       (ContextLess else))
-      ((ContextLess (If pred then else))) :ruleset context_propagate)
-(rule ((Switch pred cases)
-       (ContextLess pred)
-       (ContextLessList cases))
-      ((ContextLess (Switch pred cases))) :ruleset context_propagate)
-(rule ((Let inputs body)
-       (ContextLess inputs)
-       (ContextLess body))
-      ((ContextLess (Let inputs body))) :ruleset context_propagate)
-(rule ((DoWhile inputs pred_outputs)
-       (ContextLess inputs)
-       (ContextLess pred_outputs))
-      ((ContextLess (DoWhile inputs pred_outputs))) :ruleset context_propagate)
-(rule ((Nil)) ((ContextLessList (Nil))) :ruleset context_propagate)
-(rule ((Cons a b)
-       (ContextLess a)
-       (ContextLessList b))
-      ((ContextLessList (Cons a b))) :ruleset context_propagate)
-(rule ((Function name in_ty out_ty out)
-       (ContextLess out))
-      ((ContextLess (Function name in_ty out_ty out))) :ruleset context_propagate)
+;; ############################## Base cases- leaf nodes
+
+(rewrite (AddContext seen ctx scope (Arg ty))
+         (InContext ctx (Arg ty))
+         :ruleset context)
+
+
+
+
+
+

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -89,7 +89,7 @@
 ;; substitution is subsumed to ensure saturation.
 (rule ((= lhs (DoAddContext seen ctx scope in))
        (Path-contains seen
-         (PathCons in original ctx)))
+         (PathCons in original rest)))
       ((union lhs original)
        (subsume (DoAddContext seen ctx scope in)))
       :ruleset context-helpers)
@@ -103,12 +103,12 @@
          (InContext ctx (Arg ty))
          :ruleset context)
 
-(rewrite (DoAddContext seen ctx scope (Const constant))
-         (InContext ctx (Const constant))
+(rewrite (DoAddContext seen ctx scope (Const constant ty))
+         (InContext ctx (Const constant ty))
          :ruleset context)
 
-(rewrite (DoAddContext seen ctx scope (Empty))
-         (InContext ctx (Empty)))
+(rewrite (DoAddContext seen ctx scope (Empty ty))
+         (InContext ctx (Empty ty)))
 
 
 ;; ######################################### Operators
@@ -122,20 +122,20 @@
 (rewrite (DoAddContext seen ctx scope (Uop op c1))
          (Uop op (DoAddContext seen ctx scope c1))
          :ruleset context)
-(rewrite (DoAddContext seen ctx scope to (Get c1 index))
+(rewrite (DoAddContext seen ctx scope (Get c1 index))
          (Get (DoAddContext seen ctx scope c1) index)
                :ruleset context)
-(rewrite (DoAddContext seen ctx scope to (Alloc c1 ty))
+(rewrite (DoAddContext seen ctx scope (Alloc c1 ty))
          (Alloc (DoAddContext seen ctx scope c1) ty)
          :ruleset context)
-(rewrite (DoAddContext seen ctx scope to (Call name c1))
+(rewrite (DoAddContext seen ctx scope (Call name c1))
          (Call name (DoAddContext seen ctx scope c1))
          :ruleset context)
 
-(rewrite (DoAddContext seen ctx scope to (Single c1))
+(rewrite (DoAddContext seen ctx scope (Single c1))
          (Single (DoAddContext seen ctx scope c1))
          :ruleset context)
-(rewrite (DoAddContext seen ctx scope to (Concat order c1 c2))
+(rewrite (DoAddContext seen ctx scope (Concat order c1 c2))
          (Concat order
            (DoAddContext seen ctx scope c1)
            (DoAddContext seen ctx scope c2))
@@ -161,21 +161,21 @@
 
 
 ;; ########################################## Control flow
-(rewrite (DoAddContext seen ctx scope to (Switch pred branches))
+(rewrite (DoAddContext seen ctx scope (Switch pred branches))
          (Switch (DoAddContext seen ctx scope pred)
                  (DoAddContextList seen ctx scope branches))
          :ruleset context)
 
 
 (rule ((= lhs (DoAddContext seen ctx scope (If pred c1 c2))))
-      ((let new-inputs
+      ((let newpred
          (DoAddContext seen ctx scope pred))
        (let newpath
          (PathCons (If pred c1 c2) lhs seen))
        (union lhs
          (If newpred
-           (DoAddContext newpath (InIf true newpred) scope to c1)
-           (DoAddContext newpath (InIf false newpred) scope to c2))))
+           (DoAddContext newpath (InIf true newpred) scope c1)
+           (DoAddContext newpath (InIf false newpred) scope c2))))
        :ruleset context)
 
 

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -39,6 +39,7 @@
 (StopAtLoop)
 (StopAtLoopOrLet)
 
+;; AddFuncContext is a helper for tests, it adds full context to everything in a function.
 (function AddFuncContext (Expr) Expr :unextractable)
 (function AddContext (Assumption ContextDepth Expr) Expr :unextractable)
 (function DoAddContext (ContextPath Assumption ContextDepth Expr) Expr :unextractable)
@@ -63,6 +64,12 @@
 
 ;; ################################ saturation
 
+;; Outer context nodes are more specific by our semantics
+(rewrite (InContext ctx-outer (InContext ctx-inner expr))
+         (InContext ctx-outer expr)
+         :ruleset context-helpers)
+
+
 ;; Adding context a second time does nothing, so union
 (rule
   ((= lhs (DoAddContext seen ctx (Full) inner))
@@ -80,11 +87,12 @@
 ;; (DoWhile inputs (InContext (InLoop inputs ctx1) ctx1))
 ;; These two contexts are equal, since the set of reachable
 ;; values is the same.
-(rule ((= body_with_context (InContext (InLoop inputs outputs) outputs)) ;; a loop body with context
-       (InContext (InLoop inputs body_with_context) ;; same inputs
-                  body_with_context) ;; a loop body whose context already has context
+(rule ((= body_with_context
+          (DoAddContext seen  (InLoop inputs outputs) (Full) outputs)) ;; a loop body with context
+       (DoAddContext    seen2 (InLoop inputs body_with_context) ;; same inputs
+                    (Full) body_with_context) ;; a loop body whose context already has context
        )
-      ((union (InLoop inputs outputs) (InLoop inputs outputs)))
+      ((union (InLoop inputs outputs) (InLoop inputs body_with_context)))
       :ruleset context-helpers)
 
 ;; key rule that detects cycles
@@ -105,15 +113,15 @@
 
 (rewrite (DoAddContext seen ctx scope (Arg ty))
          (InContext ctx (Arg ty))
-         :ruleset context)
+         :ruleset context-helpers)
 
 (rewrite (DoAddContext seen ctx scope (Const constant ty))
          (InContext ctx (Const constant ty))
-         :ruleset context)
+         :ruleset context-helpers)
 
 (rewrite (DoAddContext seen ctx scope (Empty ty))
          (InContext ctx (Empty ty))
-         :ruleset context)
+         :ruleset context-helpers)
 
 
 ;; ######################################### Operators
@@ -123,35 +131,35 @@
          (Bop op
            (DoAddContext seen ctx scope c1)
            (DoAddContext seen ctx scope c2))
-               :ruleset context)
+               :ruleset context-helpers)
 (rewrite (DoAddContext seen ctx scope (Uop op c1))
          (Uop op (DoAddContext seen ctx scope c1))
-         :ruleset context)
+         :ruleset context-helpers)
 (rewrite (DoAddContext seen ctx scope (Get c1 index))
          (Get (DoAddContext seen ctx scope c1) index)
-               :ruleset context)
+               :ruleset context-helpers)
 (rewrite (DoAddContext seen ctx scope (Alloc c1 ty))
          (Alloc (DoAddContext seen ctx scope c1) ty)
-         :ruleset context)
+         :ruleset context-helpers)
 (rewrite (DoAddContext seen ctx scope (Call name c1))
          (Call name (DoAddContext seen ctx scope c1))
-         :ruleset context)
+         :ruleset context-helpers)
 
 (rewrite (DoAddContext seen ctx scope (Single c1))
          (Single (DoAddContext seen ctx scope c1))
-         :ruleset context)
+         :ruleset context-helpers)
 (rewrite (DoAddContext seen ctx scope (Concat order c1 c2))
          (Concat order
            (DoAddContext seen ctx scope c1)
            (DoAddContext seen ctx scope c2))
-         :ruleset context)
+         :ruleset context-helpers)
 
 ;; Replace existing contexts.
 ;; This relies on the fact that new contexts must be more specific than old ones.
 ;; This is a part of the semantics of InContext.
 (rewrite (DoAddContext seen ctx scope (InContext ctx2 expr))
          (DoAddContext seen ctx scope expr)
-         :ruleset context)
+         :ruleset context-helpers)
 
 ;; ################################### List operators
 
@@ -169,7 +177,7 @@
 (rewrite (DoAddContext seen ctx scope (Switch pred branches))
          (Switch (DoAddContext seen ctx scope pred)
                  (DoAddContextList seen ctx scope branches))
-         :ruleset context)
+         :ruleset context-helpers)
 
 
 (rule ((= lhs (DoAddContext seen ctx scope (If pred c1 c2))))

--- a/tree_in_context/src/utility/in_context.egg
+++ b/tree_in_context/src/utility/in_context.egg
@@ -37,6 +37,7 @@
 (function AddFuncContext (Expr) Expr :unextractable)
 (function AddContext (Assumption ContextDepth Expr) Expr :unextractable)
 (function DoAddContext (ContextPath Assumption ContextDepth Expr) Expr :unextractable)
+(function DoAddContextList (ContextPath Assumption ContextDepth ListExpr) ListExpr :unextractable)
 
 ;; ###################### sugar
 
@@ -75,10 +76,11 @@
 ;; (DoWhile inputs (InContext (InLoop inputs ctx1) ctx1))
 ;; These two contexts are equal, since the set of reachable
 ;; values is the same.
-(rule ((= body_with_context (InContext (InLoop inputs outputs) body)) ;; a loop body with context
-       (InContext (InLoop inputs body_with_context) body_with_context) ;; a loop body whose context already has context
+(rule ((= body_with_context (InContext (InLoop inputs outputs) outputs)) ;; a loop body with context
+       (InContext (InLoop inputs body_with_context) ;; same inputs
+                  body_with_context) ;; a loop body whose context already has context
        )
-      ((union (InLoop inputs outputs) (InLoop inputs old_body)))
+      ((union (InLoop inputs outputs) (InLoop inputs outputs)))
       :ruleset context-helpers)
 
 ;; key rule that detects cycles
@@ -89,7 +91,7 @@
        (Path-contains seen
          (PathCons in original ctx)))
       ((union lhs original)
-       (subsume (DoAddContext seen ctx scope in) in))
+       (subsume (DoAddContext seen ctx scope in)))
       :ruleset context-helpers)
 
 
@@ -97,11 +99,107 @@
 
 ;; ############################## Base cases- leaf nodes
 
-(rewrite (AddContext seen ctx scope (Arg ty))
+(rewrite (DoAddContext seen ctx scope (Arg ty))
          (InContext ctx (Arg ty))
          :ruleset context)
 
+(rewrite (DoAddContext seen ctx scope (Const constant))
+         (InContext ctx (Const constant))
+         :ruleset context)
 
+(rewrite (DoAddContext seen ctx scope (Empty))
+         (InContext ctx (Empty)))
+
+
+;; ######################################### Operators
+
+
+(rewrite (DoAddContext seen ctx scope (Bop op c1 c2))
+         (Bop op
+           (DoAddContext seen ctx scope c1)
+           (DoAddContext seen ctx scope c2))
+               :ruleset context)
+(rewrite (DoAddContext seen ctx scope (Uop op c1))
+         (Uop op (DoAddContext seen ctx scope c1))
+         :ruleset context)
+(rewrite (DoAddContext seen ctx scope to (Get c1 index))
+         (Get (DoAddContext seen ctx scope c1) index)
+               :ruleset context)
+(rewrite (DoAddContext seen ctx scope to (Alloc c1 ty))
+         (Alloc (DoAddContext seen ctx scope c1) ty)
+         :ruleset context)
+(rewrite (DoAddContext seen ctx scope to (Call name c1))
+         (Call name (DoAddContext seen ctx scope c1))
+         :ruleset context)
+
+(rewrite (DoAddContext seen ctx scope to (Single c1))
+         (Single (DoAddContext seen ctx scope c1))
+         :ruleset context)
+(rewrite (DoAddContext seen ctx scope to (Concat order c1 c2))
+         (Concat order
+           (DoAddContext seen ctx scope c1)
+           (DoAddContext seen ctx scope c2))
+         :ruleset context)
+
+;; Replace existing contexts.
+;; This relies on the fact that new contexts must be more specific than old ones.
+;; This is a part of the semantics of InContext.
+(rewrite (DoAddContext seen ctx scope (InContext ctx2 expr))
+         (DoAddContext seen ctx scope expr)
+         :ruleset context)
+
+;; ################################### List operators
+
+(rewrite (DoAddContextList seen ctx scope (Nil))
+         (Nil)
+         :ruleset context-helpers)
+
+(rewrite (DoAddContextList seen ctx scope (Cons c1 rest))
+         (Cons (DoAddContext seen ctx scope c1)
+               (DoAddContextList seen ctx scope rest))
+               :ruleset context-helpers)
+
+
+;; ########################################## Control flow
+(rewrite (DoAddContext seen ctx scope to (Switch pred branches))
+         (Switch (DoAddContext seen ctx scope pred)
+                 (DoAddContextList seen ctx scope branches))
+         :ruleset context)
+
+
+(rule ((= lhs (DoAddContext seen ctx scope (If pred c1 c2))))
+      ((let new-inputs
+         (DoAddContext seen ctx scope pred))
+       (let newpath
+         (PathCons (If pred c1 c2) lhs seen))
+       (union lhs
+         (If newpred
+           (DoAddContext newpath (InIf true newpred) scope to c1)
+           (DoAddContext newpath (InIf false newpred) scope to c2))))
+       :ruleset context)
+
+
+(rule ((= lhs (DoAddContext seen ctx scope (Let in out)))
+       (!= scope (StopAtLoopOrLet)))
+      ((let new-inputs
+         (DoAddContext seen ctx scope in))
+       (let newpath
+          (PathCons (Let in out) lhs seen))
+       (union lhs
+         (Let new-inputs
+           (DoAddContext newpath (InLet new-inputs) scope out))))
+       :ruleset context)
+
+(rule ((= lhs (DoAddContext seen ctx scope (DoWhile inputs outputs)))
+       (= scope (Full)))
+      ((let new-inputs
+         (DoAddContext seen ctx scope inputs))
+       (let newpath
+         (PathCons (DoWhile inputs outputs) lhs seen))
+       (union lhs
+         (DoWhile new-inputs
+           (DoAddContext newpath (InLoop new-inputs outputs) scope outputs))))
+       :ruleset context)
 
 
 

--- a/tree_in_context/src/utility/in_context.rs
+++ b/tree_in_context/src/utility/in_context.rs
@@ -85,21 +85,23 @@ fn test_if_contexts() -> crate::Result {
 }
 
 #[test]
-fn test_simple_subst_cycle() -> crate::Result {
+fn test_simple_context_cycle() -> crate::Result {
     use crate::ast::*;
     let expr = dowhile(single(arg()), parallel!(tfalse(), int(3)))
         .with_arg_types(base(intt()), tuplet!(intt()));
-    let inner = single(int(3));
+    let inner = single(int(3)).with_arg_types(tuplet!(intt()), tuplet!(intt()));
 
     egglog_test(
         &format!(
             "
 (union {expr} {inner})
-(Subst (InFunc \"main\") (FuncScope) (Arg (FuncScope) (Base (IntT))) {expr})",
+(AddContext (InFunc \"main\") (Full) {expr})
+",
         ),
         &format!(
             "
-(check (= {expr} {inner}))"
+(check (= {expr} {inner}))
+"
         ),
         vec![expr.to_program(base(intt()), tuplet!(intt()))],
         Value::Const(Constant::Int(3)),
@@ -109,54 +111,24 @@ fn test_simple_subst_cycle() -> crate::Result {
 }
 
 #[test]
-fn test_let_cycle() -> crate::Result {
-    use crate::ast::*;
-    let tuple_looparg = arg_ty(tuplet!(intt()));
-    let mylet = tlet(int(3), tuple_looparg.clone());
-
-    let new_value = parallel!(int(3));
-    let target = tlet(
-        in_context(infunc("main"), int(3)),
-        parallel!(in_context(infunc("main"), int(3))),
-    );
-    let target2 = parallel!(in_context(infunc("main"), int(3)));
-
-    egglog_test(
-        &format!(
-            "
-(union {mylet} {tuple_looparg})
-(let mysubst (Subst (InFunc \"main\") (LoopScope) {new_value} {mylet}))
-(let mysubst2 (Subst (InFunc \"main\") (LoopScope) {new_value} mysubst))
-",
-        ),
-        &format!(
-            "
-(check (= mysubst {target}))
-(check (= mysubst {target2}))
-(check (= mysubst mysubst2))",
-        ),
-        vec![],
-        Value::Tuple(vec![Value::Const(Constant::Int(3))]),
-        Value::Tuple(vec![Value::Const(Constant::Int(3))]),
-        vec![],
-    )
-}
-
-#[test]
-fn test_dowhile_cycle_in_context() -> crate::Result {
+fn test_harder_context_cycle() -> crate::Result {
     use crate::ast::*;
     // loop runs one iteration and returns 3
     let myloop = dowhile(arg(), parallel!(tfalse(), int(3)))
         .with_arg_types(tuplet!(intt()), tuplet!(intt()));
     let expr =
         function("main", tuplet!(intt()), tuplet!(intt()), myloop.clone()).func_with_arg_types();
-    let int3func = function("main", tuplet!(intt()), tuplet!(intt()), single(int(3)));
+    let int3func =
+        function("main", tuplet!(intt()), tuplet!(intt()), single(int(3))).func_with_arg_types();
 
     let fargincontext = in_context(
         infunc("main"),
         arg().with_arg_types(tuplet!(intt()), tuplet!(intt())),
     );
-    let inner_in_context = inloop(fargincontext.clone(), parallel!(tfalse(), int(3)));
+    let inner_in_context = inloop(
+        fargincontext.clone(),
+        parallel!(tfalse(), int(3)).with_arg_types(tuplet!(intt()), tuplet!(boolt(), intt())),
+    );
     let expr2 = function(
         "main",
         tuplet!(intt()),
@@ -218,99 +190,6 @@ fn simple_context() -> crate::Result {
         ],
         Value::Tuple(vec![]),
         Value::Const(Constant::Int(2)),
-        vec![],
-    )
-}
-
-#[test]
-fn test_subst_nested() -> crate::Result {
-    use crate::ast::*;
-    use crate::{interpreter::Value, schema::Constant};
-    let twoint = tuplet!(intt(), intt());
-    let expr = tlet(
-        parallel!(int(1), get(arg(), 1), tlet(int(2), get(arg(), 0))),
-        int(0),
-    )
-    .with_arg_types(twoint.clone(), base(intt()));
-    let replace_with = parallel!(int(3), int(4));
-    let replacement = in_context(infunc("main"), replace_with.clone());
-    let replacement_2 = get(
-        in_context(
-            inlet(in_context(infunc("main"), int(2))),
-            replace_with.clone(),
-        ),
-        0,
-    );
-    let new_inputs = parallel!(
-        in_context(infunc("main"), int(1)),
-        get(replacement.clone(), 1),
-        tlet(in_context(infunc("main"), int(2)), replacement_2)
-    );
-    let expected = tlet(
-        new_inputs.clone(),
-        in_context(inlet(new_inputs.clone()), int(0)),
-    )
-    .with_arg_types(twoint, base(intt()));
-
-    let build = format!(
-        "
-(let substituted (Subst (InFunc \"main\")
-                        (FuncScope)
-                        {replace_with}
-                        {expr}))"
-    );
-    let check = format!(
-        "
-(check (= substituted {expected}))",
-    );
-
-    crate::egglog_test(
-        &build.to_string(),
-        &check.to_string(),
-        vec![
-            expr.to_program(tuplet!(intt(), intt()), base(intt())),
-            expected.to_program(tuplet!(intt(), intt()), base(intt())),
-        ],
-        Value::Tuple(vec![
-            Value::Const(Constant::Int(10)),
-            Value::Const(Constant::Int(10)),
-        ]),
-        Value::Const(Constant::Int(0)),
-        vec![],
-    )
-}
-
-#[test]
-fn test_subst_makes_new_context() -> crate::Result {
-    use crate::ast::*;
-    use crate::{interpreter::Value, schema::Constant};
-    let expr = add(
-        in_context(infunc("otherfunc"), int_ty(1, base(intt()))),
-        in_context(infunc("otherfunc"), arg_ty(base(intt()))),
-    );
-    let replace_with = int(2);
-    let expected = add(
-        in_context(infunc("main"), int(1)),
-        in_context(infunc("main"), int(2)),
-    );
-    let build = format!(
-        "
-(let substituted (Subst (InFunc \"main\")
-                        (FuncScope) 
-                        {replace_with}
-                        {expr}))"
-    );
-    let check = format!("(check (= substituted {expected}))");
-
-    crate::egglog_test(
-        &build.to_string(),
-        &check.to_string(),
-        vec![
-            expr.to_program(base(intt()), base(intt())),
-            expected.to_program(base(intt()), base(intt())),
-        ],
-        Value::Const(Constant::Int(2)),
-        Value::Const(Constant::Int(3)),
         vec![],
     )
 }

--- a/tree_in_context/src/utility/in_context.rs
+++ b/tree_in_context/src/utility/in_context.rs
@@ -2,44 +2,20 @@
 use crate::{egglog_test, interpreter::Value, schema::Constant};
 
 #[test]
-fn test_in_context_in_func() -> crate::Result {
-    use crate::ast::*;
-    let expr = function("main", base(intt()), base(intt()), int(2)).func_with_arg_types();
-    let expected = function(
-        "main",
-        base(intt()),
-        base(intt()),
-        in_context(infunc("main"), int(2)),
-    )
-    .func_with_arg_types();
-    egglog_test(
-        &format!("{expr}"),
-        &format!("(check (= {expr} {expected}))"),
-        vec![
-            expr.to_program(emptyt(), base(intt())),
-            expected.to_program(emptyt(), base(intt())),
-        ],
-        Value::Tuple(vec![]),
-        Value::Const(Constant::Int(2)),
-        vec![],
-    )
-}
-
-#[test]
 fn test_in_context_two_lets() -> crate::Result {
     use crate::ast::*;
     let expr = function(
         "main",
         base(intt()),
         base(intt()),
-        tlet(int(1), tlet(add(iarg(), iarg()), mul(iarg(), int(2)))),
+        tlet(int(1), tlet(add(arg(), arg()), mul(arg(), int(2)))),
     )
     .func_with_arg_types();
-    let int1 = in_context(infunc("main"), int(1)).with_arg_types(base(intt()), base(intt()));
-    let arg1 = in_context(inlet(int1.clone()), iarg());
+    let int1 = in_context(infunc("main"), int_ty(1, base(intt())));
+    let arg1 = in_context(inlet(int1.clone()), arg_ty(base(intt())));
     let addarg1 = add(arg1.clone(), arg1.clone());
-    let int2 = in_context(inlet(addarg1.clone()), int_ty(2, base(intt())));
-    let arg2 = in_context(inlet(addarg1.clone()), iarg());
+    let int2 = in_context(inlet(addarg1.clone()), int(2));
+    let arg2 = in_context(inlet(addarg1.clone()), arg());
     let expr2 = function(
         "main",
         base(intt()),
@@ -55,7 +31,7 @@ fn test_in_context_two_lets() -> crate::Result {
     .func_with_arg_types();
 
     egglog_test(
-        &format!("{expr}"),
+        &format!("(AddFuncContext {expr})"),
         &format!("(check (= {expr} {expr2}))"),
         vec![
             expr.to_program(emptyt(), base(intt())),
@@ -68,16 +44,15 @@ fn test_in_context_two_lets() -> crate::Result {
 }
 
 #[test]
-fn test_switch_contexts() -> crate::Result {
+fn test_if_contexts() -> crate::Result {
     use crate::ast::*;
     let expr = function(
         "main",
         base(intt()),
         base(intt()),
         tif(ttrue(), int(1), int(2)),
-    )
-    .func_with_arg_types();
-    let pred = in_context(infunc("main"), ttrue_ty(base(intt())));
+    );
+    let pred = in_context(infunc("main"), ttrue());
     let expr2 = function(
         "main",
         base(intt()),
@@ -87,10 +62,9 @@ fn test_switch_contexts() -> crate::Result {
             in_context(inif(true, pred.clone()), int(1)),
             in_context(inif(false, pred.clone()), int(2)),
         ),
-    )
-    .func_with_arg_types();
+    );
     egglog_test(
-        &format!("{expr}"),
+        &format!("(AddFuncContext {expr})"),
         &format!("(check (= {expr} {expr2}))"),
         vec![
             expr.to_program(emptyt(), base(intt())),
@@ -103,29 +77,78 @@ fn test_switch_contexts() -> crate::Result {
 }
 
 #[test]
+fn test_simple_subst_cycle() -> crate::Result {
+    use crate::ast::*;
+    let expr = dowhile(single(arg()), parallel!(tfalse(), int(3)))
+        .with_arg_types(base(intt()), tuplet!(intt()));
+    let inner = single(int(3));
+
+    egglog_test(
+        &format!(
+            "
+(union {expr} {inner})
+(Subst (InFunc \"main\") (FuncScope) (Arg (FuncScope) (Base (IntT))) {expr})",
+        ),
+        &format!(
+            "
+(check (= {expr} {inner}))"
+        ),
+        vec![expr.to_program(base(intt()), tuplet!(intt()))],
+        Value::Const(Constant::Int(3)),
+        Value::Tuple(vec![Value::Const(Constant::Int(3))]),
+        vec![],
+    )
+}
+
+#[test]
+fn test_let_cycle() -> crate::Result {
+    use crate::ast::*;
+    let tuple_looparg = arg_ty(tuplet!(intt()));
+    let mylet = tlet(int(3), tuple_looparg.clone());
+
+    let new_value = parallel!(int(3));
+    let target = tlet(
+        in_context(infunc("main"), int(3)),
+        parallel!(in_context(infunc("main"), int(3))),
+    );
+    let target2 = parallel!(in_context(infunc("main"), int(3)));
+
+    egglog_test(
+        &format!(
+            "
+(union {mylet} {tuple_looparg})
+(let mysubst (Subst (InFunc \"main\") (LoopScope) {new_value} {mylet}))
+(let mysubst2 (Subst (InFunc \"main\") (LoopScope) {new_value} mysubst))
+",
+        ),
+        &format!(
+            "
+(check (= mysubst {target}))
+(check (= mysubst {target2}))
+(check (= mysubst mysubst2))",
+        ),
+        vec![],
+        Value::Tuple(vec![Value::Const(Constant::Int(3))]),
+        Value::Tuple(vec![Value::Const(Constant::Int(3))]),
+        vec![],
+    )
+}
+
+#[test]
 fn test_dowhile_cycle_in_context() -> crate::Result {
     use crate::ast::*;
     // loop runs one iteration and returns 3
-    let myloop = dowhile(arg(), parallel!(tfalse(), int(3)));
-    let expr = function("main", tuplet!(intt()), tuplet!(intt()), myloop).func_with_arg_types();
-    let int3func =
-        function("main", tuplet!(intt()), tuplet!(intt()), single(int(3))).func_with_arg_types();
+    let myloop = dowhile(arg(), parallel!(tfalse(), int(3)))
+        .with_arg_types(tuplet!(intt()), tuplet!(intt()));
+    let expr =
+        function("main", tuplet!(intt()), tuplet!(intt()), myloop.clone()).func_with_arg_types();
+    let int3func = function("main", tuplet!(intt()), tuplet!(intt()), single(int(3)));
 
-    let fargincontext = in_context(infunc("main"), arg_ty(tuplet!(intt())));
-    let inner_in_context = inloop(
-        fargincontext.clone(),
-        parallel!(tfalse(), int(3)).with_arg_types(tuplet!(intt()), tuplet!(boolt(), intt())),
+    let fargincontext = in_context(
+        infunc("main"),
+        arg().with_arg_types(tuplet!(intt()), tuplet!(intt())),
     );
-    let expr_intermediate = function(
-        "main",
-        tuplet!(intt()),
-        tuplet!(intt()),
-        dowhile(
-            fargincontext.clone(),
-            in_context(inner_in_context.clone(), parallel!(tfalse(), int(3))),
-        ),
-    )
-    .func_with_arg_types();
+    let inner_in_context = inloop(fargincontext.clone(), parallel!(tfalse(), int(3)));
     let expr2 = function(
         "main",
         tuplet!(intt()),
@@ -133,19 +156,22 @@ fn test_dowhile_cycle_in_context() -> crate::Result {
         dowhile(
             fargincontext.clone(),
             parallel!(
-                in_context(inner_in_context.clone(), tfalse()),
-                in_context(inner_in_context.clone(), int(3)),
+                in_context(inner_in_context.clone(), tfalse()), // false gets the loop context
+                in_context(infunc("main"), int(3)) // 3 is equal to the loop, which is equal to 3 in the outer context
             ),
         ),
     )
     .func_with_arg_types();
 
     egglog_test(
-        &format!("{expr}",),
         &format!(
             "
-(check (ContextLess {expr}))
-(check (= {expr} {expr_intermediate}))
+{expr}
+(AddFuncContext {expr})
+    ",
+        ),
+        &format!(
+            "
 (check (= {expr} {expr2}))
 (check (= {expr} {int3func}))"
         ),
@@ -155,6 +181,127 @@ fn test_dowhile_cycle_in_context() -> crate::Result {
         ],
         Value::Tuple(vec![Value::Const(Constant::Int(3))]),
         Value::Tuple(vec![Value::Const(Constant::Int(3))]),
+        vec![],
+    )
+}
+
+#[test]
+fn simple_identity_subst() -> crate::Result {
+    use crate::ast::*;
+    use crate::egglog_test;
+    use crate::{interpreter::Value, schema::Constant};
+    let expr = function("main", base(intt()), base(intt()), int(2));
+    let expected = function(
+        "main",
+        base(intt()),
+        base(intt()),
+        in_context(infunc("main"), int(2)),
+    );
+    egglog_test(
+        &format!("(AddFuncContext {expr})"),
+        &format!(
+            "
+(check (= {expr} {expected}))",
+        ),
+        vec![
+            expr.to_program(emptyt(), base(intt())),
+            expected.to_program(emptyt(), base(intt())),
+        ],
+        Value::Tuple(vec![]),
+        Value::Const(Constant::Int(2)),
+        vec![],
+    )
+}
+
+#[test]
+fn test_subst_nested() -> crate::Result {
+    use crate::ast::*;
+    use crate::{interpreter::Value, schema::Constant};
+    let twoint = tuplet!(intt(), intt());
+    let expr = tlet(
+        parallel!(int(1), get(arg(), 1), tlet(int(2), get(arg(), 0))),
+        int(0),
+    )
+    .with_arg_types(twoint.clone(), base(intt()));
+    let replace_with = parallel!(int(3), int(4));
+    let replacement = in_context(infunc("main"), replace_with.clone());
+    let replacement_2 = get(
+        in_context(
+            inlet(in_context(infunc("main"), int(2))),
+            replace_with.clone(),
+        ),
+        0,
+    );
+    let new_inputs = parallel!(
+        in_context(infunc("main"), int(1)),
+        get(replacement.clone(), 1),
+        tlet(in_context(infunc("main"), int(2)), replacement_2)
+    );
+    let expected = tlet(
+        new_inputs.clone(),
+        in_context(inlet(new_inputs.clone()), int(0)),
+    )
+    .with_arg_types(twoint, base(intt()));
+
+    let build = format!(
+        "
+(let substituted (Subst (InFunc \"main\")
+                        (FuncScope)
+                        {replace_with}
+                        {expr}))"
+    );
+    let check = format!(
+        "
+(check (= substituted {expected}))",
+    );
+
+    crate::egglog_test(
+        &build.to_string(),
+        &check.to_string(),
+        vec![
+            expr.to_program(tuplet!(intt(), intt()), base(intt())),
+            expected.to_program(tuplet!(intt(), intt()), base(intt())),
+        ],
+        Value::Tuple(vec![
+            Value::Const(Constant::Int(10)),
+            Value::Const(Constant::Int(10)),
+        ]),
+        Value::Const(Constant::Int(0)),
+        vec![],
+    )
+}
+
+#[test]
+fn test_subst_makes_new_context() -> crate::Result {
+    use crate::ast::*;
+    use crate::{interpreter::Value, schema::Constant};
+    let expr = add(
+        in_context(infunc("otherfunc"), int_ty(1, base(intt()))),
+        in_context(infunc("otherfunc"), arg_ty(base(intt()))),
+    );
+    let replace_with = int(2);
+    let expected = add(
+        in_context(infunc("main"), int(1)),
+        in_context(infunc("main"), int(2)),
+    );
+    let build = format!(
+        "
+(let substituted (Subst (InFunc \"main\")
+                        (FuncScope) 
+                        {replace_with}
+                        {expr}))"
+    );
+    let check = format!("(check (= substituted {expected}))");
+
+    crate::egglog_test(
+        &build.to_string(),
+        &check.to_string(),
+        vec![
+            expr.to_program(base(intt()), base(intt())),
+            expected.to_program(base(intt()), base(intt())),
+        ],
+        Value::Const(Constant::Int(2)),
+        Value::Const(Constant::Int(3)),
         vec![],
     )
 }


### PR DESCRIPTION
This PR improves the context rules, with fine-grained control of how deep to copy.
It also fixes our saturation issues by keeping track of a list of eclasses already visited, and subsuming rows that have encountered a cycle.