### PR TITLE
Add context before sending to egglog

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -325,10 +325,12 @@ impl Run {
     fn optimize_bril(program: &Program) -> Result<Program, EggCCError> {
         let rvsdg = Optimizer::program_to_rvsdg(program)?;
         let dag = rvsdg.to_dag_encoding();
-        let optimized = dag_in_context::optimize(&dag).map_err(EggCCError::EggLog)?;
+        let with_context = dag.add_context();
+        let optimized = dag_in_context::optimize(&with_context).map_err(EggCCError::EggLog)?;
         let rvsdg2 = dag_to_rvsdg(&optimized);
         let cfg = rvsdg2.to_cfg();
         let bril = cfg.to_bril();
+
         Ok(bril)
     }
 


### PR DESCRIPTION
This PR makes the optimizer add context nodes before sending the program to egglog.
To ensure linearity of the state edge on the way back, it removes these context nodes again. This is a hack that should be fixed by a linearity-preserving extractor in the future. Right now, eggcc assumes the extracted program uses memory linearly.