### PR TITLE
Fix bug in sharing invariant via translation to Term and back again

### DIFF
--- a/dag_in_context/src/from_egglog.rs
+++ b/dag_in_context/src/from_egglog.rs
@@ -15,6 +15,14 @@ pub struct FromEgglog {
     pub conversion_cache: HashMap<Term, RcExpr>,
 }
 
+pub fn program_from_egglog(program: Term, termdag: egglog::TermDag) -> TreeProgram {
+    let mut converter = FromEgglog {
+        termdag,
+        conversion_cache: HashMap::new(),
+    };
+    converter.program_from_egglog(program)
+}
+
 impl FromEgglog {
     fn const_from_egglog(&mut self, constant: Term) -> Constant {
         match_term_app!(constant.clone(); {

--- a/dag_in_context/src/schema.rs
+++ b/dag_in_context/src/schema.rs
@@ -6,7 +6,7 @@
 use std::rc::Rc;
 use strum_macros::EnumIter;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BaseType {
     IntT,
     BoolT,
@@ -14,7 +14,7 @@ pub enum BaseType {
     StateT,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
     Base(BaseType),
     /// Nested tuple types are not allowed.

--- a/dag_in_context/src/to_egglog.rs
+++ b/dag_in_context/src/to_egglog.rs
@@ -5,8 +5,12 @@ use egglog::{
     Term, TermDag,
 };
 
-use crate::schema::{
-    Assumption, BaseType, BinaryOp, Constant, Expr, Order, TernaryOp, TreeProgram, Type, UnaryOp,
+use crate::{
+    from_egglog::program_from_egglog,
+    schema::{
+        Assumption, BaseType, BinaryOp, Constant, Expr, Order, TernaryOp, TreeProgram, Type,
+        UnaryOp,
+    },
 };
 
 pub(crate) struct TreeToEgglog {
@@ -253,6 +257,14 @@ impl Expr {
 }
 
 impl TreeProgram {
+    /// DAG programs should share common subexpressions whenever possible.
+    /// Otherwise, effects may happen multiple times.
+    /// This function restores this invariant by converting to a Term and back again.
+    pub fn restore_sharing_invariant(&self) -> TreeProgram {
+        let (term, termdag) = self.to_egglog();
+        program_from_egglog(term, termdag)
+    }
+
     /// Translates an the program to an egglog term
     /// encoded with respect to `schema.egg`.
     /// Shares common subexpressions.

--- a/src/rvsdg/to_dag.rs
+++ b/src/rvsdg/to_dag.rs
@@ -25,6 +25,7 @@ use super::RvsdgType;
 impl RvsdgProgram {
     /// Converts an RVSDG program to the dag encoding.
     /// Common subexpressions are shared by the same Rc<Expr> in the dag encoding.
+    /// This invariant is mainted by restore_sharing_invariant.
     pub fn to_dag_encoding(&self) -> TreeProgram {
         let last_function = self.functions.last().unwrap();
         let rest_functions = self.functions.iter().take(self.functions.len() - 1);
@@ -34,6 +35,7 @@ impl RvsdgProgram {
                 .map(|f| f.to_dag_encoding())
                 .collect::<Vec<_>>(),
         )
+        .restore_sharing_invariant()
     }
 }
 
@@ -277,7 +279,7 @@ impl<'a> DagTranslator<'a> {
                     (ValueOps::Eq, [a, b]) => eq(a.clone(), b.clone()),
                     (ValueOps::And, [a, b]) => and(a.clone(), b.clone()),
                     (ValueOps::Ge, [a, b]) => greater_eq(a.clone(), b.clone()),
-                    (ValueOps::Le, [a, b]) => less_eq(b.clone(), a.clone()),
+                    (ValueOps::Le, [a, b]) => less_eq(a.clone(), b.clone()),
                     (ValueOps::Not, [a]) => not(a.clone()),
                     (ValueOps::PtrAdd, [a, b]) => ptradd(a.clone(), b.clone()),
                     (ValueOps::Load, [a, b]) => load(a.clone(), b.clone()),

--- a/tests/repro-conversion-bug-loop.bril
+++ b/tests/repro-conversion-bug-loop.bril
@@ -1,0 +1,29 @@
+
+@main() {
+  i: int = const 6;
+
+.top:
+  c: int = const 9;
+  
+
+  b: int = const 9;
+  if_cond: bool = le i b;
+  br if_cond .then_if .else_if;
+.then_if:
+  one: int = const 1;
+  print one;
+  jmp .end_if;
+.else_if:
+  two: int = const 2;
+  print two;
+.end_if:
+
+  one: int = const 1;
+  i: int = add i one;
+
+  loop_cond: bool = lt i c;
+  br loop_cond .top .end;
+.end:
+
+  print i;
+}


### PR DESCRIPTION
The RVSDG->DAG pass wasn't maintaining the sharing invariant (that sub-terms that are equal must be shared using the same Rc<Expr> poitner).
This PR fixes that.

It also fixes up typechecking to do proper caching based on the argument type