### PR TITLE
Context-preserving substitution

### DIFF
--- a/dag_in_context/src/ast.rs
+++ b/dag_in_context/src/ast.rs
@@ -38,7 +38,7 @@ pub fn pointert(t: BaseType) -> BaseType {
     BaseType::PointerT(Box::new(t))
 }
 
-pub fn val_int(i: i64) -> Value {
+pub fn intv(i: i64) -> Value {
     Value::Const(Constant::Int(i))
 }
 

--- a/dag_in_context/src/interval_analysis.rs
+++ b/dag_in_context/src/interval_analysis.rs
@@ -51,7 +51,7 @@ fn interval_test(
 #[test]
 fn constant_interval_test() -> crate::Result {
     let e = int(3);
-    int_interval_test(e, base(intt()), val_empty(), val_int(3), 3, 3)
+    int_interval_test(e, base(intt()), val_empty(), intv(3), 3, 3)
 }
 
 #[test]
@@ -63,7 +63,7 @@ fn constant_interval_test2() -> crate::Result {
 #[test]
 fn constant_fold() -> crate::Result {
     let e = add(int(3), int(2));
-    int_interval_test(e, base(intt()), val_empty(), val_int(5), 5, 5)
+    int_interval_test(e, base(intt()), val_empty(), intv(5), 5, 5)
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn test_add_constant_fold() -> crate::Result {
             expr2.to_program(emptyt(), base(intt())),
         ],
         val_empty(),
-        val_int(3),
+        intv(3),
         vec![],
     )
 }
@@ -88,7 +88,7 @@ fn test_add_constant_fold() -> crate::Result {
 #[test]
 fn test_add_interval() -> crate::Result {
     let e = add(int(3), int(4)).with_arg_types(emptyt(), base(intt()));
-    int_interval_test(e, base(intt()), val_empty(), val_int(7), 7, 7)
+    int_interval_test(e, base(intt()), val_empty(), intv(7), 7, 7)
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn test_if_constant_fold() -> crate::Result {
     let c = less_than(int(2), int(3)).with_arg_types(emptyt(), base(boolt()));
     let e = tif(c, int_ty(3, emptyt()), int_ty(4, emptyt()));
 
-    int_interval_test(e, base(intt()), val_empty(), val_int(3), 3, 3)
+    int_interval_test(e, base(intt()), val_empty(), intv(3), 3, 3)
 }
 
 #[test]
@@ -118,8 +118,8 @@ fn if_interval() -> crate::Result {
         &format!("{f}"),
         &format!("(check (ival {e}) (IntI 4 5))"),
         vec![f.to_program(base(intt()), base(intt()))],
-        val_int(1),
-        val_int(4),
+        intv(1),
+        intv(4),
         vec![],
     )
 }
@@ -142,8 +142,8 @@ fn nested_if() -> crate::Result {
         &format!("{f}"),
         &format!("(check (ival {inner}) (IntI 4 5)) (check (ival {outer}) (IntI 20 20))"),
         vec![f.to_program(base(intt()), base(intt()))],
-        val_int(2),
-        val_int(20),
+        intv(2),
+        intv(20),
         vec![],
     )
 }

--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -37,6 +37,7 @@ pub fn prologue() -> String {
         &optimizations::purity_analysis::rules().join("\n"),
         &optimizations::conditional_invariant_code_motion::rules().join("\n"),
         include_str!("utility/in_context.egg"),
+        include_str!("utility/context-prop.egg"),
         include_str!("utility/subst.egg"),
         include_str!("optimizations/switch_rewrites.egg"),
         include_str!("optimizations/function_inlining.egg"),

--- a/dag_in_context/src/optimizations/constant_fold.rs
+++ b/dag_in_context/src/optimizations/constant_fold.rs
@@ -15,7 +15,7 @@ fn test_add_constant_fold() -> crate::Result {
             expr2.to_program(emptyt(), base(intt())),
         ],
         val_empty(),
-        val_int(3),
+        intv(3),
         vec![],
     )
 }

--- a/dag_in_context/src/optimizations/purity_analysis.rs
+++ b/dag_in_context/src/optimizations/purity_analysis.rs
@@ -134,7 +134,7 @@ fn test_purity_analysis() -> crate::Result {
         &check,
         vec![pureloop.to_program(emptyt(), tuplet!(intt()))],
         tuplev!(),
-        tuplev!(val_int(4)),
+        tuplev!(intv(4)),
         vec![],
     )
 }

--- a/dag_in_context/src/optimizations/switch_rewrites.rs
+++ b/dag_in_context/src/optimizations/switch_rewrites.rs
@@ -18,7 +18,7 @@ fn switch_rewrite_three_quarters_and() -> crate::Result {
             check.to_program(emptyt(), base(intt())),
         ],
         val_empty(),
-        val_int(2),
+        intv(2),
         vec![],
     )
 }
@@ -40,7 +40,7 @@ fn switch_rewrite_three_quarters_or() -> crate::Result {
             check.to_program(emptyt(), base(intt())),
         ],
         val_empty(),
-        val_int(1),
+        intv(1),
         vec![],
     )
 }
@@ -62,7 +62,7 @@ fn switch_rewrite_three_quarters_purity() -> crate::Result {
         &format!("(check (= {build} {check}))"),
         vec![build.to_program(emptyt(), base(intt()))],
         val_empty(),
-        val_int(2),
+        intv(2),
         vec![],
     )?;
 
@@ -80,7 +80,7 @@ fn switch_rewrite_three_quarters_purity() -> crate::Result {
         &format!("(fail (check (= {build} {check})))"),
         vec![build.to_program(base(statet()), base(intt()))],
         statev(),
-        val_int(2),
+        intv(2),
         vec!["1".to_string()],
     )
 }

--- a/dag_in_context/src/schedule.egg
+++ b/dag_in_context/src/schedule.egg
@@ -10,6 +10,7 @@
       (saturate subst) ;; subst depends on type information for the argument
       (saturate interval-analysis)
       (saturate
+        (saturate context-prop)
         (saturate context-helpers)
         context))
     conditional-invariant-code-motion

--- a/dag_in_context/src/type_analysis.rs
+++ b/dag_in_context/src/type_analysis.rs
@@ -59,11 +59,11 @@ fn _debug(inp: RcExpr, after: &str) -> crate::Result {
 
 #[test]
 fn primitives() -> crate::Result {
-    type_test(int(3), base(intt()), val_int(0), val_int(3))?;
-    type_test(int(12), base(intt()), val_int(0), val_int(12))?;
-    type_test(ttrue(), base(boolt()), val_int(0), val_bool(true))?;
-    type_test(tfalse(), base(boolt()), val_int(0), val_bool(false))?;
-    type_test(empty(), emptyt(), val_int(0), val_empty())
+    type_test(int(3), base(intt()), intv(0), intv(3))?;
+    type_test(int(12), base(intt()), intv(0), intv(12))?;
+    type_test(ttrue(), base(boolt()), intv(0), val_bool(true))?;
+    type_test(tfalse(), base(boolt()), intv(0), val_bool(false))?;
+    type_test(empty(), emptyt(), intv(0), val_empty())
 }
 
 /* Fix type tests after dag semantics

--- a/dag_in_context/src/utility/context-prop.egg
+++ b/dag_in_context/src/utility/context-prop.egg
@@ -1,0 +1,49 @@
+;; Besides the in_context rules that add fresh contexts to everything,
+;; we normalize terms to keep contexts in the leaf nodes.
+;; This file contains the rules that move contexts to leaf nodes
+
+(ruleset context-prop)
+
+
+(rewrite (InContext ctx (Top op a b c))
+         (Top op (InContext ctx a) (InContext ctx b) (InContext ctx c))
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Bop op a b))
+         (Bop op (InContext ctx a) (InContext ctx b))
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Uop op a))
+         (Uop op (InContext ctx a))
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Get expr ith))
+         (Get (InContext ctx expr) ith)
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Alloc i amount state_edge ty))
+         (Alloc i (InContext ctx amount) (InContext ctx state_edge) ty)
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Call name arg))
+         (Call name (InContext ctx arg))
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Single expr))
+         (Single (InContext ctx expr))
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (Concat order e1 e2))
+         (Concat order (InContext ctx e1) (InContext ctx e2))
+         :ruleset context-prop)
+
+(rewrite (InContext ctx (If cond then else))
+          (If (InContext ctx cond) (InContext ctx then) (InContext ctx else))
+          :ruleset context-prop)
+
+
+;; don't add context to body, since it's a new region
+(rewrite (InContext ctx (DoWhile inputs body))
+         (DoWhile (InContext ctx inputs) body)
+         :ruleset context-prop)
+

--- a/dag_in_context/src/utility/in_context.egg
+++ b/dag_in_context/src/utility/in_context.egg
@@ -74,12 +74,6 @@
 
 ;; ################################ saturation
 
-;; Outer context nodes are more specific by our semantics
-(rewrite (InContext ctx (InContext ctx expr))
-         (InContext ctx expr)
-         :ruleset context-helpers)
-
-
 ;; Adding context a second time does nothing, so union
 (rule
   ((= lhs (DoAddContext seen ctx (Full) inner))
@@ -99,8 +93,8 @@
 ;; values is the same.
 (rule ((= body_with_context
           (DoAddContext seen  (InLoop inputs outputs) (Full) outputs)) ;; a loop body with context
-       (DoAddContext    seen2 (InLoop inputs body_with_context) ;; same inputs
-                    (Full) body_with_context) ;; a loop body whose context already has context
+          (DoAddContext seen2 (InLoop inputs body_with_context) ;; same inputs
+                              (Full) body_with_context) ;; a loop body whose context already has context
        )
       ((union (InLoop inputs outputs) (InLoop inputs body_with_context)))
       :ruleset context-helpers)

--- a/dag_in_context/src/utility/in_context.rs
+++ b/dag_in_context/src/utility/in_context.rs
@@ -36,7 +36,7 @@ fn test_in_context_two_loops() -> crate::Result {
         ),
         vec![expr.func_to_program(), with_context.func_to_program()],
         Value::Tuple(vec![]),
-        tuplev!(val_int(4)),
+        tuplev!(intv(4)),
         vec![],
     )
 }

--- a/dag_in_context/src/utility/subst.egg
+++ b/dag_in_context/src/utility/subst.egg
@@ -105,3 +105,8 @@
 (rewrite (SubstList assum to (Nil))
          (Nil)
          :ruleset subst)
+
+;; substitute into function (convenience)
+(rewrite (Subst assum to (Function name inty outty body))
+         (Function name inty outty (Subst assum to body))
+         :ruleset subst)

--- a/dag_in_context/src/utility/subst.egg
+++ b/dag_in_context/src/utility/subst.egg
@@ -1,35 +1,57 @@
+;; Substitution rules allow for substituting some new expression for the argument
+;; in some new context.
+;; It performs the substitution, copying over the equalities from the original eclass.
+;; It only places context on the leaf nodes.
+
 (ruleset subst)
 
 ;; (Subst assumption to in) substitutes 
 ;; (InContext assumption to) for `(Arg ty)` in `in`
 ;; It also replaces `(Asuume anything (Arg ty))` with `(InContext assumption to)`
 (function Subst (Assumption Expr Expr) Expr :unextractable)
+;; (SubstLeaf to in) substitutes `to` for `in` in a leaf node `in`
+;; SubstLeaf assumes context has already been added
+(function SubstLeaf (Expr Expr) Expr :unextractable)
 (function SubstList (Assumption Expr ListExpr) ListExpr :unextractable)
 
 
 ;; Base case- leaf nodes
-(rewrite (Subst assum to (Arg ty))
-         (InContext assum to)
+;; leaf node without context
+(rule ((= lhs (Subst assum to leaf))
+       (IsLeaf leaf))
+      ((union lhs (InContext assum (SubstLeaf to leaf))))
+      :ruleset subst)
+;; leaf node with context
+;; replace infunc context
+(rule ((= lhs (Subst assum to (InContext (InFunc name) leaf)))
+       (IsLeaf leaf))
+      ((union lhs (InContext assum (SubstLeaf to leaf))))
+      :ruleset subst)
+(rule ((= lhs (Subst assum to (InContext (InLoop inputs body) leaf)))
+       (IsLeaf leaf))
+      ((union lhs (InContext assum (SubstLeaf to leaf))))
+      :ruleset subst)
+;; modify inif context
+(rule ((= lhs (Subst assum to (InContext (InIf branch pred) leaf)))
+       (IsLeaf leaf))
+      ((union lhs
+        (InContext
+          (InIf branch (Subst assum to pred))
+          (SubstLeaf to leaf))))
+      :ruleset subst)
+
+
+(rewrite (SubstLeaf to (Arg ty))
+         to
          :ruleset subst)
-(rewrite (Subst assum to (InContext assum2 (Arg ty)))
-         (InContext assum to)
-         :ruleset subst)
-(rewrite (Subst assum to (Const constant ty))
-         (InContext assum (Const constant ty2))
+(rewrite (SubstLeaf to (Const constant ty))
+         (Const constant ty2)
          :when ((HasArgType to ty2))
          :ruleset subst)
-(rewrite (Subst assum to (InContext assum2 (Const constant ty)))
-         (InContext assum (Const constant ty2))
-         :when ((HasArgType to ty2))
-         :ruleset subst)
-(rewrite (Subst assum to (Empty ty))
-         (InContext assum (Empty ty2))
+(rewrite (SubstLeaf to (Empty ty))
+         (Empty ty2)
          :when ((HasArgType to ty2))
           :ruleset subst)
-(rewrite (Subst assum to (InContext assum2 (Empty ty)))
-         (InContext assum (Empty ty2))
-         :when ((HasArgType to ty2))
-         :ruleset subst)
 
 
 ;; Operators

--- a/dag_in_context/src/utility/subst.rs
+++ b/dag_in_context/src/utility/subst.rs
@@ -104,12 +104,14 @@ fn test_subst_arg_type_changes() -> crate::Result {
     use crate::{interpreter::Value, schema::Constant};
     let expr = add(iarg(), iarg());
     let tupletype = tuplet!(intt(), intt());
+    let replace_with = get(arg(), 0).with_arg_types(tupletype.clone(), base(intt()));
+
+
     let expected = add(
         in_context(infunc("main"), get(arg(), 0)),
         in_context(infunc("main"), get(arg(), 0)),
     )
     .with_arg_types(tupletype.clone(), base(intt()));
-    let replace_with = get(arg(), 0).with_arg_types(tupletype.clone(), base(intt()));
     let build = format!(
         "
 (let substituted (Subst (InFunc \"main\")

--- a/dag_in_context/src/utility/util.egg
+++ b/dag_in_context/src/utility/util.egg
@@ -35,3 +35,10 @@
        (= len1 (tuple-length expr1))
        (= ith (tuple-ith expr2 i)))
        ((union (tuple-ith (Concat ord expr1 expr2) (+ len1 i)) ith)) :ruleset always-run)
+
+
+(relation IsLeaf (Expr))
+
+(rule ((Arg ty)) ((IsLeaf (Arg ty))) :ruleset always-run)
+(rule ((Const val ty)) ((IsLeaf (Const val ty))) :ruleset always-run)
+(rule ((Empty ty)) ((IsLeaf (Empty ty))) :ruleset always-run)


### PR DESCRIPTION
This PR tweaks the substitution rules to preserve `InIf` contexts. Before, it would throw these away (which is unsound).
It also adds back in the context-prop rules to normalize terms, pushing context to leaf nodes.