### PR TITLE
Add snapshots

### DIFF
--- a/dag_in_context/src/schema.rs
+++ b/dag_in_context/src/schema.rs
@@ -6,7 +6,7 @@
 use std::rc::Rc;
 use strum_macros::EnumIter;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BaseType {
     IntT,
     BoolT,
@@ -14,7 +14,7 @@ pub enum BaseType {
     StateT,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Type {
     Base(BaseType),
     /// Nested tuple types are not allowed.
@@ -28,12 +28,12 @@ pub enum Type {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter)]
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, PartialOrd, Ord)]
 pub enum TernaryOp {
     Write,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter)]
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, PartialOrd, Ord)]
 pub enum BinaryOp {
     Add,
     Sub,
@@ -52,18 +52,18 @@ pub enum BinaryOp {
     Free,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter)]
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, PartialOrd, Ord)]
 pub enum UnaryOp {
     Not,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Constant {
     Int(i64),
     Bool(bool),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Order {
     Parallel,
     Sequential,
@@ -76,14 +76,14 @@ pub enum Order {
 /// This is important for the correctness of the interpreter, which makes this assumption.
 pub type RcExpr = Rc<Expr>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Assumption {
     InLoop(RcExpr, RcExpr),
     InFunc(String),
     InIf(bool, RcExpr),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Expr {
     Const(Constant, Type),
     Top(TernaryOp, RcExpr, RcExpr, RcExpr),

--- a/src/rvsdg/dag_region_query.rs
+++ b/src/rvsdg/dag_region_query.rs
@@ -26,7 +26,7 @@ impl AlwaysExecutedCache {
         &mut self,
         conditional_expr: &RcExpr,
         region_root: &RcExpr,
-    ) -> HashMap<*const Expr, RcExpr> {
+    ) -> Vec<RcExpr> {
         let children = match conditional_expr.as_ref() {
             Expr::If(_, then_branch, else_branch) => vec![then_branch.clone(), else_branch.clone()],
             Expr::Switch(_, branches) => branches.clone(),
@@ -65,7 +65,7 @@ impl AlwaysExecutedCache {
             }
         }
 
-        result
+        rcexpr_set(result.values().cloned())
     }
 
     /// Get the set of expressions that are always executed given this expression
@@ -119,12 +119,11 @@ impl AlwaysExecutedCache {
     }
 }
 
-#[cfg(test)]
-fn rcexpr_set(iterator: impl IntoIterator<Item = RcExpr>) -> HashMap<*const Expr, RcExpr> {
-    iterator
-        .into_iter()
-        .map(|e| (Rc::as_ptr(&e), e.clone()))
-        .collect()
+fn rcexpr_set(iterator: impl IntoIterator<Item = RcExpr>) -> Vec<RcExpr> {
+    let mut vec: Vec<RcExpr> = iterator.into_iter().collect();
+    vec.sort();
+    vec.dedup();
+    vec
 }
 
 #[test]

--- a/src/rvsdg/from_dag.rs
+++ b/src/rvsdg/from_dag.rs
@@ -362,7 +362,7 @@ impl<'a> TreeToRvsdg<'a> {
                     (0..self.current_args.len()).map(Operand::Arg).collect();
                 // branch inputs are added to this cache
                 let mut new_expr_cache = HashMap::new();
-                for (_pointer, input_expr) in branch_inputs {
+                for input_expr in branch_inputs {
                     let input = self.convert_expr(input_expr.clone());
                     let cached_input = input
                         .iter()
@@ -409,14 +409,14 @@ impl<'a> TreeToRvsdg<'a> {
                 assert_eq!(pred.len(), 1, "Expected exactly one result for predicate");
 
                 // find the branch inputs for each case
-                let branch_inputs: HashMap<*const Expr, Rc<Expr>> = self
+                let branch_inputs = self
                     .always_executed_cache
                     .get_without_subchildren_for_branch(&expr, &self.current_region_root);
 
                 let mut new_inputs: Vec<Operand> =
                     (0..self.current_args.len()).map(Operand::Arg).collect();
                 let mut new_expr_cache = HashMap::new();
-                for (_pointer, input_expr) in branch_inputs {
+                for input_expr in branch_inputs {
                     let input = self.convert_expr(input_expr.clone());
                     let cached_input = input
                         .iter()

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -8,7 +8,7 @@ fn generate_tests(glob: &str) -> Vec<Trial> {
     let mut trials = vec![];
 
     let mut mk_trial = |run: Run, snapshot: bool| {
-        let snapshot_configurations: HashSet<RunType> = [].into_iter().collect();
+        let snapshot_configurations: HashSet<RunType> = [RunType::Optimize].into_iter().collect();
 
         trials.push(Trial::test(run.name(), move || {
             let result = match run.run() {

--- a/tests/snapshots/files__add-optimize.snap
+++ b/tests/snapshots/files__add-optimize.snap
@@ -1,0 +1,10 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: int = const 1;
+  v3: int = const 2;
+  v5: int = add v1 v3;
+  print v5;
+}

--- a/tests/snapshots/files__add_block_indirection-optimize.snap
+++ b/tests/snapshots/files__add_block_indirection-optimize.snap
@@ -1,0 +1,10 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: int = const 1;
+  v3: int = const 2;
+  v5: int = add v1 v3;
+  print v5;
+}

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -1,0 +1,56 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 2;
+  v5: bool = lt v0 v3;
+  v10: int = const 0;
+  v12: int = const 1;
+  br v5 .__33__ .__19__;
+.__33__:
+  v35: bool = lt v3 v0;
+  v50: int = add v10 v3;
+  br v35 .__66__ .__55__;
+.__66__:
+  v69: int = add v50 v3;
+  v73: bool = const true;
+  v61: int = id v69;
+  v62: int = id v12;
+  v63: int = id v3;
+  v64: bool = id v73;
+.__76__:
+  v28: int = id v61;
+  v29: int = id v62;
+  v30: int = id v63;
+  v31: bool = id v64;
+.__82__:
+  br v31 .__103__ .__94__;
+.__103__:
+  v100: int = id v28;
+  v101: int = id v29;
+  jmp .__107__;
+.__94__:
+  v97: int = add v28 v30;
+  v100: int = id v97;
+  v101: int = id v29;
+  jmp .__107__;
+.__55__:
+  v59: bool = const false;
+  v61: int = id v50;
+  v62: int = id v12;
+  v63: int = id v3;
+  v64: bool = id v59;
+  jmp .__76__;
+.__19__:
+  v22: int = add v10 v12;
+  v26: bool = const false;
+  v28: int = id v22;
+  v29: int = id v12;
+  v30: int = id v3;
+  v31: bool = id v26;
+  jmp .__82__;
+.__107__:
+  v109: int = add v100 v101;
+  print v109;
+}

--- a/tests/snapshots/files__bool-optimize.snap
+++ b/tests/snapshots/files__bool-optimize.snap
@@ -1,0 +1,8 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: bool = const true;
+  print v1;
+}

--- a/tests/snapshots/files__branch_duplicate_work-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize.snap
@@ -1,0 +1,18 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 2;
+  v5: bool = lt v0 v3;
+  v13: int = add v0 v0;
+  br v5 .__23__ .__16__;
+.__23__:
+  v21: int = id v13;
+  jmp .__26__;
+.__16__:
+  v19: int = mul v13 v3;
+  v21: int = id v19;
+.__26__:
+  print v21;
+}

--- a/tests/snapshots/files__collatz-optimize.snap
+++ b/tests/snapshots/files__collatz-optimize.snap
@@ -1,0 +1,74 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 0;
+  v6: int = const 2;
+  v8: int = const 1;
+  v10: int = const 3;
+  v13: int = id v3;
+  v14: int = id v0;
+  v15: int = id v6;
+  v16: int = id v8;
+  v17: int = id v10;
+  v18: int = id v3;
+.__20__:
+  v22: bool = eq v14 v16;
+  br v22 .__137__ .__43__;
+.__137__:
+  v139: bool = const false;
+  v129: int = id v13;
+  v130: bool = id v139;
+  v131: int = id v14;
+  v132: int = id v15;
+  v133: int = id v16;
+  v134: int = id v17;
+  v135: int = id v18;
+.__147__:
+  v13: int = id v129;
+  v14: int = id v131;
+  v15: int = id v132;
+  v16: int = id v133;
+  v17: int = id v134;
+  v18: int = id v135;
+  br v130 .__20__ .__157__;
+.__43__:
+  v46: int = div v14 v15;
+  v49: int = mul v46 v15;
+  v51: int = sub v14 v49;
+  v54: bool = eq v51 v18;
+  v86: int = add v13 v16;
+  v88: bool = const true;
+  br v54 .__112__ .__90__;
+.__112__:
+  v104: int = id v86;
+  v105: bool = id v88;
+  v106: int = id v46;
+  v107: int = id v15;
+  v108: int = id v16;
+  v109: int = id v17;
+  v110: int = id v18;
+.__121__:
+  v129: int = id v104;
+  v130: bool = id v105;
+  v131: int = id v106;
+  v132: int = id v107;
+  v133: int = id v108;
+  v134: int = id v109;
+  v135: int = id v110;
+  jmp .__147__;
+.__90__:
+  v96: int = mul v17 v14;
+  v98: int = add v16 v96;
+  v104: int = id v86;
+  v105: bool = id v88;
+  v106: int = id v98;
+  v107: int = id v15;
+  v108: int = id v16;
+  v109: int = id v17;
+  v110: int = id v18;
+  jmp .__121__;
+.__157__:
+  print v13;
+}

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -1,0 +1,74 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v5: int = const 1;
+  v7: int = const 3;
+  v9: int = const 2;
+  v11: int = const 0;
+  v13: int = id v0;
+  v14: int = id v0;
+  v15: int = id v5;
+  v16: int = id v7;
+  v17: int = id v9;
+  v18: int = id v11;
+.__20__:
+  v22: bool = eq v14 v15;
+  br v22 .__136__ .__43__;
+.__136__:
+  v138: bool = const false;
+  v128: int = id v13;
+  v129: bool = id v138;
+  v130: int = id v14;
+  v131: int = id v15;
+  v132: int = id v16;
+  v133: int = id v17;
+  v134: int = id v18;
+.__146__:
+  v13: int = id v128;
+  v14: int = id v130;
+  v15: int = id v131;
+  v16: int = id v132;
+  v17: int = id v133;
+  v18: int = id v134;
+  br v129 .__20__ .__156__;
+.__43__:
+  v46: int = div v14 v17;
+  v49: int = mul v46 v17;
+  v51: int = sub v14 v49;
+  v54: bool = eq v51 v18;
+  print v14;
+  v87: bool = const true;
+  br v54 .__111__ .__89__;
+.__111__:
+  v103: int = id v13;
+  v104: bool = id v87;
+  v105: int = id v46;
+  v106: int = id v15;
+  v107: int = id v16;
+  v108: int = id v17;
+  v109: int = id v18;
+.__120__:
+  v128: int = id v103;
+  v129: bool = id v104;
+  v130: int = id v105;
+  v131: int = id v106;
+  v132: int = id v107;
+  v133: int = id v108;
+  v134: int = id v109;
+  jmp .__146__;
+.__89__:
+  v95: int = mul v16 v14;
+  v97: int = add v15 v95;
+  v103: int = id v13;
+  v104: bool = id v87;
+  v105: int = id v97;
+  v106: int = id v15;
+  v107: int = id v16;
+  v108: int = id v17;
+  v109: int = id v18;
+  jmp .__120__;
+.__156__:
+  print v13;
+}

--- a/tests/snapshots/files__constant_fold_simple-optimize.snap
+++ b/tests/snapshots/files__constant_fold_simple-optimize.snap
@@ -1,0 +1,12 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: int = const 1;
+  v3: int = const 2;
+  v5: int = add v1 v3;
+  v9: int = mul v1 v3;
+  v11: int = div v5 v9;
+  print v11;
+}

--- a/tests/snapshots/files__diamond-optimize.snap
+++ b/tests/snapshots/files__diamond-optimize.snap
@@ -1,0 +1,16 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v4: bool = lt v0 v0;
+  br v4 .__16__ .__11__;
+.__16__:
+  v15: int = const 1;
+  print v15;
+  jmp .__20__;
+.__11__:
+  v10: int = const 2;
+  print v10;
+.__20__:
+}

--- a/tests/snapshots/files__duplicate_branch-optimize.snap
+++ b/tests/snapshots/files__duplicate_branch-optimize.snap
@@ -1,0 +1,16 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v2: int = const 4;
+  v5: bool = lt v2 v0;
+  br v5 .__16__ .__12__;
+.__16__:
+  v14: int = id v2;
+  jmp .__19__;
+.__12__:
+  v14: int = id v2;
+.__19__:
+  print v14;
+}

--- a/tests/snapshots/files__eliminate_gamma-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma-optimize.snap
@@ -1,0 +1,16 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: int = const 1;
+  v3: int = const 2;
+  v5: bool = lt v1 v3;
+  br v5 .__16__ .__12__;
+.__16__:
+  print v1;
+  jmp .__20__;
+.__12__:
+  print v3;
+.__20__:
+}

--- a/tests/snapshots/files__eliminate_gamma_interval-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-optimize.snap
@@ -1,0 +1,33 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 10;
+  v5: bool = lt v0 v3;
+  v10: int = const 5;
+  br v5 .__24__ .__14__;
+.__24__:
+  v25: int = const 2;
+  v28: int = add v25 v10;
+  v21: int = id v28;
+  v22: int = id v10;
+.__32__:
+  v34: bool = lt v21 v22;
+  br v34 .__46__ .__41__;
+.__46__:
+  v45: int = const 1;
+  print v45;
+  jmp .__50__;
+.__41__:
+  v40: int = const 2;
+  print v40;
+  jmp .__50__;
+.__14__:
+  v15: int = const 3;
+  v18: int = add v15 v10;
+  v21: int = id v18;
+  v22: int = id v10;
+  jmp .__32__;
+.__50__:
+}

--- a/tests/snapshots/files__eliminate_loop-optimize.snap
+++ b/tests/snapshots/files__eliminate_loop-optimize.snap
@@ -1,0 +1,14 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: int = const 1;
+.__5__:
+  v6: int = const 3;
+  v8: int = const 1;
+  v10: bool = lt v6 v8;
+  br v10 .__5__ .__14__;
+.__14__:
+  print v1;
+}

--- a/tests/snapshots/files__fib_shape-optimize.snap
+++ b/tests/snapshots/files__fib_shape-optimize.snap
@@ -1,0 +1,35 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 0;
+  v5: int = const 1;
+  v8: int = id v3;
+  v9: int = id v5;
+  v10: int = id v0;
+.__12__:
+  v14: bool = lt v8 v10;
+  br v14 .__37__ .__26__;
+.__37__:
+  v40: int = add v8 v9;
+  v42: bool = const true;
+  v32: int = id v40;
+  v33: bool = id v42;
+  v34: int = id v9;
+  v35: int = id v10;
+.__47__:
+  v8: int = id v32;
+  v9: int = id v34;
+  v10: int = id v35;
+  br v33 .__12__ .__54__;
+.__26__:
+  v28: bool = const false;
+  v32: int = id v8;
+  v33: bool = id v28;
+  v34: int = id v9;
+  v35: int = id v10;
+  jmp .__47__;
+.__54__:
+  print v8;
+}

--- a/tests/snapshots/files__flatten_loop-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-optimize.snap
@@ -1,0 +1,77 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+  v4: int = const 0;
+  v6: int = const 1;
+  v10: int = id v4;
+  v11: int = id v6;
+  v12: int = id v1;
+  v13: int = id v0;
+.__15__:
+  v17: bool = lt v10 v13;
+  br v17 .__43__ .__30__;
+.__43__:
+  v46: int = const 0;
+  v50: int = id v10;
+  v51: int = id v11;
+  v52: int = id v46;
+  v53: int = id v12;
+  v54: int = id v13;
+.__56__:
+  v58: bool = lt v52 v53;
+  br v58 .__91__ .__76__;
+.__91__:
+  v93: int = mul v50 v53;
+  v96: int = add v93 v52;
+  print v96;
+  v102: bool = const true;
+  v106: int = add v52 v51;
+  v84: int = id v50;
+  v85: int = id v51;
+  v86: bool = id v102;
+  v87: int = id v106;
+  v88: int = id v53;
+  v89: int = id v54;
+.__111__:
+  v50: int = id v84;
+  v51: int = id v85;
+  v52: int = id v87;
+  v53: int = id v88;
+  v54: int = id v89;
+  br v86 .__56__ .__120__;
+.__120__:
+  v123: int = add v50 v51;
+  v125: bool = const true;
+  v37: int = id v123;
+  v38: bool = id v125;
+  v39: int = id v51;
+  v40: int = id v53;
+  v41: int = id v54;
+.__131__:
+  v10: int = id v37;
+  v11: int = id v39;
+  v12: int = id v40;
+  v13: int = id v41;
+  br v38 .__15__ .__139__;
+.__76__:
+  v79: bool = const false;
+  v84: int = id v50;
+  v85: int = id v51;
+  v86: bool = id v79;
+  v87: int = id v52;
+  v88: int = id v53;
+  v89: int = id v54;
+  jmp .__111__;
+.__30__:
+  v32: bool = const false;
+  v37: int = id v10;
+  v38: bool = id v32;
+  v39: int = id v11;
+  v40: int = id v12;
+  v41: int = id v13;
+  jmp .__131__;
+.__139__:
+  print v10;
+}

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -1,0 +1,21 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 2;
+  v5: bool = lt v0 v3;
+  v8: int = const 3;
+  v10: bool = lt v3 v8;
+  v12: bool = and v5 v10;
+  br v12 .__27__ .__21__;
+.__27__:
+  print v0;
+  v25: int = id v8;
+  jmp .__32__;
+.__21__:
+  print v3;
+  v25: int = id v8;
+.__32__:
+  print v25;
+}

--- a/tests/snapshots/files__gamma_pull_in-optimize.snap
+++ b/tests/snapshots/files__gamma_pull_in-optimize.snap
@@ -1,0 +1,19 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 10;
+  v5: bool = lt v0 v3;
+  br v5 .__16__ .__11__;
+.__16__:
+  v17: int = const 2;
+  v14: int = id v17;
+  jmp .__20__;
+.__11__:
+  v12: int = const 3;
+  v14: int = id v12;
+.__20__:
+  v22: int = add v14 v14;
+  print v22;
+}

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -1,0 +1,46 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@pow(v0: int, v1: int) {
+  v5: int = const 0;
+  v9: int = id v0;
+  v10: int = id v5;
+  v11: int = id v0;
+  v12: int = id v1;
+.__14__:
+  v16: int = const 1;
+  v18: int = sub v12 v16;
+  v20: bool = lt v10 v18;
+  br v20 .__48__ .__35__;
+.__48__:
+  v51: int = mul v9 v11;
+  v53: bool = const true;
+  v57: int = add v10 v16;
+  v42: int = id v51;
+  v43: bool = id v53;
+  v44: int = id v57;
+  v45: int = id v11;
+  v46: int = id v12;
+.__62__:
+  v9: int = id v42;
+  v10: int = id v44;
+  v11: int = id v45;
+  v12: int = id v46;
+  br v43 .__14__ .__70__;
+.__35__:
+  v37: bool = const false;
+  v42: int = id v9;
+  v43: bool = id v37;
+  v44: int = id v10;
+  v45: int = id v11;
+  v46: int = id v12;
+  jmp .__62__;
+.__70__:
+  print v9;
+}
+@main {
+  v1: int = const 4;
+  v3: int = const 15;
+  call @pow v1 v3;
+}

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -1,0 +1,43 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v2: int = const 0;
+  v5: int = id v2;
+  v6: int = id v2;
+.__8__:
+  v10: bool = eq v6 v5;
+  br v10 .__35__ .__20__;
+.__35__:
+  v31: int = id v5;
+  v32: bool = id v10;
+  v33: int = id v6;
+.__40__:
+  br v32 .__57__ .__48__;
+.__57__:
+  v59: bool = const false;
+  v53: int = id v31;
+  v54: bool = id v59;
+  v55: int = id v33;
+.__63__:
+  v5: int = id v53;
+  v6: int = id v55;
+  br v54 .__8__ .__69__;
+.__48__:
+  v50: bool = const true;
+  v53: int = id v31;
+  v54: bool = id v50;
+  v55: int = id v33;
+  jmp .__63__;
+.__20__:
+  v22: int = const 1;
+  v24: int = add v5 v22;
+  v29: int = add v6 v22;
+  v31: int = id v24;
+  v32: bool = id v10;
+  v33: int = id v29;
+  jmp .__40__;
+.__69__:
+  print v5;
+}

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -1,0 +1,19 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 1;
+  v6: int = id v3;
+  v7: int = id v0;
+.__9__:
+  v12: int = add v6 v6;
+  v16: int = const 10;
+  v18: bool = lt v6 v16;
+  v6: int = id v12;
+  v7: int = id v7;
+  br v18 .__9__ .__22__;
+.__22__:
+  v24: int = add v6 v7;
+  print v24;
+}

--- a/tests/snapshots/files__nested_call-optimize.snap
+++ b/tests/snapshots/files__nested_call-optimize.snap
@@ -1,0 +1,23 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@inc(v0: int): int {
+  v2: int = const 1;
+  v5: int = add v2 v0;
+  v8: int = call @double v5;
+  ret v8;
+}
+@double(v0: int): int {
+  v2: int = const 2;
+  v5: int = mul v2 v0;
+  ret v5;
+}
+@main {
+  v1: int = const 1;
+  v3: int = const 0;
+  v6: int = call @inc v3;
+  print v6;
+  v10: int = call @double v1;
+  print v10;
+}

--- a/tests/snapshots/files__range_check-optimize.snap
+++ b/tests/snapshots/files__range_check-optimize.snap
@@ -1,0 +1,40 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v2: int = const 0;
+  v4: int = id v2;
+.__6__:
+  v7: int = const 5;
+  v9: bool = lt v4 v7;
+  v14: int = const 1;
+  br v9 .__25__ .__19__;
+.__25__:
+  print v14;
+  v23: int = id v4;
+.__30__:
+  v31: int = const 6;
+  v33: bool = lt v23 v31;
+  v41: int = add v23 v14;
+  br v33 .__50__ .__43__;
+.__50__:
+  v52: bool = const true;
+  v47: int = id v41;
+  v48: bool = id v52;
+.__55__:
+  v4: int = id v47;
+  br v48 .__6__ .__60__;
+.__43__:
+  v45: bool = const false;
+  v47: int = id v41;
+  v48: bool = id v45;
+  jmp .__55__;
+.__19__:
+  v18: int = const 2;
+  print v18;
+  v23: int = id v4;
+  jmp .__30__;
+.__60__:
+  print v4;
+}

--- a/tests/snapshots/files__range_splitting-optimize.snap
+++ b/tests/snapshots/files__range_splitting-optimize.snap
@@ -1,0 +1,39 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v2: int = const 0;
+  v4: int = id v2;
+.__6__:
+  v7: int = const 5;
+  v9: bool = lt v4 v7;
+  v14: int = const 1;
+  br v9 .__25__ .__19__;
+.__25__:
+  print v14;
+  v23: int = id v4;
+.__30__:
+  v32: int = add v23 v14;
+  v35: bool = lt v32 v7;
+  br v35 .__49__ .__42__;
+.__49__:
+  v51: bool = const true;
+  v46: int = id v32;
+  v47: bool = id v51;
+.__54__:
+  v4: int = id v46;
+  br v47 .__6__ .__59__;
+.__42__:
+  v44: bool = const false;
+  v46: int = id v32;
+  v47: bool = id v44;
+  jmp .__54__;
+.__19__:
+  v18: int = const 2;
+  print v18;
+  v23: int = id v4;
+  jmp .__30__;
+.__59__:
+  print v4;
+}

--- a/tests/snapshots/files__reassoc-optimize.snap
+++ b/tests/snapshots/files__reassoc-optimize.snap
@@ -1,0 +1,14 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+  v3: int = const 1;
+  v6: int = const 3;
+  v8: int = add v0 v6;
+  v11: int = const 4;
+  v13: int = add v1 v11;
+  v15: int = add v8 v13;
+  v17: int = add v3 v15;
+  print v17;
+}

--- a/tests/snapshots/files__simple-call-optimize.snap
+++ b/tests/snapshots/files__simple-call-optimize.snap
@@ -1,0 +1,14 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@inc(v0: int): int {
+  v2: int = const 1;
+  v5: int = add v2 v0;
+  ret v5;
+}
+@main {
+  v1: int = const 0;
+  v4: int = call @inc v1;
+  print v4;
+}

--- a/tests/snapshots/files__simple_branch-optimize.snap
+++ b/tests/snapshots/files__simple_branch-optimize.snap
@@ -1,0 +1,17 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 0;
+  v5: bool = lt v0 v3;
+  br v5 .__16__ .__12__;
+.__16__:
+  v17: int = const 1;
+  v14: int = id v17;
+  jmp .__20__;
+.__12__:
+  v14: int = id v3;
+.__20__:
+  print v14;
+}

--- a/tests/snapshots/files__simple_call-optimize.snap
+++ b/tests/snapshots/files__simple_call-optimize.snap
@@ -1,0 +1,13 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@inc(v0: int) {
+  v2: int = const 1;
+  v5: int = add v2 v0;
+  print v5;
+}
+@main {
+  v1: int = const 0;
+  call @inc v1;
+}

--- a/tests/snapshots/files__simple_loop-optimize.snap
+++ b/tests/snapshots/files__simple_loop-optimize.snap
@@ -1,0 +1,13 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v1: int = const 0;
+.__5__:
+  v6: int = const 0;
+  v9: bool = lt v6 v6;
+  br v9 .__5__ .__13__;
+.__13__:
+  print v1;
+}

--- a/tests/snapshots/files__simple_recursive-optimize.snap
+++ b/tests/snapshots/files__simple_recursive-optimize.snap
@@ -1,0 +1,25 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@inc(v0: int): int {
+  v3: int = const 2;
+  v5: bool = lt v0 v3;
+  br v5 .__17__ .__12__;
+.__17__:
+  v16: int = const 1;
+  v19: int = add v16 v0;
+  print v19;
+  v24: int = call @inc v19;
+  v14: int = id v24;
+  jmp .__28__;
+.__12__:
+  v14: int = id v0;
+.__28__:
+  ret v14;
+}
+@main {
+  v1: int = const 0;
+  v4: int = call @inc v1;
+  print v4;
+}

--- a/tests/snapshots/files__strong_loop-optimize.snap
+++ b/tests/snapshots/files__strong_loop-optimize.snap
@@ -1,0 +1,30 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int) {
+  v3: int = const 3;
+  v7: int = add v0 v3;
+  v9: int = const 0;
+  v12: int = id v3;
+  v13: int = id v7;
+  v14: int = id v9;
+  v15: int = id v0;
+.__18__:
+  v17: int = const 7;
+  v20: int = mul v17 v12;
+  print v20;
+  v25: int = const 2;
+  v27: int = add v12 v25;
+  v32: int = add v14 v20;
+  v37: bool = lt v12 v15;
+  v12: int = id v27;
+  v13: int = id v13;
+  v14: int = id v32;
+  v15: int = id v15;
+  br v37 .__18__ .__41__;
+.__41__:
+  print v14;
+  print v13;
+  print v12;
+}

--- a/tests/snapshots/files__two_fns-optimize.snap
+++ b/tests/snapshots/files__two_fns-optimize.snap
@@ -1,0 +1,16 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@sub: int {
+  v1: int = const 1;
+  v3: int = const 2;
+  v5: int = sub v1 v3;
+  ret v5;
+}
+@main {
+  v1: int = const 1;
+  v3: int = const 2;
+  v5: int = add v1 v3;
+  print v5;
+}

--- a/tests/snapshots/files__unroll_and_constant_fold-optimize.snap
+++ b/tests/snapshots/files__unroll_and_constant_fold-optimize.snap
@@ -1,0 +1,18 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main {
+  v2: int = const 0;
+  v4: int = const 1;
+  v6: int = id v2;
+  v7: int = id v4;
+.__9__:
+  v12: int = add v6 v7;
+  v17: bool = lt v12 v7;
+  v6: int = id v12;
+  v7: int = id v7;
+  br v17 .__9__ .__21__;
+.__21__:
+  print v6;
+}


### PR DESCRIPTION
This PR enables snapshot testing for bril files.
Most of the complexity is removing a hashmap-iteration by replacing it with a sorted vector.