### PR TITLE
Fix parallel to nest like a linked list

### DIFF
--- a/dag_in_context/src/utility/util.egg
+++ b/dag_in_context/src/utility/util.egg
@@ -36,9 +36,11 @@
        (= ith (tuple-ith expr2 i)))
        ((union (tuple-ith (Concat ord expr1 expr2) (+ len1 i)) ith)) :ruleset always-run)
 
-
 (relation IsLeaf (Expr))
-
 (rule ((Arg ty)) ((IsLeaf (Arg ty))) :ruleset always-run)
 (rule ((Const val ty)) ((IsLeaf (Const val ty))) :ruleset always-run)
 (rule ((Empty ty)) ((IsLeaf (Empty ty))) :ruleset always-run)
+
+(rewrite (Concat order (Concat order a b) c)
+         (Concat order a (Concat order b c))
+         :ruleset always-run)

--- a/src/rvsdg/to_dag.rs
+++ b/src/rvsdg/to_dag.rs
@@ -135,7 +135,7 @@ impl<'a> DagTranslator<'a> {
         &mut self,
         argument_values: Vec<StoredValue>,
         num_let_bound: usize,
-        operands: impl Iterator<Item = Operand>,
+        operands: impl Iterator<Item = Operand> + DoubleEndedIterator,
     ) -> RcExpr {
         let mut translator = DagTranslator::new(self.nodes, argument_values, num_let_bound);
         let resulting_exprs = operands.map(|operand| {

--- a/tests/snapshots/files__collatz-optimize.snap
+++ b/tests/snapshots/files__collatz-optimize.snap
@@ -38,12 +38,12 @@ expression: visualization.result
   v49: int = mul v46 v15;
   v51: int = sub v14 v49;
   v54: bool = eq v51 v18;
-  v86: int = add v13 v16;
-  v88: bool = const true;
+  v79: bool = const true;
+  v83: int = add v13 v16;
   br v54 .__112__ .__90__;
 .__112__:
-  v104: int = id v86;
-  v105: bool = id v88;
+  v104: int = id v83;
+  v105: bool = id v79;
   v106: int = id v46;
   v107: int = id v15;
   v108: int = id v16;
@@ -61,8 +61,8 @@ expression: visualization.result
 .__90__:
   v96: int = mul v17 v14;
   v98: int = add v16 v96;
-  v104: int = id v86;
-  v105: bool = id v88;
+  v104: int = id v83;
+  v105: bool = id v79;
   v106: int = id v98;
   v107: int = id v15;
   v108: int = id v16;

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -38,12 +38,12 @@ expression: visualization.result
   v49: int = mul v46 v17;
   v51: int = sub v14 v49;
   v54: bool = eq v51 v18;
+  v79: bool = const true;
   print v14;
-  v87: bool = const true;
   br v54 .__111__ .__89__;
 .__111__:
   v103: int = id v13;
-  v104: bool = id v87;
+  v104: bool = id v79;
   v105: int = id v46;
   v106: int = id v15;
   v107: int = id v16;
@@ -62,7 +62,7 @@ expression: visualization.result
   v95: int = mul v16 v14;
   v97: int = add v15 v95;
   v103: int = id v13;
-  v104: bool = id v87;
+  v104: bool = id v79;
   v105: int = id v97;
   v106: int = id v15;
   v107: int = id v16;

--- a/tests/snapshots/files__range_check-optimize.snap
+++ b/tests/snapshots/files__range_check-optimize.snap
@@ -16,18 +16,18 @@ expression: visualization.result
 .__30__:
   v31: int = const 6;
   v33: bool = lt v23 v31;
-  v41: int = add v23 v14;
+  v40: int = add v23 v14;
   br v33 .__50__ .__43__;
 .__50__:
   v52: bool = const true;
-  v47: int = id v41;
+  v47: int = id v40;
   v48: bool = id v52;
 .__55__:
   v4: int = id v47;
   br v48 .__6__ .__60__;
 .__43__:
   v45: bool = const false;
-  v47: int = id v41;
+  v47: int = id v40;
   v48: bool = id v45;
   jmp .__55__;
 .__19__:


### PR DESCRIPTION
This makes the `parallel!` macro nest to the right and adds a canonicalization rule to the optimizer.