### PR TITLE
[Interval Analysis] Working examples of using context nodes for interval analysis

### DIFF
--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -83,6 +83,16 @@
       )
       :ruleset interval-analysis)
 
+; negative number * negative number is positive
+(rule (
+        (= lhs (Bop (Mul) x y))
+        (= (IntB hi-x) (hi-bound x))
+        (= (IntB hi-y) (hi-bound y))
+        (<= hi-x 0)
+        (<= hi-y 0) 
+      )
+      ((set (lo-bound lhs) (IntB 0)))
+      :ruleset interval-analysis)
 
 ; < a b interval is (< ha lb) (< la hb)
 (rule (
@@ -106,6 +116,8 @@
 ; =================================
 ; Conditionals
 ; =================================
+; lo-bound of If is the min of the lower bounds
+; hi-bound of If is the max of the upper bounds
 (rule (
        (= lhs (If cond thn els))
        (= lo-thn (lo-bound thn))
@@ -119,4 +131,35 @@
        (= hi-els (hi-bound els))
       )
       ((set (hi-bound lhs) (bound-max hi-thn hi-els)))
+      :ruleset interval-analysis)
+
+; Things with bounds still have those bounds when in a context
+(rule (
+        (= lhs (InContext ctx expr))
+        (= lo (lo-bound expr))
+      )
+      ((set (lo-bound lhs) lo))
+      :ruleset interval-analysis)
+(rule (
+        (= lhs (InContext ctx expr))
+        (= hi (hi-bound expr))
+      )
+      ((set (hi-bound lhs) hi))
+      :ruleset interval-analysis)
+
+; Set bounds on the Context node if the If predicate is <= some value for which we know an upper bound
+(rule (
+       (= lhs (InContext (InIf true (Bop (LessEq) v (InContext ctx expr))) expr))
+       (= (IntB hi) (hi-bound v))
+      )
+      ((set (hi-bound lhs) (IntB hi)))
+      :ruleset interval-analysis)
+
+(rule (
+       (= lhs (InContext (InIf false (Bop (LessEq) v (InContext ctx expr))) expr))
+       (= (IntB hi) (hi-bound v))
+      )
+      (
+       (set (lo-bound lhs) (IntB hi))
+      )
       :ruleset interval-analysis)

--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -60,6 +60,22 @@
       ((union expr (Const (Bool x) ty)))
       :ruleset interval-analysis)
 
+; lower bound being true means the bool must be true
+(rule (
+       (= (BoolB true) (lo-bound expr))
+       (HasArgType expr ty)
+      )
+      ((union expr (Const (Bool true) ty)))
+      :ruleset interval-analysis)
+
+; upper bound being false means the bool must be false
+(rule (
+       (= (BoolB false) (hi-bound expr))
+       (HasArgType expr ty)
+      )
+      ((union expr (Const (Bool false) ty)))
+      :ruleset interval-analysis)
+
 ; =================================
 ; Arithmetic
 ; =================================
@@ -83,6 +99,9 @@
       )
       :ruleset interval-analysis)
 
+; mul commutes
+(rewrite (Bop (Mul) x y) (Bop (Mul) y x) :ruleset interval-analysis)
+
 ; negative number * negative number is positive
 (rule (
         (= lhs (Bop (Mul) x y))
@@ -92,6 +111,17 @@
         (<= hi-y 0) 
       )
       ((set (lo-bound lhs) (IntB 0)))
+      :ruleset interval-analysis)
+
+; negative number * positive number is negative
+(rule (
+        (= lhs (Bop (Mul) x y))
+        (= (IntB hi-x) (hi-bound x))
+        (= (IntB lo-y) (lo-bound y))
+        (<= hi-x 0) ; x <= 0 (x is negative)
+        (>= lo-y 0) ; y >= 0 (y is positive)
+      )
+      ((set (hi-bound lhs) (IntB 0)))
       :ruleset interval-analysis)
 
 ; < a b interval is (< ha lb) (< la hb)
@@ -111,6 +141,26 @@
       )
       (
        (set (hi-bound lhs) (BoolB (bool-< la hb)))
+      )
+      :ruleset interval-analysis)
+
+; <= a b interval is (<= ha lb) (<= la hb)
+(rule (
+       (= lhs (Bop (LessEq) a b))
+       (= (IntB ha) (hi-bound a))
+       (= (IntB lb) (lo-bound b))
+      )
+      (
+       (set (lo-bound lhs) (BoolB (bool-<= ha lb)))
+      )
+      :ruleset interval-analysis)
+(rule (
+       (= lhs (Bop (LessEq) a b))
+       (= (IntB la) (lo-bound a))
+       (= (IntB hb) (hi-bound b))
+      )
+      (
+       (set (hi-bound lhs) (BoolB (bool-<= la hb)))
       )
       :ruleset interval-analysis)
 ; =================================
@@ -147,19 +197,37 @@
       ((set (hi-bound lhs) hi))
       :ruleset interval-analysis)
 
-; Set bounds on the Context node if the If predicate is <= some value for which we know an upper bound
+; if e <= v is true, then e is at most the upper bound of v
 (rule (
-       (= lhs (InContext (InIf true (Bop (LessEq) v (InContext ctx expr))) expr))
+       (= lhs (InContext (InIf true (Bop (LessEq) (InContext ctx expr) v)) expr))
        (= (IntB hi) (hi-bound v))
       )
       ((set (hi-bound lhs) (IntB hi)))
       :ruleset interval-analysis)
 
+; if e <= v is false, then e is at least the lower bound of v + 1
+(rule (
+       (= lhs (InContext (InIf false (Bop (LessEq) (InContext ctx expr) v)) expr))
+       (= (IntB lo) (lo-bound v))
+      )
+      ((set (lo-bound lhs) (IntB (+ lo 1))))
+      :ruleset interval-analysis)
+
+
+; if v <= e is true, then e is at least the lower bound of v
+(rule (
+       (= lhs (InContext (InIf true (Bop (LessEq) v (InContext ctx expr))) expr))
+       (= (IntB lo) (lo-bound v))
+      )
+      ((set (lo-bound lhs) (IntB lo)))
+      :ruleset interval-analysis)
+
+; if v <= e is false, then e is at most the upper bound of v - 1
 (rule (
        (= lhs (InContext (InIf false (Bop (LessEq) v (InContext ctx expr))) expr))
        (= (IntB hi) (hi-bound v))
       )
       (
-       (set (lo-bound lhs) (IntB hi))
+       (set (hi-bound lhs) (IntB (- hi 1)))
       )
       :ruleset interval-analysis)

--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -1,54 +1,60 @@
 (ruleset interval-analysis)
 
+(datatype Bound
+  (IntB i64)
+  (BoolB bool)
+  (bound-max Bound Bound)
+  (bound-min Bound Bound))
 
+; bound tables
+(function lo-bound (Expr) Bound :merge (bound-max old new))
+(function hi-bound (Expr) Bound :merge (bound-min old new))
 
-(datatype Interval
-  (BoolI bool bool)
-  (IntI i64 i64)
-  (interval-intersect Interval Interval)
-  (interval-union Interval Interval))
-
-; Interval combinators
-(rewrite (interval-intersect (IntI la ha) (IntI lb hb))
-         (IntI (max la lb) (min ha hb))
+; combinators
+(rewrite (bound-max (IntB x) (IntB y))
+         (IntB (max x y))
          :ruleset interval-analysis)
-(rewrite (interval-union (IntI la ha) (IntI lb hb))
-         (IntI (min la lb) (max ha hb))
+(rewrite (bound-min (IntB x) (IntB y))
+         (IntB (min x y))
          :ruleset interval-analysis)
-(rewrite (interval-intersect (BoolI la ha) (BoolI lb hb))
-         (BoolI (or la lb) (and ha hb))
+(rewrite (bound-max (BoolB x) (BoolB y))
+         (BoolB (or x y))
          :ruleset interval-analysis)
-(rewrite (interval-union (BoolI la ha) (BoolI lb hb))
-         (BoolI (and la lb) (or ha hb))
+(rewrite (bound-min (BoolB x) (BoolB y))
+         (BoolB (and x y))
          :ruleset interval-analysis)
-
-; Interval Table
-(function ival (Expr) Interval
-  :merge (interval-intersect old new))
 
 ; =================================
 ; Constants
 ; =================================
 (rule ((= lhs (Const (Int x) ty)))
-      ((set (ival lhs) (IntI x x)))
+      (
+        (set (lo-bound lhs) (IntB x))
+        (set (hi-bound lhs) (IntB x))
+      )
       :ruleset interval-analysis)
 
 (rule ((= lhs (Const (Bool x) ty)))
-      ((set (ival lhs) (BoolI x x)))
+      (
+        (set (lo-bound lhs) (BoolB x))
+        (set (hi-bound lhs) (BoolB x))
+      )
       :ruleset interval-analysis)
 
 ; =================================
 ; Constant Folding
 ; =================================
 (rule (
-       (= (IntI x x) (ival expr))
+       (= (IntB x) (lo-bound expr))
+       (= (IntB x) (hi-bound expr))
        (HasArgType expr ty)
       )
       ((union expr (Const (Int x) ty)))
       :ruleset interval-analysis)
 
 (rule (
-       (= (BoolI x x) (ival expr))
+       (= (BoolB x) (lo-bound expr))
+       (= (BoolB x) (hi-bound expr))
        (HasArgType expr ty)
       )
       ((union expr (Const (Bool x) ty)))
@@ -59,29 +65,58 @@
 ; =================================
 ; + a b interval is (+ la lb) (+ ha hb)
 (rule (
-       (= lhs (Bop (Add) x y))
-       (= (ival x) (IntI la ha))
-       (= (ival y) (IntI lb hb))
+       (= lhs (Bop (Add) a b))
+       (= (IntB la) (lo-bound a))
+       (= (IntB lb) (lo-bound b))
       )
-      ((set (ival lhs) (IntI (+ la hb) (+ ha hb))))
+      (
+       (set (lo-bound lhs) (IntB (+ la lb)))
+      )
       :ruleset interval-analysis)
+(rule (
+       (= lhs (Bop (Add) a b))
+       (= (IntB ha) (hi-bound a))
+       (= (IntB hb) (hi-bound b))
+      )
+      (
+       (set (hi-bound lhs) (IntB (+ ha hb)))
+      )
+      :ruleset interval-analysis)
+
 
 ; < a b interval is (< ha lb) (< la hb)
 (rule (
-        (= lhs (Bop (LessThan) a b))
-        (= (IntI la ha) (ival a))
-        (= (IntI lb hb) (ival b))
+       (= lhs (Bop (LessThan) a b))
+       (= (IntB ha) (hi-bound a))
+       (= (IntB lb) (lo-bound b))
       )
-      ((set (ival lhs) (BoolI (bool-< ha lb) (bool-< la hb))))
+      (
+       (set (lo-bound lhs) (BoolB (bool-< ha lb)))
+      )
       :ruleset interval-analysis)
-
+(rule (
+       (= lhs (Bop (LessThan) a b))
+       (= (IntB la) (lo-bound a))
+       (= (IntB hb) (hi-bound b))
+      )
+      (
+       (set (hi-bound lhs) (BoolB (bool-< la hb)))
+      )
+      :ruleset interval-analysis)
 ; =================================
 ; Conditionals
 ; =================================
 (rule (
-        (= lhs (If cond thn els))
-        (= thn-ival (ival thn))
-        (= els-ival (ival els))
+       (= lhs (If cond thn els))
+       (= lo-thn (lo-bound thn))
+       (= lo-els (lo-bound els))
       )
-      ((set (ival lhs) (interval-union thn-ival els-ival)))
+      ((set (lo-bound lhs) (bound-min lo-thn lo-els)))
+      :ruleset interval-analysis)
+(rule (
+       (= lhs (If cond thn els))
+       (= hi-thn (hi-bound thn))
+       (= hi-els (hi-bound els))
+      )
+      ((set (hi-bound lhs) (bound-max hi-thn hi-els)))
       :ruleset interval-analysis)

--- a/dag_in_context/src/interval_analysis.rs
+++ b/dag_in_context/src/interval_analysis.rs
@@ -160,3 +160,32 @@ fn nested_if() -> crate::Result {
         vec![],
     )
 }
+
+#[test]
+fn context_if() -> crate::Result {
+    let cond = less_eq(int_ty(0, base(intt())), iarg());
+
+    let y = tif(cond, mul(iarg(), int_ty(-1, base(intt()))), iarg());
+
+    let z = less_eq(int_ty(0, base(intt())), y);
+
+    let f = function("main", base(intt()), base(boolt()), z.clone()).func_with_arg_types();
+    let prog = f.to_program(base(intt()), base(boolt()));
+    let with_context = prog.add_context();
+
+    egglog_test(
+        &format!("{with_context}"),
+        &format!("
+        (print-function lo-bound 100)
+        (print-function hi-bound 100)
+        (print-function InContext 100)
+        (print-function DebugE 100)
+        (print-function DebugB 100)
+        "
+        ),
+        vec![with_context],
+        intv(4),
+        val_bool(false),
+        vec![],
+    )
+}

--- a/dag_in_context/src/interval_analysis.rs
+++ b/dag_in_context/src/interval_analysis.rs
@@ -11,10 +11,12 @@ fn int_interval_test(
     hi: i64,
 ) -> crate::Result {
     let with_arg_types = inp.clone().with_arg_types(emptyt(), expected_ty.clone());
-    let check = format!("
+    let check = format!(
+        "
     (check (lo-bound {with_arg_types}) (IntB {lo}))
     (check (hi-bound {with_arg_types}) (IntB {hi}))
-    ");
+    "
+    );
     interval_test(with_arg_types, expected_ty, arg, expected_val, check)
 }
 
@@ -28,10 +30,12 @@ fn bool_interval_test(
     hi: bool,
 ) -> crate::Result {
     let with_arg_types = inp.clone().with_arg_types(emptyt(), expected_ty.clone());
-    let check = format!("
+    let check = format!(
+        "
     (check (lo-bound {with_arg_types}) (BoolB {lo}))
     (check (hi-bound {with_arg_types}) (BoolB {hi}))
-    ");
+    "
+    );
     interval_test(with_arg_types, expected_ty, arg, expected_val, check)
 }
 
@@ -122,10 +126,12 @@ fn if_interval() -> crate::Result {
 
     egglog_test(
         &format!("{f}"),
-        &format!("
+        &format!(
+            "
         (check (lo-bound {e}) (IntB 4))
         (check (hi-bound {e}) (IntB 5))
-        "),
+        "
+        ),
         vec![f.to_program(base(intt()), base(intt()))],
         intv(1),
         intv(4),
@@ -149,11 +155,13 @@ fn nested_if() -> crate::Result {
 
     egglog_test(
         &format!("{f}"),
-        &format!("
+        &format!(
+            "
         (check (lo-bound {inner}) (IntB 4))
         (check (hi-bound {inner}) (IntB 5))
         (check (lo-bound {outer}) (IntB 20))
-        (check (hi-bound {outer}) (IntB 20))"),
+        (check (hi-bound {outer}) (IntB 20))"
+        ),
         vec![f.to_program(base(intt()), base(intt()))],
         intv(2),
         intv(20),
@@ -163,26 +171,53 @@ fn nested_if() -> crate::Result {
 
 #[test]
 fn context_if() -> crate::Result {
-    let cond = less_eq(int_ty(0, base(intt())), iarg());
+    // input <= 0
+    let cond = less_eq(iarg(), int_ty(0, base(intt())));
 
+    // y = if cond {-1 * input} else {input}
+    // interval analysis should tell us that y is always positive (= (lo-bound y) (IntB 0))
     let y = tif(cond, mul(iarg(), int_ty(-1, base(intt()))), iarg());
 
-    let z = less_eq(int_ty(0, base(intt())), y);
+    // z = y < 0
+    // interval analysis should tell us that z is false
+    let z = less_than(y.clone(), int_ty(0, base(intt())));
 
     let f = function("main", base(intt()), base(boolt()), z.clone()).func_with_arg_types();
     let prog = f.to_program(base(intt()), base(boolt()));
     let with_context = prog.add_context();
+    let term = with_context.entry.func_body().unwrap();
 
     egglog_test(
         &format!("{with_context}"),
-        &format!("
-        (print-function lo-bound 100)
-        (print-function hi-bound 100)
-        (print-function InContext 100)
-        (print-function DebugE 100)
-        (print-function DebugB 100)
-        "
-        ),
+        &format!("(check (= {term} (Const (Bool false) (Base (IntT)))))"),
+        vec![with_context],
+        intv(4),
+        val_bool(false),
+        vec![],
+    )
+}
+
+#[test]
+fn context_if_rev() -> crate::Result {
+    // 0 <= input
+    let cond = less_eq(int_ty(0, base(intt())), iarg());
+
+    // y = if cond {-1 * input} else {input}
+    // interval analysis should tell us that y is always negative (= (hi-bound y) (IntB 0))
+    let y = tif(cond, mul(iarg(), int_ty(-1, base(intt()))), iarg());
+
+    // z = 0 < y
+    // interval analysis should tell us that z is false
+    let z = less_than(int_ty(0, base(intt())), y.clone());
+
+    let f = function("main", base(intt()), base(boolt()), z.clone()).func_with_arg_types();
+    let prog = f.to_program(base(intt()), base(boolt()));
+    let with_context = prog.add_context();
+    let term = with_context.entry.func_body().unwrap();
+
+    egglog_test(
+        &format!("{with_context}"),
+        &format!("(check (= {term} (Const (Bool false) (Base (IntT)))))"),
         vec![with_context],
         intv(4),
         val_bool(false),

--- a/dag_in_context/src/interval_analysis.rs
+++ b/dag_in_context/src/interval_analysis.rs
@@ -11,7 +11,10 @@ fn int_interval_test(
     hi: i64,
 ) -> crate::Result {
     let with_arg_types = inp.clone().with_arg_types(emptyt(), expected_ty.clone());
-    let check = format!("(check (ival {with_arg_types}) (IntI {lo} {hi}))");
+    let check = format!("
+    (check (lo-bound {with_arg_types}) (IntB {lo}))
+    (check (hi-bound {with_arg_types}) (IntB {hi}))
+    ");
     interval_test(with_arg_types, expected_ty, arg, expected_val, check)
 }
 
@@ -25,7 +28,10 @@ fn bool_interval_test(
     hi: bool,
 ) -> crate::Result {
     let with_arg_types = inp.clone().with_arg_types(emptyt(), expected_ty.clone());
-    let check = format!("(check (ival {with_arg_types}) (BoolI {lo} {hi}))");
+    let check = format!("
+    (check (lo-bound {with_arg_types}) (BoolB {lo}))
+    (check (hi-bound {with_arg_types}) (BoolB {hi}))
+    ");
     interval_test(with_arg_types, expected_ty, arg, expected_val, check)
 }
 
@@ -116,7 +122,10 @@ fn if_interval() -> crate::Result {
 
     egglog_test(
         &format!("{f}"),
-        &format!("(check (ival {e}) (IntI 4 5))"),
+        &format!("
+        (check (lo-bound {e}) (IntB 4))
+        (check (hi-bound {e}) (IntB 5))
+        "),
         vec![f.to_program(base(intt()), base(intt()))],
         intv(1),
         intv(4),
@@ -140,7 +149,11 @@ fn nested_if() -> crate::Result {
 
     egglog_test(
         &format!("{f}"),
-        &format!("(check (ival {inner}) (IntI 4 5)) (check (ival {outer}) (IntI 20 20))"),
+        &format!("
+        (check (lo-bound {inner}) (IntB 4))
+        (check (hi-bound {inner}) (IntB 5))
+        (check (lo-bound {outer}) (IntB 20))
+        (check (hi-bound {outer}) (IntB 20))"),
         vec![f.to_program(base(intt()), base(intt()))],
         intv(2),
         intv(20),


### PR DESCRIPTION
This PR changes to using separate `lo-bound` and `hi-bound` tables instead of one `ival` table (as discussed in lab today)

The first test roughly corresponds to:
```
if (input <= 0) {
  y = -1 * input
} else {
  y = input
}
return y < 0
```
And the interval analysis reduces this to just `false`

The second test roughly corresponds to:
```
if (0 <= input) {
  y = -1 * input
} else {
  y = input
}
return 0 < y
```
Which is also `false`.
