### PR TITLE
Implement cost model

### DIFF
--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -24,7 +24,8 @@
 
 ; Interval Table
 (function ival (Expr) Interval
-  :merge (interval-intersect old new))
+    :unextractable
+    :merge (interval-intersect old new))
 
 ; =================================
 ; Constants

--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use egglog::{Term, TermDag};
 use from_egglog::FromEgglog;
-use greedy_dag_extractor::{extract, serialized_egraph, CostModel};
+use greedy_dag_extractor::{extract, serialized_egraph, DefaultCostModel};
 use interpreter::Value;
 use schema::TreeProgram;
 use std::fmt::Write;
@@ -108,12 +108,7 @@ pub fn optimize(program: &TreeProgram) -> std::result::Result<TreeProgram, egglo
 
     let (serialized, unextractables) = serialized_egraph(egraph);
     let mut termdag = egglog::TermDag::default();
-    let results = extract(
-        &serialized,
-        unextractables,
-        &mut termdag,
-        &CostModel::simple_cost_model(),
-    );
+    let results = extract(&serialized, unextractables, &mut termdag, DefaultCostModel);
     assert_eq!(results.len(), 1);
     let (_cid, costset) = results.into_iter().next().unwrap();
     let mut from_egglog = FromEgglog {

--- a/dag_in_context/src/type_analysis.egg
+++ b/dag_in_context/src/type_analysis.egg
@@ -7,7 +7,7 @@
          (TCons hd (TLConcat tl r))
          :ruleset type-helpers)
 
-(function TypeList-length (TypeList) i64)
+(function TypeList-length (TypeList) i64 :unextractable)
 (function TypeList-ith (TypeList i64) BaseType :unextractable)
 (function TypeList-suffix (TypeList i64) TypeList :unextractable)
 


### PR DESCRIPTION
Implements a cost model for all constructors and relations and datatypes using a match statement and a trait.

It is concerning to me that none of the snapshots changed, but maybe it's fine.