### PR TITLE
Remove `Operand::Id` from RVSDG type.

### DIFF
--- a/src/rvsdg/from_cfg.rs
+++ b/src/rvsdg/from_cfg.rs
@@ -257,14 +257,17 @@ impl<'a> RvsdgBuilder<'a> {
                 ..
             } => {
                 // Predicate is just "true"
-                Operand::Id(get_id(
-                    &mut self.expr,
-                    RvsdgBody::BasicOp(BasicExpr::Const(
-                        ConstOps::Const,
-                        Literal::Bool(true),
-                        Type::Bool,
-                    )),
-                ))
+                Operand::Project(
+                    0,
+                    get_id(
+                        &mut self.expr,
+                        RvsdgBody::BasicOp(BasicExpr::Const(
+                            ConstOps::Const,
+                            Literal::Bool(true),
+                            Type::Bool,
+                        )),
+                    ),
+                )
             }
             BranchOp::Cond {
                 arg,
@@ -284,10 +287,13 @@ impl<'a> RvsdgBuilder<'a> {
                 let op = get_op(var, &None, &self.store, &self.analysis.intern)?;
                 if val == 0 {
                     // We need to negate the operand
-                    Operand::Id(get_id(
-                        &mut self.expr,
-                        RvsdgBody::BasicOp(BasicExpr::Op(ValueOps::Not, vec![op], Type::Bool)),
-                    ))
+                    Operand::Project(
+                        0,
+                        get_id(
+                            &mut self.expr,
+                            RvsdgBody::BasicOp(BasicExpr::Op(ValueOps::Not, vec![op], Type::Bool)),
+                        ),
+                    )
                 } else {
                     op
                 }
@@ -540,7 +546,7 @@ impl<'a> RvsdgBuilder<'a> {
                             const_type.clone(),
                         )),
                     );
-                    self.store.insert(dest_var, Operand::Id(const_id));
+                    self.store.insert(dest_var, Operand::Project(0, const_id));
                 }
                 Instruction::Value {
                     args,
@@ -593,7 +599,7 @@ impl<'a> RvsdgBuilder<'a> {
                         let ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
                         let expr = BasicExpr::Op(*op, ops, op_type.clone());
                         let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
-                        self.store.insert(dest_var, Operand::Id(expr_id));
+                        self.store.insert(dest_var, Operand::Project(0, expr_id));
                     }
                 },
                 Instruction::Effect {
@@ -619,7 +625,7 @@ impl<'a> RvsdgBuilder<'a> {
                     );
                     let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
                     self.store
-                        .insert(self.analysis.state_var, Operand::Id(expr_id));
+                        .insert(self.analysis.state_var, Operand::Project(0, expr_id));
                     debug_assert_eq!(funcs.len(), 1);
                 }
                 Instruction::Effect {
@@ -633,7 +639,7 @@ impl<'a> RvsdgBuilder<'a> {
                     let expr = BasicExpr::Effect(*op, ops);
                     let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
                     self.store
-                        .insert(self.analysis.state_var, Operand::Id(expr_id));
+                        .insert(self.analysis.state_var, Operand::Project(0, expr_id));
                 }
                 Instruction::Effect { op, pos, .. } => {
                     // Note: Control flow like Return and Jmp _are_ supported,
@@ -665,7 +671,7 @@ impl<'a> RvsdgBuilder<'a> {
                         )),
                     );
                     let dest_var = self.analysis.intern.intern(dst.clone());
-                    self.store.insert(dest_var, Operand::Id(id));
+                    self.store.insert(dest_var, Operand::Project(0, id));
                 }
                 Annotation::AssignRet { src } => {
                     let src_var = self.analysis.intern.intern(src.clone());

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -136,10 +136,7 @@ impl<Op> BasicExpr<Op> {
 pub(crate) enum Operand {
     /// A reference to an argument in the enclosing region.
     Arg(usize),
-    /// Another node in the RVSDG.
-    /// Equivalent to Project(0, id).
-    Id(Id),
-    /// Project a single output from a multi-output region.
+    /// Project a single output from a region in the RVSDG.
     Project(usize, Id),
 }
 

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -594,7 +594,7 @@ fn search_for(f: &RvsdgFunction, mut pred: impl FnMut(&RvsdgBody) -> bool) -> bo
     ) -> bool {
         match op {
             Operand::Arg(_) => false,
-            Operand::Id(x) | Operand::Project(_, x) => search_node(f, &f.nodes[*x], pred),
+            Operand::Project(_, x) => search_node(f, &f.nodes[*x], pred),
         }
     }
     fn search_node(
@@ -663,15 +663,8 @@ fn deep_equal(f1: &RvsdgFunction, f2: &RvsdgFunction) -> bool {
             (Operand::Project(p1, l), Operand::Project(p2, r)) => {
                 p1 == p2 && ids_equal(*l, *r, f1, f2)
             }
-            (Operand::Id(l), Operand::Id(r))
-            | (Operand::Project(0, l), Operand::Id(r))
-            | (Operand::Id(l), Operand::Project(0, r)) => ids_equal(*l, *r, f1, f2),
-            (Operand::Arg(_), Operand::Id(_))
-            | (Operand::Arg(_), Operand::Project(_, _))
-            | (Operand::Id(_), Operand::Arg(_))
-            | (Operand::Project(_, _), Operand::Arg(_))
-            | (Operand::Project(_, _), Operand::Id(_))
-            | (Operand::Id(_), Operand::Project(_, _)) => false,
+            (Operand::Arg(_), Operand::Project(_, _))
+            | (Operand::Project(_, _), Operand::Arg(_)) => false,
         }
     }
 

--- a/src/rvsdg/to_cfg.rs
+++ b/src/rvsdg/to_cfg.rs
@@ -269,14 +269,6 @@ impl<'a> RvsdgToCfg<'a> {
         }
 
         let res = match operand {
-            Operand::Id(id) => {
-                let res = self.body_to_bril(id, current_args, context);
-                TranslationResult {
-                    start: res.start,
-                    end: res.end,
-                    values: vec![res.values[0].clone()],
-                }
-            }
             Operand::Arg(index) => {
                 let new_block = self.make_block(vec![]);
                 TranslationResult {

--- a/src/rvsdg/to_dag.rs
+++ b/src/rvsdg/to_dag.rs
@@ -139,7 +139,6 @@ impl<'a> DagTranslator<'a> {
                 is_tuple: false,
                 expr: get(arg(), index),
             },
-            Operand::Id(id) => self.translate_node(id).project(0),
             Operand::Project(p_index, id) => self.translate_node(id).project(p_index),
         }
     }


### PR DESCRIPTION
We should just be using Project(0,...).

Sending this before looking into some more changes to rvsdg=>cfg.