### PR TITLE
Remove list of helpers from extraction

### DIFF
--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -3,7 +3,10 @@ use egraph_serialize::{ClassId, EGraph, NodeId};
 use ordered_float::NotNan;
 use rpds::HashTrieMap;
 use rustc_hash::FxHashMap;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    f64::INFINITY,
+};
 
 use crate::{
     from_egglog::FromEgglog,
@@ -79,7 +82,10 @@ impl<'a> EgraphInfo<'a> {
         // find all the (root, enode) pairs that are root nodes (no children)
         for (root, eclass) in &relavent_nodes {
             for enode in egraph.classes()[eclass].nodes.iter() {
-                if enode_children(egraph, &egraph[enode]).is_empty() {
+                // skip if cost is infinite
+                if enode_children(egraph, &egraph[enode]).is_empty()
+                    && cm.get_op_cost(&egraph[enode].op) != INFINITY
+                {
                     roots.push((root.clone(), enode.clone()));
                 }
             }
@@ -92,12 +98,17 @@ impl<'a> EgraphInfo<'a> {
         for (root, eclass) in relavent_nodes {
             // iterate over every root, enode pair
             for enode in egraph.classes()[&eclass].nodes.iter() {
+                let node = &egraph[enode];
+                // skip if cost is infinite
+                if cm.get_op_cost(&node.op) == INFINITY {
+                    continue;
+                }
                 // add to the parents table
                 for EnodeChild {
                     child,
                     is_subregion,
                     is_assumption,
-                } in enode_children(egraph, &egraph[enode])
+                } in enode_children(egraph, node)
                 {
                     if is_assumption {
                         continue;
@@ -304,6 +315,7 @@ fn calculate_cost_set(
     info: &EgraphInfo,
 ) -> Option<CostSet> {
     let node = &info.egraph[&node_id];
+
     let cid = info.egraph.nid_to_cid(&node_id);
     let region_costs = extractor.costs.get(&rootid).unwrap();
 
@@ -571,69 +583,10 @@ impl CostModel for DefaultCostModel {
             "Program" | "Function" => 0.,
             "DoWhile" => 100., // TODO: we could make this more accurate
             "If" | "Switch" => 50.,
-            // Unreachable
-            "I"
-            | "Infinity"
-            | "NegInfinity"
-            | "AddIntOrInfinity"
-            | "MaxIntOrInfinity"
-            | "MinIntOrInfinity"
-            | "MkIntInterval"
-            | "IntersectIntInterval"
-            | "UnionIntInterval"
-            | "AddIntIntervalToAll"
-            | "AddIntInterval"
-            | "AddIntIntervalToPtrPointees"
-            | "Intersect-PtrPointees"
-            | "PointsAnywhere"
-            | "ConsIfNonEmpty"
-            | "Cons-List<i64+IntInterval>"
-            | "Nil-List<i64+IntInterval>"
-            | "Length-List<i64+IntInterval>"
-            | "Concat-List<i64+IntInterval>"
-            | "RevConcat-List<i64+IntInterval>"
-            | "Rev-List<i64+IntInterval>"
-            | "UnionHelper-List<i64+IntInterval>"
-            | "Union-List<i64+IntInterval>"
-            | "IntersectHelper-List<i64+IntInterval>"
-            | "Intersect-List<i64+IntInterval>"
-            | "Cons-List<PtrPointees>"
-            | "Nil-List<PtrPointees>"
-            | "Length-List<PtrPointees>"
-            | "Concat-List<PtrPointees>"
-            | "RevConcat-List<PtrPointees>"
-            | "Rev-List<PtrPointees>"
-            | "Union-PtrPointees"
-            | "Zip<Union-PtrPointees>"
-            | "Zip<Intersect-PtrPointees>"
-            | "UnionPointees"
-            | "IntersectPointees"
-            | "UnwrapTuplePointsTo"
-            | "UnwrapPtrPointsTo"
-            | "PointeesDropFirst"
-            | "PointsToCellsAtIter"
-            | "PtrPointsTo"
-            | "TuplePointsTo"
-            | "GetPointees"
-            | "TypeToPointees"
-            | "PointsTo"
-            | "BaseTypeToPtrPointees"
-            | "TypeListToList<PtrPointees>"
-            | "HasType"
-            | "HasArgType"
-            | "ContextOf"
-            | "NoContext"
-            | "CellHasValues"
-            | "PointsToExpr"
-            | "ExpectType" => 0.,
-            "ExprIsPure" | "ListExprIsPure" | "BinaryOpIsPure" | "UnaryOpIsPure" => 0.,
-            "BodyContainsExpr" | "ScopeContext" => 0.,
-            "Region" | "Full" | "IntB" | "BoolB" => 0.,
-            "PathNil" | "PathCons" => 0.,
             // Schema
             "Bop" | "Uop" | "Top" => 0.,
             _ if self.ignore_children(op) => 0.,
-            _ => panic!("Please provide a cost for {op}"),
+            _ => INFINITY,
         }
         .try_into()
         .unwrap()
@@ -897,10 +850,11 @@ fn dag_extraction_linearity_check(prog: &TreeProgram, error_message: &str) {
 
     let mut egraph = egglog::EGraph::default();
     egraph.parse_and_run_program(&string_prog).unwrap();
-    let (serialized_egraph, unextractables) = serialized_egraph(egraph);
+    let (mut serialized_egraph, unextractables) = serialized_egraph(egraph);
     let mut termdag = TermDag::default();
 
-    let egraph_info = EgraphInfo::new(&DefaultCostModel, &serialized_egraph, unextractables);
+    let egraph = &mut serialized_egraph;
+    let egraph_info = EgraphInfo::new(&DefaultCostModel, egraph, unextractables);
     let extractor_not_linear = &mut Extractor::new(prog, &mut termdag);
 
     let (_cost_res, prog) = extract_without_linearity(extractor_not_linear, &egraph_info, None);

--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -542,7 +542,7 @@ pub fn extract_with_paths(
     // now run translation to expressions
     let resulting_prog = extractor.terms_to_expressions(info, root_costset.term.clone());
 
-    let root_cost = root_costset.costs.get(root_eclass).unwrap();
+    let root_cost = root_costset.total;
     if root_cost.is_infinite() {
         panic!("Failed to extract program! Found infinite cost on result node.");
     }

--- a/dag_in_context/src/to_egglog.rs
+++ b/dag_in_context/src/to_egglog.rs
@@ -284,12 +284,12 @@ impl TreeProgram {
             termdag,
             converted_cache: HashMap::new(),
         };
-        (self.to_egglog_internal(&mut state), state.termdag)
+        (self.to_egglog_with(&mut state), state.termdag)
     }
 
     // TODO Implement sharing of common subexpressions using
     // a cache and the Rc's pointer.
-    pub(crate) fn to_egglog_internal(&self, term_dag: &mut TreeToEgglog) -> Term {
+    pub(crate) fn to_egglog_with(&self, term_dag: &mut TreeToEgglog) -> Term {
         let entry_term = self.entry.to_egglog_internal(term_dag);
         let functions_terms = self
             .functions

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -3,7 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 2;
+  v1_: int = const 1;
   v2_: int = id v1_;
   v3_: int = id v0;
 .v4_:


### PR DESCRIPTION
If we change the schema, it'll be fine because we'll get an error that something wasn't extractable.
I also optimized the extraction algorithm to not consider parents that have infinite cost