### PR TITLE
Remove dependency on NoContext in loop unrolling

### DIFF
--- a/dag_in_context/src/optimizations/loop_unroll.egg
+++ b/dag_in_context/src/optimizations/loop_unroll.egg
@@ -15,11 +15,13 @@
      (SubTuple executed-once 1 (- outputs-len 1)))
   (let then-ctx
     (InIf true (Get executed-once 0) executed-once-body))
+  (let else-ctx
+    (InIf false (Get executed-once 0) executed-once-body))
   (union lhs
     ;; check if we need to continue executing the loop
     (If (Get executed-once 0)
         executed-once-body ;; inputs are the body executed once
         (DoWhile (Arg inputs-ty then-ctx)
           outputs) ;; right now, loop unrolling shares the same outputs, but we could add more context here
-        (Arg inputs-ty (NoContext)))))
+        (Arg inputs-ty else-ctx))))
  :ruleset loop-peel)

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -3,7 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 1;
+  v1_: int = const 2;
   v2_: int = id v1_;
   v3_: int = id v0;
 .v4_:

--- a/tests/snapshots/files__strong_loop-optimize.snap
+++ b/tests/snapshots/files__strong_loop-optimize.snap
@@ -4,7 +4,7 @@ expression: visualization.result
 ---
 @main(v0: int) {
   v1_: int = const 3;
-  v2_: int = add v1_ v0;
+  v2_: int = add v0 v1_;
   v3_: int = const 0;
   v4_: int = id v1_;
   v5_: int = id v2_;


### PR DESCRIPTION
This is the only place where NoContext is used in optimizations. Since we are converting from NoContext to InFunc as the "base" context, we need to make sure our optimizations do not rely on it in critical ways.