### PR TITLE
Add some basic peepholes

### DIFF
--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -52,6 +52,7 @@ pub fn prologue() -> String {
         include_str!("utility/expr_size.egg"),
         include_str!("interval_analysis.egg"),
         include_str!("optimizations/switch_rewrites.egg"),
+        include_str!("optimizations/peepholes.egg"),
         &optimizations::memory::rules(),
         include_str!("optimizations/memory.egg"),
         &optimizations::loop_invariant::rules().join("\n"),

--- a/dag_in_context/src/optimizations/loop_invariant.rs
+++ b/dag_in_context/src/optimizations/loop_invariant.rs
@@ -129,7 +129,7 @@ fn test_invariant_detect() -> crate::Result {
 
     let output_ty = tuplet!(intt(), intt(), intt(), intt(), statet());
     let inner_inv = sub(getat(2), getat(1)).with_arg_types(output_ty.clone(), base(intt()));
-    let inv = add(inner_inv.clone(), int(0)).with_arg_types(output_ty.clone(), base(intt()));
+    let inv = add(inner_inv.clone(), int(3)).with_arg_types(output_ty.clone(), base(intt()));
     let pred = less_than(getat(0), getat(3)).with_arg_types(output_ty.clone(), base(boolt()));
     let not_inv = add(getat(0), inv.clone()).with_arg_types(output_ty.clone(), base(intt()));
     let inv_in_print = add(inv.clone(), int_ty(4, output_ty.clone()));

--- a/dag_in_context/src/optimizations/mod.rs
+++ b/dag_in_context/src/optimizations/mod.rs
@@ -7,5 +7,6 @@ pub mod loop_invariant;
 pub mod loop_unroll;
 pub mod memory;
 pub mod passthrough;
+mod peepholes;
 pub mod purity_analysis;
 pub mod switch_rewrites;

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -1,0 +1,24 @@
+; Simple rewrites that don't do a ton with control flow.
+
+(ruleset peepholes)
+
+; Contexts?
+
+(rewrite (Bop (Mul) (Const (Int 0) ty ctx) e) (Const (Int 0) ty ctx) :ruleset peepholes)
+(rewrite (Bop (Mul) e (Const (Int 0) ty ctx)) (Const (Int 0) ty ctx) :ruleset peepholes)
+(rewrite (Bop (Mul) (Const (Int 1) ty ctx) e) e :ruleset peepholes)
+(rewrite (Bop (Mul) e (Const (Int 1) ty ctx) ) e :ruleset peepholes)
+(rewrite (Bop (Add) (Const (Int 0) ty ctx) e) e :ruleset peepholes)
+(rewrite (Bop (Add) e (Const (Int 0) ty ctx) ) e :ruleset peepholes)
+
+(rewrite (Bop (Mul) (Const (Int j) ty ctx) (Const (Int i) ty ctx)) (Const (Int (* i j)) ty ctx) :ruleset peepholes)
+(rewrite (Bop (Add) (Const (Int j) ty ctx) (Const (Int i) ty ctx)) (Const (Int (+ i j)) ty ctx) :ruleset peepholes)
+
+(rewrite (Bop (And) (Const (Bool true) ty ctx) e) e :ruleset peepholes)
+(rewrite (Bop (And) e (Const (Bool true) ty ctx)) e :ruleset peepholes)
+(rewrite (Bop (And) (Const (Bool false) ty ctx) e) (Const (Bool false) ty ctx) :ruleset peepholes)
+(rewrite (Bop (And) e (Const (Bool false) ty ctx)) (Const (Bool false) ty ctx) :ruleset peepholes)
+(rewrite (Bop (Or) (Const (Bool false) ty ctx) e) e :ruleset peepholes)
+(rewrite (Bop (Or) e (Const (Bool false) ty ctx)) e :ruleset peepholes)
+(rewrite (Bop (Or) (Const (Bool true) ty ctx) e) (Const (Bool true) ty ctx) :ruleset peepholes)
+(rewrite (Bop (Or) e (Const (Bool true) ty ctx)) (Const (Bool true) ty ctx) :ruleset peepholes)

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -2,12 +2,10 @@
 
 (ruleset peepholes)
 
-; Contexts?
-
 (rewrite (Bop (Mul) (Const (Int 0) ty ctx) e) (Const (Int 0) ty ctx) :ruleset peepholes)
 (rewrite (Bop (Mul) e (Const (Int 0) ty ctx)) (Const (Int 0) ty ctx) :ruleset peepholes)
 (rewrite (Bop (Mul) (Const (Int 1) ty ctx) e) e :ruleset peepholes)
-(rewrite (Bop (Mul) e (Const (Int 1) ty ctx) ) e :ruleset peepholes)
+(rewrite (Bop (Mul) e (Const (Int 1) ty ctx)) e :ruleset peepholes)
 (rewrite (Bop (Add) (Const (Int 0) ty ctx) e) e :ruleset peepholes)
 (rewrite (Bop (Add) e (Const (Int 0) ty ctx) ) e :ruleset peepholes)
 

--- a/dag_in_context/src/optimizations/peepholes.rs
+++ b/dag_in_context/src/optimizations/peepholes.rs
@@ -1,0 +1,31 @@
+//! Tests for the peepholes ruleset
+#![cfg(test)]
+
+use crate::{egglog_test, Result};
+
+#[test]
+fn arith_rewrites() -> Result {
+    use crate::ast::*;
+    // (0 + x + 0 + 1 + 2 + y * 1) -> (x + 3 + y)
+    let ctx_ty = tuplet_vec(vec![intt(), intt(), statet()]);
+    let zero = int_ty(0, ctx_ty.clone());
+    let one = int_ty(1, ctx_ty.clone());
+    let two = int_ty(2, ctx_ty.clone());
+    let three = int_ty(3, ctx_ty.clone());
+    let x = get(arg_ty(ctx_ty.clone()), 0);
+    let y = get(arg_ty(ctx_ty.clone()), 1);
+    let expr = add(
+        add(add(zero.clone(), x.clone()), zero.clone()),
+        add(add(one.clone(), two.clone()), mul(y.clone(), one.clone())),
+    );
+
+    let expected = add(x.clone(), add(three.clone(), y.clone()));
+    egglog_test(
+        &format!("(let expr_ {expr})"),
+        &format!("(check (= expr_ {expected}))"),
+        vec![],
+        val_empty(),
+        intv(1),
+        vec![],
+    )
+}

--- a/dag_in_context/src/optimizations/switch_rewrites.egg
+++ b/dag_in_context/src/optimizations/switch_rewrites.egg
@@ -49,3 +49,13 @@
 (rewrite (If (Const (Bool false) ty ctx) ins thn els)
          (Subst ctx ins els)
          :ruleset switch_rewrite)
+
+(rule ((= lhs (If pred ins thn els))
+       (= (Get thn i) (Const (Bool true) ty ctx1))
+       (= (Get els i) (Const (Bool false) ty ctx2)))
+      ((union (Get lhs i) pred)) :ruleset switch_rewrite)
+
+(rule ((= lhs (If pred ins thn els))
+       (= (Get thn i) (Const (Bool false) ty ctx1))
+       (= (Get els i) (Const (Bool true) ty ctx2)))
+      ((union (Get lhs i) (Uop (Not) pred))) :ruleset switch_rewrite)

--- a/dag_in_context/src/optimizations/switch_rewrites.rs
+++ b/dag_in_context/src/optimizations/switch_rewrites.rs
@@ -56,3 +56,57 @@ fn switch_rewrite_three_quarters_or() -> crate::Result {
         vec![],
     )
 }
+
+#[test]
+fn switch_rewrite_forward_pred() -> crate::Result {
+    use crate::ast::*;
+
+    let ctx_ty = tuplet!(boolt());
+
+    let arg = get(arg_ty(ctx_ty.clone()), 0);
+
+    let build = get(
+        tif(arg.clone(), empty(), single(ttrue()), single(tfalse()))
+            .add_arg_type(ctx_ty.clone())
+            .add_ctx(noctx()),
+        0,
+    );
+
+    let check = arg.clone();
+
+    egglog_test(
+        &format!("(let build_ {build})"),
+        &format!("(let check_ {check}) (check (= build_ check_))"),
+        vec![],
+        val_empty(),
+        intv(1),
+        vec![],
+    )
+}
+
+#[test]
+fn switch_rewrite_negate_pred() -> crate::Result {
+    use crate::ast::*;
+
+    let ctx_ty = tuplet!(boolt());
+
+    let arg = get(arg_ty(ctx_ty.clone()), 0);
+
+    let build = get(
+        tif(arg.clone(), empty(), single(tfalse()), single(ttrue()))
+            .add_arg_type(ctx_ty.clone())
+            .add_ctx(noctx()),
+        0,
+    );
+
+    let check = not(arg.clone());
+
+    egglog_test(
+        &format!("(let build_ {build})"),
+        &format!("(let check_ {check}) (check (= build_ check_))"),
+        vec![],
+        val_empty(),
+        intv(1),
+        vec![],
+    )
+}

--- a/dag_in_context/src/optimizations/switch_rewrites.rs
+++ b/dag_in_context/src/optimizations/switch_rewrites.rs
@@ -60,6 +60,7 @@ fn switch_rewrite_three_quarters_or() -> crate::Result {
 #[test]
 fn switch_rewrite_forward_pred() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
 
     let ctx_ty = tuplet!(boolt());
 
@@ -68,7 +69,7 @@ fn switch_rewrite_forward_pred() -> crate::Result {
     let build = get(
         tif(arg.clone(), empty(), single(ttrue()), single(tfalse()))
             .add_arg_type(ctx_ty.clone())
-            .add_ctx(noctx()),
+            .add_ctx(Assumption::dummy()),
         0,
     );
 
@@ -87,6 +88,7 @@ fn switch_rewrite_forward_pred() -> crate::Result {
 #[test]
 fn switch_rewrite_negate_pred() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
 
     let ctx_ty = tuplet!(boolt());
 
@@ -95,7 +97,7 @@ fn switch_rewrite_negate_pred() -> crate::Result {
     let build = get(
         tif(arg.clone(), empty(), single(tfalse()), single(ttrue()))
             .add_arg_type(ctx_ty.clone())
-            .add_ctx(noctx()),
+            .add_ctx(Assumption::dummy()),
         0,
     );
 

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -25,7 +25,6 @@ pub fn mk_schedule() -> String {
     context
     interval-analysis
     memory-helpers
-    peepholes
   )
   
     
@@ -33,6 +32,7 @@ pub fn mk_schedule() -> String {
     loop-simplify
     memory
     loop-unroll
+    peepholes
   )
 
   (unstable-combined-ruleset expensive-optimizations

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -25,6 +25,7 @@ pub fn mk_schedule() -> String {
     context
     interval-analysis
     memory-helpers
+    peepholes
   )
   
     

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -5,36 +5,37 @@ expression: visualization.result
 @main(v0: int) {
   v1_: int = const 2;
   v2_: bool = lt v0 v1_;
-  v3_: int = const 0;
-  v4_: int = const 1;
-  v5_: int = const 5;
-  br v2_ .v6_ .v7_;
-.v6_:
-  v8_: int = const 4;
-  v9_: bool = const false;
-  v10_: int = id v8_;
-  v11_: int = id v4_;
-  v12_: int = id v1_;
-  v13_: bool = id v9_;
-.v14_:
-  br v13_ .v15_ .v16_;
-.v15_:
-  v17_: int = add v10_ v1_;
-  v18_: int = id v17_;
-  v19_: int = id v4_;
-  jmp .v20_;
-.v16_:
-  v18_: int = id v10_;
-  v19_: int = id v4_;
-  jmp .v20_;
+  v3_: bool = not v2_;
+  v4_: int = const 0;
+  v5_: int = const 1;
+  v6_: int = const 5;
+  br v2_ .v7_ .v8_;
 .v7_:
-  v21_: bool = const true;
-  v10_: int = id v4_;
-  v11_: int = id v4_;
-  v12_: int = id v1_;
-  v13_: bool = id v21_;
-  jmp .v14_;
-.v20_:
-  v22_: int = add v18_ v4_;
-  print v22_;
+  v9_: int = const 4;
+  v10_: bool = const false;
+  v11_: int = id v9_;
+  v12_: int = id v5_;
+  v13_: int = id v1_;
+  v14_: bool = id v10_;
+.v15_:
+  br v3_ .v16_ .v17_;
+.v16_:
+  v18_: int = add v11_ v1_;
+  v19_: int = id v18_;
+  v20_: int = id v5_;
+  jmp .v21_;
+.v17_:
+  v19_: int = id v11_;
+  v20_: int = id v5_;
+  jmp .v21_;
+.v8_:
+  v22_: bool = const true;
+  v11_: int = id v5_;
+  v12_: int = id v5_;
+  v13_: int = id v1_;
+  v14_: bool = id v22_;
+  jmp .v15_;
+.v21_:
+  v23_: int = add v19_ v5_;
+  print v23_;
 }

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -4,43 +4,41 @@ expression: visualization.result
 ---
 @pow(v0: int, v1: int) {
   v2_: int = const 0;
-  v3_: int = const 1;
-  v4_: int = sub v1 v3_;
+  v3_: int = id v0;
+  v4_: int = id v2_;
   v5_: int = id v0;
-  v6_: int = id v2_;
-  v7_: int = id v0;
-  v8_: int = id v1;
-  v9_: int = id v4_;
-.v10_:
-  v11_: bool = lt v6_ v9_;
-  br v11_ .v12_ .v13_;
+  v6_: int = id v1;
+.v7_:
+  v8_: int = const 1;
+  v9_: int = sub v6_ v8_;
+  v10_: bool = lt v4_ v9_;
+  br v10_ .v11_ .v12_;
+.v11_:
+  v13_: int = mul v5_ v3_;
+  v14_: bool = const true;
+  v15_: int = const 1;
+  v16_: int = add v4_ v15_;
+  v17_: int = id v13_;
+  v18_: bool = id v14_;
+  v19_: int = id v16_;
+  v20_: int = id v5_;
+  v21_: int = id v6_;
+.v22_:
+  v3_: int = id v17_;
+  v4_: int = id v19_;
+  v5_: int = id v5_;
+  v6_: int = id v6_;
+  br v10_ .v7_ .v23_;
 .v12_:
-  v14_: int = mul v7_ v5_;
-  v15_: bool = const true;
-  v16_: int = const 1;
-  v17_: int = add v16_ v6_;
-  v18_: int = id v14_;
-  v19_: bool = id v15_;
-  v20_: int = id v17_;
-  v21_: int = id v7_;
-  v22_: int = id v8_;
+  v24_: bool = const false;
+  v17_: int = id v3_;
+  v18_: bool = id v24_;
+  v19_: int = id v4_;
+  v20_: int = id v5_;
+  v21_: int = id v6_;
+  jmp .v22_;
 .v23_:
-  v5_: int = id v18_;
-  v6_: int = id v20_;
-  v7_: int = id v7_;
-  v8_: int = id v8_;
-  v9_: int = id v9_;
-  br v11_ .v10_ .v24_;
-.v13_:
-  v25_: bool = const false;
-  v18_: int = id v5_;
-  v19_: bool = id v25_;
-  v20_: int = id v6_;
-  v21_: int = id v7_;
-  v22_: int = id v8_;
-  jmp .v23_;
-.v24_:
-  print v5_;
+  print v3_;
 }
 @main {
   v0_: int = const 4;

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -4,41 +4,43 @@ expression: visualization.result
 ---
 @pow(v0: int, v1: int) {
   v2_: int = const 0;
-  v3_: int = id v0;
-  v4_: int = id v2_;
+  v3_: int = const 1;
+  v4_: int = sub v1 v3_;
   v5_: int = id v0;
-  v6_: int = id v1;
-.v7_:
-  v8_: int = const 1;
-  v9_: int = sub v6_ v8_;
-  v10_: bool = lt v4_ v9_;
-  br v10_ .v11_ .v12_;
-.v11_:
-  v13_: int = mul v5_ v3_;
-  v14_: bool = const true;
-  v15_: int = const 1;
-  v16_: int = add v4_ v15_;
-  v17_: int = id v13_;
-  v18_: bool = id v14_;
-  v19_: int = id v16_;
-  v20_: int = id v5_;
-  v21_: int = id v6_;
-.v22_:
-  v3_: int = id v17_;
-  v4_: int = id v19_;
-  v5_: int = id v5_;
-  v6_: int = id v6_;
-  br v10_ .v7_ .v23_;
+  v6_: int = id v2_;
+  v7_: int = id v0;
+  v8_: int = id v1;
+  v9_: int = id v4_;
+.v10_:
+  v11_: bool = lt v6_ v9_;
+  br v11_ .v12_ .v13_;
 .v12_:
-  v24_: bool = const false;
-  v17_: int = id v3_;
-  v18_: bool = id v24_;
-  v19_: int = id v4_;
-  v20_: int = id v5_;
-  v21_: int = id v6_;
-  jmp .v22_;
+  v14_: int = mul v7_ v5_;
+  v15_: bool = const true;
+  v16_: int = const 1;
+  v17_: int = add v16_ v6_;
+  v18_: int = id v14_;
+  v19_: bool = id v15_;
+  v20_: int = id v17_;
+  v21_: int = id v7_;
+  v22_: int = id v8_;
 .v23_:
-  print v3_;
+  v5_: int = id v18_;
+  v6_: int = id v20_;
+  v7_: int = id v7_;
+  v8_: int = id v8_;
+  v9_: int = id v9_;
+  br v11_ .v10_ .v24_;
+.v13_:
+  v25_: bool = const false;
+  v18_: int = id v5_;
+  v19_: bool = id v25_;
+  v20_: int = id v6_;
+  v21_: int = id v7_;
+  v22_: int = id v8_;
+  jmp .v23_;
+.v24_:
+  print v5_;
 }
 @main {
   v0_: int = const 4;

--- a/tests/snapshots/files__loop_hoist-optimize.snap
+++ b/tests/snapshots/files__loop_hoist-optimize.snap
@@ -14,7 +14,7 @@ expression: visualization.result
   v8_: int = id v0_;
 .v9_:
   print v8_;
-  v10_: int = add v4_ v8_;
+  v10_: int = add v8_ v4_;
   v11_: bool = lt v10_ v5_;
   v12_: bool = not v11_;
   v4_: int = id v10_;

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -21,23 +21,24 @@ expression: visualization.result
   v15_: bool = id v13_;
   v16_: int = id v9_;
 .v17_:
+  v18_: bool = not v4_;
   v1_: int = id v7_;
   v2_: int = id v9_;
-  br v15_ .v3_ .v18_;
+  br v18_ .v3_ .v19_;
 .v12_:
-  v19_: bool = const true;
+  v20_: bool = const true;
   v14_: int = id v7_;
-  v15_: bool = id v19_;
+  v15_: bool = id v20_;
   v16_: int = id v9_;
   jmp .v17_;
 .v6_:
-  v20_: int = const 1;
-  v21_: int = add v20_ v1_;
-  v22_: int = add v2_ v20_;
-  v7_: int = id v21_;
+  v21_: int = const 1;
+  v22_: int = add v1_ v21_;
+  v23_: int = add v21_ v2_;
+  v7_: int = id v22_;
   v8_: bool = id v4_;
-  v9_: int = id v22_;
+  v9_: int = id v23_;
   jmp .v10_;
-.v18_:
+.v19_:
   print v1_;
 }

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -7,7 +7,7 @@ expression: visualization.result
   v1_: int = id v0_;
   v2_: int = id v0_;
 .v3_:
-  v4_: bool = eq v1_ v2_;
+  v4_: bool = eq v2_ v1_;
   br v4_ .v5_ .v6_;
 .v5_:
   v7_: int = id v1_;
@@ -33,8 +33,8 @@ expression: visualization.result
   jmp .v17_;
 .v6_:
   v21_: int = const 1;
-  v22_: int = add v1_ v21_;
-  v23_: int = add v21_ v2_;
+  v22_: int = add v21_ v1_;
+  v23_: int = add v2_ v21_;
   v7_: int = id v22_;
   v8_: bool = id v4_;
   v9_: int = id v23_;

--- a/tests/snapshots/files__loop_with_mul_by_inv-optimize.snap
+++ b/tests/snapshots/files__loop_with_mul_by_inv-optimize.snap
@@ -10,7 +10,7 @@ expression: visualization.result
   v5_: int = id v2_;
   v6_: int = id v0;
 .v7_:
-  v8_: int = mul v5_ v4_;
+  v8_: int = mul v4_ v5_;
   v9_: int = add v3_ v8_;
   v10_: int = const 1;
   v11_: int = add v10_ v4_;

--- a/tests/snapshots/files__unroll_multiple_4-optimize.snap
+++ b/tests/snapshots/files__unroll_multiple_4-optimize.snap
@@ -9,7 +9,7 @@ expression: visualization.result
   v3_: int = id v1_;
   v4_: int = id v0_;
 .v5_:
-  v6_: int = add v4_ v2_;
+  v6_: int = add v2_ v4_;
   v7_: bool = lt v6_ v3_;
   v2_: int = id v6_;
   v3_: int = id v3_;


### PR DESCRIPTION
This change starts a basic peephole optimization files. Most moderately complex peepholes I've found rely on things like shifting operators, sign extensions, etc. None of those can be done at the bril level (but note that LLVM will take advantage of them with optimizations turned on!)

Still, these probably don't hurt. I've added in some rules for forwarding predicates for ifs. Let me know if I'm using contexts correctly here.