### PR TITLE
Replace NoContext with InFunc

### DIFF
--- a/dag_in_context/src/add_context.rs
+++ b/dag_in_context/src/add_context.rs
@@ -63,7 +63,7 @@ impl Expr {
         let Expr::Function(name, arg_ty, ret_ty, body) = &self.as_ref() else {
             panic!("Expected Function, got {:?}", self);
         };
-        let current_ctx = Assumption::dummy();
+        let current_ctx = Assumption::InFunc(name.clone());
         RcExpr::new(Expr::Function(
             name.clone(),
             arg_ty.clone(),

--- a/dag_in_context/src/add_context.rs
+++ b/dag_in_context/src/add_context.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 
 use crate::{
-    ast::noctx,
     schema::{Assumption, Expr, RcExpr, TreeProgram},
     schema_helpers::AssumptionRef,
 };

--- a/dag_in_context/src/add_context.rs
+++ b/dag_in_context/src/add_context.rs
@@ -64,7 +64,7 @@ impl Expr {
         let Expr::Function(name, arg_ty, ret_ty, body) = &self.as_ref() else {
             panic!("Expected Function, got {:?}", self);
         };
-        let current_ctx = noctx();
+        let current_ctx = Assumption::dummy();
         RcExpr::new(Expr::Function(
             name.clone(),
             arg_ty.clone(),
@@ -79,7 +79,7 @@ impl Expr {
             symbol_gen: HashMap::new(),
             symbolic_ctx: true,
         };
-        self.add_ctx_with_cache(noctx(), &mut cache)
+        self.add_ctx_with_cache(Assumption::dummy(), &mut cache)
     }
 
     pub(crate) fn add_ctx(self: &RcExpr, current_ctx: Assumption) -> RcExpr {

--- a/dag_in_context/src/ast.rs
+++ b/dag_in_context/src/ast.rs
@@ -199,7 +199,7 @@ pub fn switch_vec(cond: RcExpr, input: RcExpr, cases: Vec<RcExpr>) -> RcExpr {
 }
 
 pub fn empty() -> RcExpr {
-    RcExpr::new(Expr::Empty(Type::Unknown, Assumption::NoContext))
+    RcExpr::new(Expr::Empty(Type::Unknown, Assumption::dummy()))
 }
 
 pub fn single(e: RcExpr) -> RcExpr {
@@ -257,22 +257,22 @@ pub fn arg_ty_ctx(ty: Type, ctx: Assumption) -> RcExpr {
 }
 
 pub fn arg_ty(ty: Type) -> RcExpr {
-    RcExpr::new(Expr::Arg(ty, Assumption::NoContext))
+    RcExpr::new(Expr::Arg(ty, Assumption::dummy()))
 }
 
 /// Returns an argument with an unknown type.
 /// Use `with_arg_types` to fill in the correct type.
 pub fn arg() -> RcExpr {
-    RcExpr::new(Expr::Arg(Type::Unknown, Assumption::NoContext))
+    RcExpr::new(Expr::Arg(Type::Unknown, Assumption::dummy()))
 }
 
 /// An argument with an integer type.
 pub fn iarg() -> RcExpr {
-    RcExpr::new(Expr::Arg(base(intt()), Assumption::NoContext))
+    RcExpr::new(Expr::Arg(base(intt()), Assumption::dummy()))
 }
 
 pub fn barg() -> RcExpr {
-    RcExpr::new(Expr::Arg(base(boolt()), Assumption::NoContext))
+    RcExpr::new(Expr::Arg(base(boolt()), Assumption::dummy()))
 }
 
 pub fn getat(index: usize) -> RcExpr {
@@ -295,7 +295,7 @@ pub fn ttrue() -> RcExpr {
     RcExpr::new(Expr::Const(
         crate::schema::Constant::Bool(true),
         Type::Unknown,
-        Assumption::NoContext,
+        Assumption::dummy(),
     ))
 }
 
@@ -303,7 +303,7 @@ pub fn ttrue_ty(ty: Type) -> RcExpr {
     RcExpr::new(Expr::Const(
         crate::schema::Constant::Bool(true),
         ty,
-        Assumption::NoContext,
+        Assumption::dummy(),
     ))
 }
 
@@ -311,7 +311,7 @@ pub fn tfalse() -> RcExpr {
     RcExpr::new(Expr::Const(
         crate::schema::Constant::Bool(false),
         Type::Unknown,
-        Assumption::NoContext,
+        Assumption::dummy(),
     ))
 }
 
@@ -319,7 +319,7 @@ pub fn tfalse_ty(ty: Type) -> RcExpr {
     RcExpr::new(Expr::Const(
         crate::schema::Constant::Bool(false),
         ty,
-        Assumption::NoContext,
+        Assumption::dummy(),
     ))
 }
 
@@ -327,7 +327,7 @@ pub fn int(i: i64) -> RcExpr {
     RcExpr::new(Expr::Const(
         crate::schema::Constant::Int(i),
         Type::Unknown,
-        Assumption::NoContext,
+        Assumption::dummy(),
     ))
 }
 
@@ -335,7 +335,7 @@ pub fn int_ty(i: i64, ty: Type) -> RcExpr {
     RcExpr::new(Expr::Const(
         crate::schema::Constant::Int(i),
         ty,
-        Assumption::NoContext,
+        Assumption::dummy(),
     ))
 }
 
@@ -353,6 +353,10 @@ pub fn inswitch(branch: i64, pred: RcExpr, input: RcExpr) -> Assumption {
 
 pub fn noctx() -> Assumption {
     Assumption::NoContext
+}
+
+pub fn infunc(str: impl Into<String>) -> Assumption {
+    Assumption::InFunc(str.into())
 }
 
 pub fn wildcardctx(str: String) -> Assumption {

--- a/dag_in_context/src/ast.rs
+++ b/dag_in_context/src/ast.rs
@@ -351,10 +351,6 @@ pub fn inswitch(branch: i64, pred: RcExpr, input: RcExpr) -> Assumption {
     Assumption::InSwitch(branch, pred, input)
 }
 
-pub fn noctx() -> Assumption {
-    Assumption::NoContext
-}
-
 pub fn infunc(str: impl Into<String>) -> Assumption {
     Assumption::InFunc(str.into())
 }

--- a/dag_in_context/src/from_egglog.rs
+++ b/dag_in_context/src/from_egglog.rs
@@ -122,8 +122,13 @@ impl<'a> FromEgglog<'a> {
               self.expr_from_egglog(self.termdag.get(*rhs)),
             )
           }
-          ("NoContext", []) => {
-            Assumption::NoContext
+          ("NoContext", []) => Assumption::NoContext,
+          ("InFunc", [str]) => {
+            let Term::Lit(Literal::String(name)) = self.termdag.get(*str)
+            else {
+              panic!("Invalid function name in InFunc: {:?}", str)
+            };
+            Assumption::InFunc(name.to_string())
           }
           ("InIf", [is_then, pred_expr, input_expr]) => {
             let Term::Lit(Literal::Bool(boolean)) = self.termdag.get(*is_then)

--- a/dag_in_context/src/from_egglog.rs
+++ b/dag_in_context/src/from_egglog.rs
@@ -122,7 +122,6 @@ impl<'a> FromEgglog<'a> {
               self.expr_from_egglog(self.termdag.get(*rhs)),
             )
           }
-          ("NoContext", []) => Assumption::NoContext,
           ("InFunc", [str]) => {
             let Term::Lit(Literal::String(name)) = self.termdag.get(*str)
             else {

--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -640,7 +640,7 @@ impl CostModel for DefaultCostModel {
     }
 
     fn ignore_children(&self, op: &str) -> bool {
-        matches!(op, "InLoop" | "NoContext" | "InSwitch" | "InIf")
+        matches!(op, "InLoop" | "NoContext" | "InSwitch" | "InIf" | "InFunc")
     }
 }
 

--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -310,10 +310,10 @@ fn calculate_cost_set(
     let dummy_ctx = CostSet {
         costs: Default::default(),
         total: 0.0.try_into().unwrap(),
-        term: extractor.termdag.app(
-            "InFunc".into(),
-            vec![Term::Lit(Literal::String("dummy".into()))],
-        ),
+        term: {
+            let dummy = extractor.termdag.lit(Literal::String("dummy".into()));
+            extractor.termdag.app("InFunc".into(), vec![dummy])
+        },
     };
 
     // get the cost sets for the children

--- a/dag_in_context/src/interval_analysis.rs
+++ b/dag_in_context/src/interval_analysis.rs
@@ -81,8 +81,8 @@ fn test_add_constant_fold() -> crate::Result {
     use crate::ast::*;
     let expr = add(int(1), int(2))
         .with_arg_types(emptyt(), base(intt()))
-        .add_ctx(noctx());
-    let expr2 = int_ty(3, emptyt()).add_ctx(noctx());
+        .add_ctx(Assumption::dummy());
+    let expr2 = int_ty(3, emptyt()).add_ctx(Assumption::dummy());
 
     egglog_test(
         &format!("{expr}"),
@@ -245,7 +245,7 @@ fn context_if_rev() -> crate::Result {
         &format!("{with_context}"),
         &format!(
             "
-(check (= {term} (Const (Bool false) (Base (IntT)) (NoContext))))"
+        (check (= {term} (Const (Bool false) (Base (IntT)) (InFunc \"main\"))))"
         ),
         vec![with_context],
         intv(4),

--- a/dag_in_context/src/interval_analysis.rs
+++ b/dag_in_context/src/interval_analysis.rs
@@ -307,7 +307,8 @@ fn context_if_with_state() -> crate::Result {
     let expected = single(tprint(
         ttrue_ty(input_type.clone()),
         get(input_arg.clone(), 1),
-    ));
+    ))
+    .add_ctx(Assumption::InFunc("main".to_string()));
 
     egglog_test(
         &format!("{prog}"),

--- a/dag_in_context/src/optimizations/is_resolved.rs
+++ b/dag_in_context/src/optimizations/is_resolved.rs
@@ -41,6 +41,7 @@ use crate::Value;
 #[test]
 fn test_is_resolved() -> crate::Result {
     use crate::schedule::helpers;
+    use crate::schema::Assumption;
     let myloop = dowhile(
         single(int(1)),
         parallel!(

--- a/dag_in_context/src/optimizations/is_resolved.rs
+++ b/dag_in_context/src/optimizations/is_resolved.rs
@@ -52,11 +52,12 @@ fn test_is_resolved() -> crate::Result {
     let add1 = add(arg(), int(1)).add_arg_type(base(intt()));
     let helpers = helpers();
     let build = format!("{myloop}");
+    let ctx = Assumption::dummy();
     let check = format!(
         "
 (check (ExprIsResolved myloop))
 
-(let substituted (Subst (NoContext) {add1} {myloop}))
+(let substituted (Subst {ctx} {add1} {myloop}))
 ;; run the IsResolved rules
 (run-schedule (saturate always-run))
 

--- a/dag_in_context/src/optimizations/loop_invariant.egg
+++ b/dag_in_context/src/optimizations/loop_invariant.egg
@@ -72,8 +72,8 @@
        (let assum (InExtendedLoop in pred_out new_input))
        (let new_out_branch (Get (Arg new_input_type assum) len))
        ;; this two subst only change arg to arg with new type
-       (let substed_pred_out (Subst assum (Arg new_input_type (NoContext)) pred_out))
-       (let inv_in_new_loop (Subst assum (Arg new_input_type (NoContext)) inv))
+       (let substed_pred_out (Subst assum (Arg new_input_type assum) pred_out))
+       (let inv_in_new_loop (Subst assum (Arg new_input_type assum) inv))
        (let new_pred_out (Concat substed_pred_out (Single new_out_branch)))
        
        (let new_loop (DoWhile new_input new_pred_out))

--- a/dag_in_context/src/optimizations/loop_invariant.rs
+++ b/dag_in_context/src/optimizations/loop_invariant.rs
@@ -125,6 +125,8 @@ pub(crate) fn rules() -> Vec<String> {
 #[test]
 fn test_invariant_detect() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
+
     let output_ty = tuplet!(intt(), intt(), intt(), intt(), statet());
     let inner_inv = sub(getat(2), getat(1)).with_arg_types(output_ty.clone(), base(intt()));
     let inv = add(inner_inv.clone(), int(0)).with_arg_types(output_ty.clone(), base(intt()));
@@ -142,12 +144,12 @@ fn test_invariant_detect() -> crate::Result {
         ),
     )
     .with_arg_types(tuplet!(statet()), output_ty.clone())
-    .add_ctx(noctx());
+    .add_ctx(Assumption::dummy());
 
     let my_loop_ctx = inloop(
         parallel!(int(1), int(2), int(3), int(4), getat(0))
             .with_arg_types(tuplet!(statet()), output_ty.clone())
-            .add_ctx(noctx()),
+            .add_ctx(Assumption::dummy()),
         concat(
             parallel!(pred.clone(), not_inv.clone(), getat(1)),
             concat(parallel!(getat(2), getat(3)), single(print.clone())),
@@ -156,7 +158,7 @@ fn test_invariant_detect() -> crate::Result {
             output_ty.clone(),
             tuplet!(boolt(), intt(), intt(), intt(), intt(), statet()),
         )
-        .add_ctx(noctx()),
+        .add_ctx(Assumption::dummy()),
     );
 
     let inv = inv.add_ctx(my_loop_ctx.clone());
@@ -200,6 +202,8 @@ fn test_invariant_detect() -> crate::Result {
 #[test]
 fn test_invariant_hoist() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
+
     let output_ty = tuplet!(intt(), intt(), intt(), intt(), statet());
     let inner_inv = sub(getat(2), getat(1));
     let inv = add(inner_inv.clone(), int(0));
@@ -215,7 +219,7 @@ fn test_invariant_hoist() -> crate::Result {
         ),
     )
     .with_arg_types(tuplet!(statet()), output_ty.clone())
-    .add_ctx(noctx());
+    .add_ctx(Assumption::dummy());
 
     let new_out_ty = tuplet!(intt(), intt(), intt(), intt(), statet(), intt());
     let new_input = parallel!(int(1), int(2), int(3), int(4), getat(0), int(1));
@@ -223,7 +227,7 @@ fn test_invariant_hoist() -> crate::Result {
     let new_print = tprint(getat(5), getat(4));
 
     let hoisted_loop = dowhile(
-        new_input.clone().add_ctx(noctx()),
+        new_input.clone().add_ctx(Assumption::dummy()),
         parallel!(
             pred.clone(),
             not_inv.clone(),

--- a/dag_in_context/src/optimizations/switch_rewrites.rs
+++ b/dag_in_context/src/optimizations/switch_rewrites.rs
@@ -4,6 +4,7 @@ use crate::egglog_test;
 #[test]
 fn switch_rewrite_three_quarters_and() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
 
     let build = tif(and(tfalse(), ttrue()), empty(), int(1), int(2))
         .with_arg_types(emptyt(), base(intt()))
@@ -31,6 +32,7 @@ fn switch_rewrite_three_quarters_and() -> crate::Result {
 #[test]
 fn switch_rewrite_three_quarters_or() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
 
     let build = tif(or(tfalse(), ttrue()), empty(), int(1), int(2))
         .with_arg_types(emptyt(), base(intt()))

--- a/dag_in_context/src/optimizations/switch_rewrites.rs
+++ b/dag_in_context/src/optimizations/switch_rewrites.rs
@@ -7,7 +7,7 @@ fn switch_rewrite_three_quarters_and() -> crate::Result {
 
     let build = tif(and(tfalse(), ttrue()), empty(), int(1), int(2))
         .with_arg_types(emptyt(), base(intt()))
-        .add_ctx(noctx());
+        .add_ctx(Assumption::dummy());
 
     let check = tif(
         tfalse(),
@@ -16,7 +16,7 @@ fn switch_rewrite_three_quarters_and() -> crate::Result {
         int(2),
     )
     .with_arg_types(emptyt(), base(intt()))
-    .add_ctx(noctx());
+    .add_ctx(Assumption::dummy());
 
     egglog_test(
         &format!("(let build_ {build})"),
@@ -34,7 +34,7 @@ fn switch_rewrite_three_quarters_or() -> crate::Result {
 
     let build = tif(or(tfalse(), ttrue()), empty(), int(1), int(2))
         .with_arg_types(emptyt(), base(intt()))
-        .add_ctx(noctx());
+        .add_ctx(Assumption::dummy());
 
     let check = tif(
         tfalse(),
@@ -43,7 +43,7 @@ fn switch_rewrite_three_quarters_or() -> crate::Result {
         tif(get(arg(), 0), empty(), int(1), int(2)),
     )
     .with_arg_types(emptyt(), base(intt()))
-    .add_ctx(noctx());
+    .add_ctx(Assumption::dummy());
 
     egglog_test(
         &format!("(let build_ {build})"),

--- a/dag_in_context/src/schema.egg
+++ b/dag_in_context/src/schema.egg
@@ -36,6 +36,7 @@
 
 (datatype Assumption
   ; Assume nothing
+  (InFunc String)
   (NoContext)
   ; The term is in a loop with `input` and `pred_output`.
   ; InLoop is a special context because it describes the argument of the loop. It is a *scope context*.

--- a/dag_in_context/src/schema.egg
+++ b/dag_in_context/src/schema.egg
@@ -37,7 +37,6 @@
 (datatype Assumption
   ; Assume nothing
   (InFunc String)
-  (NoContext)
   ; The term is in a loop with `input` and `pred_output`.
   ; InLoop is a special context because it describes the argument of the loop. It is a *scope context*.
   ;      input    pred_output

--- a/dag_in_context/src/schema.rs
+++ b/dag_in_context/src/schema.rs
@@ -74,10 +74,17 @@ pub type RcExpr = Rc<Expr>;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Assumption {
     InLoop(RcExpr, RcExpr),
+    InFunc(String),
     NoContext,
     InIf(bool, RcExpr, RcExpr),
     InSwitch(i64, RcExpr, RcExpr),
     WildCard(String),
+}
+
+impl Assumption {
+    pub fn dummy() -> Assumption {
+        Assumption::InFunc("dummy".to_string())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/dag_in_context/src/schema.rs
+++ b/dag_in_context/src/schema.rs
@@ -75,7 +75,6 @@ pub type RcExpr = Rc<Expr>;
 pub enum Assumption {
     InLoop(RcExpr, RcExpr),
     InFunc(String),
-    NoContext,
     InIf(bool, RcExpr, RcExpr),
     InSwitch(i64, RcExpr, RcExpr),
     WildCard(String),

--- a/dag_in_context/src/schema_helpers.rs
+++ b/dag_in_context/src/schema_helpers.rs
@@ -699,6 +699,7 @@ impl UnaryOp {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AssumptionRef {
     InLoop(*const Expr, *const Expr),
+    InFunc(String),
     NoContext,
     InIf(bool, *const Expr, *const Expr),
     InSwitch(i64, *const Expr, *const Expr),
@@ -711,6 +712,7 @@ impl Assumption {
             Assumption::InLoop(inputs, pred_and_body) => {
                 AssumptionRef::InLoop(Rc::as_ptr(inputs), Rc::as_ptr(pred_and_body))
             }
+            Assumption::InFunc(name) => AssumptionRef::InFunc(name.clone()),
             Assumption::NoContext => AssumptionRef::NoContext,
             Assumption::InIf(b, pred, input) => {
                 AssumptionRef::InIf(*b, Rc::as_ptr(pred), Rc::as_ptr(input))

--- a/dag_in_context/src/schema_helpers.rs
+++ b/dag_in_context/src/schema_helpers.rs
@@ -700,7 +700,6 @@ impl UnaryOp {
 pub enum AssumptionRef {
     InLoop(*const Expr, *const Expr),
     InFunc(String),
-    NoContext,
     InIf(bool, *const Expr, *const Expr),
     InSwitch(i64, *const Expr, *const Expr),
     WildCard(String),
@@ -713,7 +712,6 @@ impl Assumption {
                 AssumptionRef::InLoop(Rc::as_ptr(inputs), Rc::as_ptr(pred_and_body))
             }
             Assumption::InFunc(name) => AssumptionRef::InFunc(name.clone()),
-            Assumption::NoContext => AssumptionRef::NoContext,
             Assumption::InIf(b, pred, input) => {
                 AssumptionRef::InIf(*b, Rc::as_ptr(pred), Rc::as_ptr(input))
             }

--- a/dag_in_context/src/to_egglog.rs
+++ b/dag_in_context/src/to_egglog.rs
@@ -347,34 +347,37 @@ fn test_parses_to(term: Term, termdag: &mut TermDag, expected: &str) {
 #[test]
 fn convert_to_egglog_simple_arithmetic() {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let expr = add(int(1), iarg()).with_arg_types(base(intt()), base(intt()));
     let ctx = Assumption::dummy();
     test_expr_parses_to(
         expr,
-        "(Bop (Add) (Const (Int 1) (Base (IntT)) {ctx}) (Arg (Base (IntT)) {ctx}))",
+        &format!("(Bop (Add) (Const (Int 1) (Base (IntT)) {ctx}) (Arg (Base (IntT)) {ctx}))"),
     );
 }
 
 #[test]
 fn convert_to_egglog_switch() {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let expr = switch!(int(1), int(4); concat(single(int(1)), single(int(2))), concat(single(int(3)), single(int(4)))).with_arg_types(base(intt()), tuplet!(intt(), intt()));
-    let ctx = Assumption::dummy();
+    let ctx = format!("{}", Assumption::dummy());
     test_expr_parses_to(
         expr,
-        "(Switch (Const (Int 1) (Base (IntT)) {ctx})
+        &format!("(Switch (Const (Int 1) (Base (IntT)) {ctx})
                  (Const (Int 4) (Base (IntT)) {ctx})
                  (Cons 
                   (Concat (Single (Const (Int 1) (Base (IntT)) {ctx})) (Single (Const (Int 2) (Base (IntT)) {ctx})))
                   (Cons 
                    (Concat (Single (Const (Int 3) (Base (IntT)) {ctx})) (Single (Const (Int 4) (Base (IntT)) {ctx})))
-                   (Nil))))",
+                   (Nil))))"),
     );
 }
 
 #[test]
 fn convert_whole_program() {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let expr = program!(
         function(
             "main",
@@ -395,10 +398,10 @@ fn convert_whole_program() {
             )
         )
     );
-    let ctx = Assumption::dummy();
+    let ctx = format!("{}", Assumption::dummy());
     test_program_parses_to(
         expr,
-        "(Program 
+        &format!("(Program 
             (Function \"main\" (Base (IntT)) (Base (IntT)) 
                 (Bop (Add) (Const (Int 1) (Base (IntT)) {ctx}) (Call \"f\" (Const (Int 2) (Base (IntT)) {ctx})))) 
             (Cons 
@@ -409,6 +412,6 @@ fn convert_whole_program() {
                             (Single (Bop (LessThan) (Get (Arg (TupleT (TCons (IntT) (TNil))) {ctx}) 0) (Const (Int 10) (TupleT (TCons (IntT) (TNil))) {ctx})))
                             (Single (Bop (Add) (Get (Arg (TupleT (TCons (IntT) (TNil))) {ctx}) 0) (Const (Int 1) (TupleT (TCons (IntT) (TNil))) {ctx})))))
                         0)) 
-                (Nil)))",
+                (Nil)))"),
     );
 }

--- a/dag_in_context/src/to_egglog.rs
+++ b/dag_in_context/src/to_egglog.rs
@@ -117,7 +117,6 @@ impl Assumption {
                 let rhs = rhs.to_egglog_internal(term_dag);
                 term_dag.app("InLoop".into(), vec![lhs, rhs])
             }
-            Assumption::NoContext => term_dag.app("NoContext".into(), vec![]),
             Assumption::InIf(is_then, pred, input) => {
                 let pred = pred.to_egglog_internal(term_dag);
                 let is_then = term_dag.lit(Literal::Bool(*is_then));

--- a/dag_in_context/src/utility/add_context.rs
+++ b/dag_in_context/src/utility/add_context.rs
@@ -9,9 +9,10 @@ fn test_in_context_tuple() -> crate::Result {
     let tuple =
         parallel!(int(3), int(4)).with_arg_types(tuplet!(intt(), intt()), tuplet!(intt(), intt()));
 
+    let ctx = Assumption::dummy();
     let build = format!(
         "
-(let substituted (AddContext (NoContext) {tuple}))"
+(let substituted (AddContext {ctx} {tuple}))"
     );
     let check = format!(
         "
@@ -48,13 +49,14 @@ fn test_in_context_two_loops() -> crate::Result {
         )
     );
 
+    let ctx = Assumption::dummy();
     // expression with nested loop, we'll add context to inner loop
     let expr = dowhile(single(int(1)), loop_body.clone()).with_arg_types(emptyt(), tuplet!(intt()));
 
     egglog_test_and_print_program(
         &format!(
             "
-(let egglog-version (AddContext (NoContext) {expr}))"
+(let egglog-version (AddContext {ctx} {expr}))"
         ),
         &format!(
             "
@@ -76,13 +78,14 @@ fn test_simple_context_cycle() -> crate::Result {
     let expr = dowhile(arg(), parallel!(tfalse(), int(3)))
         .with_arg_types(tuplet!(intt()), tuplet!(intt()));
     let inner = single(int(3)).with_arg_types(tuplet!(intt()), tuplet!(intt()));
+    let ctx = Assumption::dummy();
 
     egglog_test(
         &format!(
             "
 (union {expr} {inner})
-(Subst (NoContext) {inputs} {outputs})
-(AddContext (NoContext) {expr})
+(Subst {ctx} {inputs} {outputs})
+(AddContext {ctx} {expr})
 ",
         ),
         &format!(

--- a/dag_in_context/src/utility/add_context.rs
+++ b/dag_in_context/src/utility/add_context.rs
@@ -4,6 +4,7 @@ use crate::{egglog_test, interpreter::Value, schema::Constant};
 #[test]
 fn test_in_context_tuple() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     use crate::{interpreter::Value, schema::Constant};
 
     let tuple =
@@ -37,6 +38,7 @@ fn test_in_context_tuple() -> crate::Result {
 fn test_in_context_two_loops() -> crate::Result {
     use crate::ast::*;
     use crate::egglog_test_and_print_program;
+    use crate::schema::Assumption;
 
     let loop_body = parallel!(
         tfalse(),
@@ -72,6 +74,7 @@ fn test_in_context_two_loops() -> crate::Result {
 #[test]
 fn test_simple_context_cycle() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let inputs = single(arg()).with_arg_types(base(intt()), tuplet!(intt()));
     let outputs =
         parallel!(tfalse(), int(3)).with_arg_types(tuplet!(intt()), tuplet!(boolt(), intt()));

--- a/dag_in_context/src/utility/context_of.rs
+++ b/dag_in_context/src/utility/context_of.rs
@@ -1,17 +1,19 @@
 #[test]
 fn test_context_of() -> crate::Result {
     use crate::ast::*;
-    let ctx = Assumption::dummy();
+    use crate::schema::Assumption;
+    let ctx = Assumption::InFunc("main".to_string());
 
     // fn main(x): if x = 5 then x else 4
     let pred = eq(arg(), int(5));
     let body = tif(pred, arg(), arg(), int(4))
         .with_arg_types(base(intt()), base(intt()))
         .with_arg_types(base(intt()), base(intt()));
-    let body_with_context = body.clone().add_ctx(ctx);
+    let body_with_context = body.clone().add_ctx(ctx.clone());
     let build = function("main", base(intt()), base(intt()), body.clone())
         .func_with_arg_types()
         .func_add_ctx();
+    let ctx = format!("{}", ctx);
 
     // If statement should have the context of its predicate
     let check = format!(
@@ -37,13 +39,14 @@ fn test_context_of() -> crate::Result {
 // Check that a constant has ContextOf
 #[test]
 fn test_context_of_base_case() -> crate::Result {
-    let ctx = Assumption::dummy();
-    let build = "(Const (Int 5) (Base (IntT)) {ctx})";
-    let check = "(ContextOf (Const (Int 5) (Base (IntT)) {ctx}) {ctx})";
+    use crate::schema::Assumption;
+    let ctx = format!("{}", Assumption::dummy());
+    let build = format!("(Const (Int 5) (Base (IntT)) {ctx})");
+    let check = format!("(ContextOf (Const (Int 5) (Base (IntT)) {ctx}) {ctx})");
 
     crate::egglog_test(
         &format!("(let build {build})"),
-        check,
+        &check,
         vec![],
         crate::ast::val_empty(),
         crate::ast::val_empty(),
@@ -55,7 +58,8 @@ fn test_context_of_base_case() -> crate::Result {
 #[should_panic]
 fn test_context_of_panics_if_two() {
     use crate::ast::*;
-    let ctx1 = Assumption::dummy();
+    use crate::schema::Assumption;
+    let ctx1 = format!("{}", Assumption::dummy());
     let ctx2 = inif(
         true,
         ttrue().with_arg_types(tuplet!(), base(boolt())),

--- a/dag_in_context/src/utility/context_of.rs
+++ b/dag_in_context/src/utility/context_of.rs
@@ -1,25 +1,28 @@
 #[test]
 fn test_context_of() -> crate::Result {
     use crate::ast::*;
+    let ctx = Assumption::dummy();
 
     // fn main(x): if x = 5 then x else 4
     let pred = eq(arg(), int(5));
     let body = tif(pred, arg(), arg(), int(4))
         .with_arg_types(base(intt()), base(intt()))
         .with_arg_types(base(intt()), base(intt()));
-    let body_with_context = body.clone().add_ctx(noctx());
+    let body_with_context = body.clone().add_ctx(ctx);
     let build = function("main", base(intt()), base(intt()), body.clone())
         .func_with_arg_types()
         .func_add_ctx();
 
     // If statement should have the context of its predicate
-    let check = format!("
-        (let pred-ctx (NoContext))
-        (let pred (Bop (Eq) (Arg (Base (IntT)) (NoContext)) (Const (Int 5) (Base (IntT)) (NoContext))))
+    let check = format!(
+        "
+        (let pred-ctx {ctx})
+        (let pred (Bop (Eq) (Arg (Base (IntT)) {ctx}) (Const (Int 5) (Base (IntT)) {ctx})))
         (check (ContextOf pred pred-ctx))
         (let if {body_with_context})
         (check (ContextOf if pred-ctx))
-        ");
+        "
+    );
 
     crate::egglog_test(
         &format!("(let build {build})"),
@@ -34,8 +37,9 @@ fn test_context_of() -> crate::Result {
 // Check that a constant has ContextOf
 #[test]
 fn test_context_of_base_case() -> crate::Result {
-    let build = "(Const (Int 5) (Base (IntT)) (NoContext))";
-    let check = "(ContextOf (Const (Int 5) (Base (IntT)) (NoContext)) (NoContext))";
+    let ctx = Assumption::dummy();
+    let build = "(Const (Int 5) (Base (IntT)) {ctx})";
+    let check = "(ContextOf (Const (Int 5) (Base (IntT)) {ctx}) {ctx})";
 
     crate::egglog_test(
         &format!("(let build {build})"),
@@ -51,13 +55,14 @@ fn test_context_of_base_case() -> crate::Result {
 #[should_panic]
 fn test_context_of_panics_if_two() {
     use crate::ast::*;
+    let ctx1 = Assumption::dummy();
     let ctx2 = inif(
         true,
         ttrue().with_arg_types(tuplet!(), base(boolt())),
         arg_ty(tuplet!()),
     );
     let build = format!("
-        (let ctx1 (NoContext))
+        (let ctx1 {ctx1})
         (let ctx2 {ctx2})
         (let conflict-expr (Bop (And) (Const (Bool false) (Base (BoolT)) ctx1) (Const (Bool true) (Base (BoolT)) ctx2)))");
     let check = "";

--- a/dag_in_context/src/utility/subst.rs
+++ b/dag_in_context/src/utility/subst.rs
@@ -5,9 +5,10 @@ fn test_subst_twice() -> crate::Result {
     let original = arg().add_arg_type(base(intt()));
     let expected = add(add(arg(), int(1)), int(1)).add_arg_type(base(intt()));
 
+    let ctx = Assumption::dummy();
     let build = format!(
         "
-(let substituted (Subst (NoContext) {arg_plus_one} (Subst (NoContext) {arg_plus_one} {original})))
+(let substituted (Subst {ctx} {arg_plus_one} (Subst {ctx} {arg_plus_one} {original})))
 "
     );
     let check = format!("(check (= substituted {expected}))");
@@ -31,20 +32,21 @@ fn test_subst_ten_times() -> crate::Result {
         expected = add(expected, int(1));
     }
     expected = expected.add_arg_type(base(intt()));
+    let ctx = Assumption::dummy();
 
     let build = format!(
         "
 (let substituted
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one}
-    (Subst (NoContext) {arg_plus_one} {original})))))))))))
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one}
+    (Subst {ctx} {arg_plus_one} {original})))))))))))
 "
     );
     let check = format!("(check (= substituted {expected}))");
@@ -71,10 +73,11 @@ fn test_subst_cycle() -> crate::Result {
         );
 
     let replace_with = parallel!(int(3), int(4)).with_arg_types(twoint.clone(), twoint.clone());
+    let ctx = Assumption::dummy();
 
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expr}))"
     );
@@ -133,10 +136,11 @@ fn test_subst_nested() -> crate::Result {
         0,
     )
     .with_arg_types(twoint.clone(), base(intt()));
+    let ctx = Assumption::dummy();
 
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expr}))"
     );
@@ -184,10 +188,11 @@ fn test_subst_if() -> crate::Result {
     )
     .add_arg_type(emptyt())
     .add_symbolic_ctx();
+    let ctx = Assumption::dummy();
 
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expr}))"
     );
@@ -213,9 +218,10 @@ fn test_subst_makes_new_context() -> crate::Result {
     let expr = add(int_ty(1, base(intt())), iarg());
     let replace_with = int_ty(2, base(intt()));
     let expected = add(int(1), int(2)).with_arg_types(base(intt()), base(intt()));
+    let ctx = Assumption::dummy();
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expr}))"
     );
@@ -238,18 +244,19 @@ fn test_subst_makes_new_context() -> crate::Result {
 fn test_subst_arg_type_changes() -> crate::Result {
     use crate::ast::*;
     use crate::{interpreter::Value, schema::Constant};
-    let expr = add(iarg(), iarg()).add_ctx(noctx());
+    let expr = add(iarg(), iarg()).add_ctx(Assumption::dummy());
     let tupletype = tuplet!(intt(), intt());
     let replace_with = get(arg(), 0)
         .with_arg_types(tupletype.clone(), base(intt()))
-        .add_ctx(noctx());
+        .add_ctx(Assumption::dummy());
 
     let expected = add(get(arg(), 0), get(arg(), 0))
         .with_arg_types(tupletype.clone(), base(intt()))
-        .add_ctx(noctx());
+        .add_ctx(Assumption::dummy());
+    let ctx = Assumption::dummy();
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expr}))"
     );
@@ -278,10 +285,11 @@ fn test_subst_identity() -> crate::Result {
     .func_add_ctx();
 
     let replace_with = int(5).with_arg_types(base(intt()), base(intt()));
+    let ctx = Assumption::dummy();
 
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expression}))"
     );
@@ -310,10 +318,11 @@ fn test_subst_add() -> crate::Result {
     let expected = function("main", base(intt()), base(intt()), add(int(5), int(5)))
         .func_with_arg_types()
         .func_add_ctx();
+    let ctx = Assumption::dummy();
 
     let build = format!(
         "
-(let substituted (Subst (NoContext)
+(let substituted (Subst {ctx}
                         {replace_with}
                         {expression}))"
     );

--- a/dag_in_context/src/utility/subst.rs
+++ b/dag_in_context/src/utility/subst.rs
@@ -1,6 +1,7 @@
 #[test]
 fn test_subst_twice() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let arg_plus_one = add(arg(), int(1)).add_arg_type(base(intt()));
     let original = arg().add_arg_type(base(intt()));
     let expected = add(add(arg(), int(1)), int(1)).add_arg_type(base(intt()));
@@ -25,6 +26,7 @@ fn test_subst_twice() -> crate::Result {
 #[test]
 fn test_subst_ten_times() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let arg_plus_one = add(arg(), int(1)).add_arg_type(base(intt()));
     let original = arg().add_arg_type(base(intt()));
     let mut expected = arg();
@@ -63,6 +65,7 @@ fn test_subst_ten_times() -> crate::Result {
 #[test]
 fn test_subst_cycle() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     use crate::{interpreter::Value, schema::Constant};
     let twoint = tuplet!(intt(), intt());
 
@@ -95,6 +98,7 @@ fn test_subst_cycle() -> crate::Result {
 #[test]
 fn test_subst_nested() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     use crate::{interpreter::Value, schema::Constant};
     let twoint = tuplet!(intt(), intt());
     let inputs = parallel!(
@@ -170,6 +174,7 @@ fn test_subst_nested() -> crate::Result {
 fn test_subst_if() -> crate::Result {
     use crate::ast::*;
     use crate::interpreter::Value;
+    use crate::schema::Assumption;
     let expr = tif(
         getat(0),
         add(getat(1), int(1)),
@@ -214,6 +219,7 @@ fn test_subst_if() -> crate::Result {
 #[test]
 fn test_subst_makes_new_context() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     use crate::{interpreter::Value, schema::Constant};
     let expr = add(int_ty(1, base(intt())), iarg());
     let replace_with = int_ty(2, base(intt()));
@@ -243,6 +249,7 @@ fn test_subst_makes_new_context() -> crate::Result {
 #[test]
 fn test_subst_arg_type_changes() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     use crate::{interpreter::Value, schema::Constant};
     let expr = add(iarg(), iarg()).add_ctx(Assumption::dummy());
     let tupletype = tuplet!(intt(), intt());
@@ -274,6 +281,7 @@ fn test_subst_arg_type_changes() -> crate::Result {
 #[test]
 fn test_subst_identity() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
 
     let expression = function(
         "main",
@@ -285,7 +293,7 @@ fn test_subst_identity() -> crate::Result {
     .func_add_ctx();
 
     let replace_with = int(5).with_arg_types(base(intt()), base(intt()));
-    let ctx = Assumption::dummy();
+    let ctx = Assumption::InFunc("main".to_string());
 
     let build = format!(
         "
@@ -307,6 +315,7 @@ fn test_subst_identity() -> crate::Result {
 #[test]
 fn test_subst_add() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
 
     let outer_if = add(int(5), arg());
     let expression = function("main", base(intt()), base(intt()), outer_if)
@@ -318,7 +327,7 @@ fn test_subst_add() -> crate::Result {
     let expected = function("main", base(intt()), base(intt()), add(int(5), int(5)))
         .func_with_arg_types()
         .func_add_ctx();
-    let ctx = Assumption::dummy();
+    let ctx = Assumption::InFunc("main".to_string());
 
     let build = format!(
         "

--- a/dag_in_context/src/utility/util.rs
+++ b/dag_in_context/src/utility/util.rs
@@ -5,20 +5,21 @@ use crate::{egglog_test, interpreter::Value};
 fn test_list_util() -> crate::Result {
     use crate::ast::emptyt;
     let emptyt = emptyt();
+    let ctx = Assumption::dummy();
     let build = format!(
         "
-		(let list (Cons (Const (Int 0) {emptyt} (NoContext))
-                  (Cons (Const (Int 1) {emptyt} (NoContext))
-                  (Cons (Const (Int 2) {emptyt} (NoContext))
-                  (Cons (Const (Int 3) {emptyt} (NoContext))
-                  (Cons (Const (Int 4) {emptyt} (NoContext)) (Nil)))))))
-		(let expr (Switch (Const (Int 1) {emptyt} (NoContext)) (Empty {emptyt} (NoContext)) list))
+		(let list (Cons (Const (Int 0) {emptyt} {ctx})
+                  (Cons (Const (Int 1) {emptyt} {ctx})
+                  (Cons (Const (Int 2) {emptyt} {ctx})
+                  (Cons (Const (Int 3) {emptyt} {ctx})
+                  (Cons (Const (Int 4) {emptyt} {ctx}) (Nil)))))))
+		(let expr (Switch (Const (Int 1) {emptyt} {ctx}) (Empty {emptyt} {ctx}) list))
 	"
     );
     let check = format!(
         "
-		(check (= (ListExpr-ith list 1) (Const (Int 1) {emptyt} (NoContext))))
-        (check (= (ListExpr-ith list 4) (Const (Int 4) {emptyt} (NoContext))))
+		(check (= (ListExpr-ith list 1) (Const (Int 1) {emptyt} {ctx})))
+        (check (= (ListExpr-ith list 4) (Const (Int 4) {emptyt} {ctx})))
         (check (= (ListExpr-length list) 5))
 	"
     );
@@ -36,19 +37,20 @@ fn test_list_util() -> crate::Result {
 fn append_test() -> crate::Result {
     use crate::ast::emptyt;
     let emptyt = emptyt();
+    let ctx = Assumption::dummy();
     let build = format!(
         "
         (let appended
             (Append
-                (Cons (Const (Int 0) {emptyt} (NoContext)) (Cons (Const (Int 1) {emptyt} (NoContext)) (Nil)))
-                (Const (Int 2) {emptyt} (NoContext))))
+                (Cons (Const (Int 0) {emptyt} {ctx}) (Cons (Const (Int 1) {emptyt} {ctx}) (Nil)))
+                (Const (Int 2) {emptyt} {ctx})))
     "
     );
 
     let check = format!("
         (check (
             =
-            (Cons (Const (Int 0) {emptyt} (NoContext)) (Cons (Const (Int 1) {emptyt} (NoContext)) (Cons (Const (Int 2) {emptyt} (NoContext)) (Nil))))
+            (Cons (Const (Int 0) {emptyt} {ctx}) (Cons (Const (Int 1) {emptyt} {ctx}) (Cons (Const (Int 2) {emptyt} {ctx}) (Nil))))
             appended
         ))
     ");
@@ -66,35 +68,36 @@ fn append_test() -> crate::Result {
 fn test_tuple_ith() -> crate::Result {
     use crate::ast::emptyt;
     let emptyt = emptyt();
+    let ctx = Assumption::dummy();
     let build = format!(
         "
     (let tup (Concat
-                  (Concat (Single (Const (Int 0) {emptyt} (NoContext))) (Single (Const (Int 1) {emptyt} (NoContext))))
-                  (Concat (Single (Const (Int 2) {emptyt} (NoContext))) (Single (Const (Int 3) {emptyt} (NoContext))))))
+                  (Concat (Single (Const (Int 0) {emptyt} {ctx})) (Single (Const (Int 1) {emptyt} {ctx})))
+                  (Concat (Single (Const (Int 2) {emptyt} {ctx})) (Single (Const (Int 3) {emptyt} {ctx})))))
     
     ;; with print
     (let tup2 (Concat 
                 (Concat 
-                    (Single (Bop (Print) (Const (Int 0) {emptyt} (NoContext)) (Arg (Base (StateT)) (NoContext))))
-                    (Concat (Single (Const (Int 1) {emptyt} (NoContext))) 
-                                (Single (Const (Int 2) {emptyt} (NoContext)))))
-                (Single (Const (Int 3) {emptyt} (NoContext)))))
+                    (Single (Bop (Print) (Const (Int 0) {emptyt} {ctx}) (Arg (Base (StateT)) {ctx})))
+                    (Concat (Single (Const (Int 1) {emptyt} {ctx})) 
+                                (Single (Const (Int 2) {emptyt} {ctx}))))
+                (Single (Const (Int 3) {emptyt} {ctx}))))
     "
     );
 
     let check = format!(
         "
-    (check (= (Get tup 0) (Const (Int 0) {emptyt} (NoContext))))
-    (check (= (Get tup 1) (Const (Int 1) {emptyt} (NoContext))))
-    (check (= (Get tup 2) (Const (Int 2) {emptyt} (NoContext))))
-    (check (= (Get tup 3) (Const (Int 3) {emptyt} (NoContext))))
+    (check (= (Get tup 0) (Const (Int 0) {emptyt} {ctx})))
+    (check (= (Get tup 1) (Const (Int 1) {emptyt} {ctx})))
+    (check (= (Get tup 2) (Const (Int 2) {emptyt} {ctx})))
+    (check (= (Get tup 3) (Const (Int 3) {emptyt} {ctx})))
     (check (= 4 (tuple-length tup)))
     (fail (check (Get tup 4)))
 
-    (check (= (Get tup2 0) (Bop (Print) (Const (Int 0) {emptyt} (NoContext)) (Arg (Base (StateT)) (NoContext)))))
-    (check (= (Get tup2 1) (Const (Int 1) {emptyt} (NoContext))))
-    (check (= (Get tup2 2) (Const (Int 2) {emptyt} (NoContext))))
-    (check (= (Get tup2 3) (Const (Int 3) {emptyt} (NoContext))))
+    (check (= (Get tup2 0) (Bop (Print) (Const (Int 0) {emptyt} {ctx}) (Arg (Base (StateT)) {ctx}))))
+    (check (= (Get tup2 1) (Const (Int 1) {emptyt} {ctx})))
+    (check (= (Get tup2 2) (Const (Int 2) {emptyt} {ctx})))
+    (check (= (Get tup2 3) (Const (Int 3) {emptyt} {ctx})))
     (check (= 4 (tuple-length tup2)))
     (fail (check (Get tup2 4)))
     "

--- a/dag_in_context/src/utility/util.rs
+++ b/dag_in_context/src/utility/util.rs
@@ -4,6 +4,7 @@ use crate::{egglog_test, interpreter::Value};
 #[test]
 fn test_list_util() -> crate::Result {
     use crate::ast::emptyt;
+    use crate::schema::Assumption;
     let emptyt = emptyt();
     let ctx = Assumption::dummy();
     let build = format!(
@@ -36,6 +37,7 @@ fn test_list_util() -> crate::Result {
 #[test]
 fn append_test() -> crate::Result {
     use crate::ast::emptyt;
+    use crate::schema::Assumption;
     let emptyt = emptyt();
     let ctx = Assumption::dummy();
     let build = format!(
@@ -67,6 +69,7 @@ fn append_test() -> crate::Result {
 #[test]
 fn test_tuple_ith() -> crate::Result {
     use crate::ast::emptyt;
+    use crate::schema::Assumption;
     let emptyt = emptyt();
     let ctx = Assumption::dummy();
     let build = format!(

--- a/dag_in_context/src/utility/wildcard.rs
+++ b/dag_in_context/src/utility/wildcard.rs
@@ -4,6 +4,7 @@ use crate::{egglog_test, interpreter::Value};
 #[test]
 fn test_wildcard() -> crate::Result {
     use crate::ast::*;
+    use crate::schema::Assumption;
     let in_ty = tuplet!(intt(), intt());
     let expr = add(getat(0), getat(1))
         .with_arg_types(in_ty.clone(), base(intt()))

--- a/dag_in_context/src/utility/wildcard.rs
+++ b/dag_in_context/src/utility/wildcard.rs
@@ -7,7 +7,7 @@ fn test_wildcard() -> crate::Result {
     let in_ty = tuplet!(intt(), intt());
     let expr = add(getat(0), getat(1))
         .with_arg_types(in_ty.clone(), base(intt()))
-        .add_ctx(noctx());
+        .add_ctx(Assumption::dummy());
     let expr_with_wildcard = add(getat(0), getat(1))
         .with_arg_types(in_ty.clone(), base(intt()))
         .add_ctx(wildcardctx("CTX".to_string()));

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -37,9 +37,9 @@ expression: visualization.result
   v25_: int = div v6_ v9_;
   v26_: int = mul v9_ v25_;
   v27_: int = sub v6_ v26_;
-  v28_: bool = eq v10_ v27_;
+  v28_: bool = eq v27_ v10_;
   print v6_;
-  v29_: int = mul v8_ v6_;
+  v29_: int = mul v6_ v8_;
   v30_: int = add v29_ v7_;
   br v28_ .v31_ .v32_;
 .v31_:

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -37,9 +37,9 @@ expression: visualization.result
   v25_: int = div v6_ v9_;
   v26_: int = mul v9_ v25_;
   v27_: int = sub v6_ v26_;
-  v28_: bool = eq v27_ v10_;
+  v28_: bool = eq v10_ v27_;
   print v6_;
-  v29_: int = mul v8_ v6_;
+  v29_: int = mul v6_ v8_;
   v30_: int = add v7_ v29_;
   br v28_ .v31_ .v32_;
 .v31_:

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -4,7 +4,7 @@ expression: visualization.result
 ---
 @fac(v0: int): int {
   v1_: int = const 0;
-  v2_: bool = eq v0 v1_;
+  v2_: bool = eq v1_ v0;
   v3_: int = const 1;
   br v2_ .v4_ .v5_;
 .v4_:

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -15,7 +15,7 @@ expression: visualization.result
   br v8_ .v9_ .v10_;
 .v9_:
   v11_: int = call @fac v1_;
-  v12_: int = id v3_;
+  v12_: int = id v0;
 .v13_:
   v6_: int = id v12_;
   jmp .v7_;
@@ -24,7 +24,7 @@ expression: visualization.result
   v15_: int = sub v14_ v3_;
   v16_: int = call @fac v14_;
   v17_: int = call @fac v15_;
-  v18_: int = add v17_ v16_;
+  v18_: int = add v16_ v17_;
   v12_: int = id v18_;
   jmp .v13_;
 .v7_:

--- a/tests/snapshots/files__fib_shape-optimize.snap
+++ b/tests/snapshots/files__fib_shape-optimize.snap
@@ -12,7 +12,7 @@ expression: visualization.result
   v7_: bool = lt v3_ v5_;
   br v7_ .v8_ .v9_;
 .v8_:
-  v10_: int = add v4_ v3_;
+  v10_: int = add v3_ v4_;
   v11_: bool = const true;
   v12_: int = id v10_;
   v13_: bool = id v11_;

--- a/tests/snapshots/files__flatten_loop-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-optimize.snap
@@ -24,10 +24,10 @@ expression: visualization.result
   br v19_ .v20_ .v21_;
 .v20_:
   v22_: int = mul v16_ v13_;
-  v23_: int = add v15_ v22_;
+  v23_: int = add v22_ v15_;
   print v23_;
   v24_: bool = const true;
-  v25_: int = add v14_ v15_;
+  v25_: int = add v15_ v14_;
   v26_: int = id v13_;
   v27_: int = id v14_;
   v28_: bool = id v24_;
@@ -42,7 +42,7 @@ expression: visualization.result
   v17_: int = id v17_;
   br v19_ .v18_ .v33_;
 .v33_:
-  v34_: int = add v14_ v13_;
+  v34_: int = add v13_ v14_;
   v35_: bool = const true;
   v36_: int = id v34_;
   v37_: bool = id v35_;

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -4,8 +4,8 @@ expression: visualization.result
 ---
 @main(v0: int) {
   v1_: int = const 0;
-  v2_: bool = gt v0 v1_;
-  v3_: bool = lt v0 v1_;
+  v2_: bool = lt v0 v1_;
+  v3_: bool = gt v0 v1_;
   v4_: int = const 1;
   br v2_ .v5_ .v6_;
 .v5_:

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -15,10 +15,10 @@ expression: visualization.result
   v11_: bool = lt v6_ v9_;
   br v11_ .v12_ .v13_;
 .v12_:
-  v14_: int = mul v7_ v5_;
+  v14_: int = mul v5_ v7_;
   v15_: bool = const true;
   v16_: int = const 1;
-  v17_: int = add v6_ v16_;
+  v17_: int = add v16_ v6_;
   v18_: int = id v14_;
   v19_: bool = id v15_;
   v20_: int = id v17_;

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -14,10 +14,10 @@ expression: visualization.result
   v10_: bool = lt v4_ v9_;
   br v10_ .v11_ .v12_;
 .v11_:
-  v13_: int = mul v5_ v3_;
+  v13_: int = mul v3_ v5_;
   v14_: bool = const true;
   v15_: int = const 1;
-  v16_: int = add v4_ v15_;
+  v16_: int = add v15_ v4_;
   v17_: int = id v13_;
   v18_: bool = id v14_;
   v19_: int = id v16_;

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -32,8 +32,8 @@ expression: visualization.result
   jmp .v17_;
 .v6_:
   v20_: int = const 1;
-  v21_: int = add v1_ v20_;
-  v22_: int = add v20_ v2_;
+  v21_: int = add v20_ v1_;
+  v22_: int = add v2_ v20_;
   v7_: int = id v21_;
   v8_: bool = id v4_;
   v9_: int = id v22_;

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -7,7 +7,7 @@ expression: visualization.result
   v1_: int = id v0_;
   v2_: int = id v0_;
 .v3_:
-  v4_: bool = eq v1_ v2_;
+  v4_: bool = eq v2_ v1_;
   br v4_ .v5_ .v6_;
 .v5_:
   v7_: int = id v1_;

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -7,7 +7,7 @@ expression: visualization.result
   v1_: int = id v0_;
   v2_: int = id v0_;
 .v3_:
-  v4_: bool = eq v2_ v1_;
+  v4_: bool = eq v1_ v2_;
   br v4_ .v5_ .v6_;
 .v5_:
   v7_: int = id v1_;

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -3,7 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 2;
+  v1_: int = const 1;
   v2_: int = id v1_;
   v3_: int = id v0;
 .v4_:
@@ -14,6 +14,6 @@ expression: visualization.result
   v3_: int = id v3_;
   br v7_ .v4_ .v8_;
 .v8_:
-  v9_: int = add v3_ v2_;
+  v9_: int = add v2_ v3_;
   print v9_;
 }

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -3,7 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 1;
+  v1_: int = const 2;
   v2_: int = id v1_;
   v3_: int = id v0;
 .v4_:

--- a/tests/snapshots/files__nested_call-optimize.snap
+++ b/tests/snapshots/files__nested_call-optimize.snap
@@ -10,7 +10,7 @@ expression: visualization.result
 }
 @double(v0: int): int {
   v1_: int = const 2;
-  v2_: int = mul v0 v1_;
+  v2_: int = mul v1_ v0;
   ret v2_;
 }
 @main {

--- a/tests/snapshots/files__range_splitting-optimize.snap
+++ b/tests/snapshots/files__range_splitting-optimize.snap
@@ -7,7 +7,7 @@ expression: visualization.result
   v1_: int = id v0_;
 .v2_:
   v3_: int = const 1;
-  v4_: int = add v1_ v3_;
+  v4_: int = add v3_ v1_;
   v5_: int = const 5;
   v6_: bool = lt v4_ v5_;
   v7_: bool = lt v1_ v5_;

--- a/tests/snapshots/files__simple_call-optimize.snap
+++ b/tests/snapshots/files__simple_call-optimize.snap
@@ -4,7 +4,7 @@ expression: visualization.result
 ---
 @inc(v0: int) {
   v1_: int = const 1;
-  v2_: int = add v1_ v0;
+  v2_: int = add v0 v1_;
   print v2_;
 }
 @main {

--- a/tests/snapshots/files__small-collatz-optimize.snap
+++ b/tests/snapshots/files__small-collatz-optimize.snap
@@ -14,7 +14,7 @@ expression: visualization.result
   v9_: int = id v4_;
   v10_: int = id v1_;
 .v11_:
-  v12_: bool = eq v6_ v8_;
+  v12_: bool = eq v8_ v6_;
   br v12_ .v13_ .v14_;
 .v13_:
   v15_: bool = const false;
@@ -35,7 +35,7 @@ expression: visualization.result
   br v17_ .v11_ .v24_;
 .v14_:
   v25_: int = div v6_ v7_;
-  v26_: int = mul v25_ v7_;
+  v26_: int = mul v7_ v25_;
   v27_: int = sub v6_ v26_;
   v28_: bool = eq v27_ v10_;
   v29_: int = add v8_ v5_;

--- a/tests/snapshots/files__small-collatz-optimize.snap
+++ b/tests/snapshots/files__small-collatz-optimize.snap
@@ -35,10 +35,10 @@ expression: visualization.result
   br v17_ .v11_ .v24_;
 .v14_:
   v25_: int = div v6_ v7_;
-  v26_: int = mul v25_ v7_;
+  v26_: int = mul v7_ v25_;
   v27_: int = sub v6_ v26_;
-  v28_: bool = eq v10_ v27_;
-  v29_: int = add v8_ v5_;
+  v28_: bool = eq v27_ v10_;
+  v29_: int = add v5_ v8_;
   br v28_ .v30_ .v31_;
 .v30_:
   v32_: bool = const true;
@@ -61,7 +61,7 @@ expression: visualization.result
   jmp .v23_;
 .v31_:
   v42_: bool = const true;
-  v43_: int = mul v9_ v6_;
+  v43_: int = mul v6_ v9_;
   v44_: int = add v8_ v43_;
   v34_: int = id v29_;
   v35_: bool = id v42_;

--- a/tests/snapshots/files__small-collatz-optimize.snap
+++ b/tests/snapshots/files__small-collatz-optimize.snap
@@ -35,7 +35,7 @@ expression: visualization.result
   br v17_ .v11_ .v24_;
 .v14_:
   v25_: int = div v6_ v7_;
-  v26_: int = mul v7_ v25_;
+  v26_: int = mul v25_ v7_;
   v27_: int = sub v6_ v26_;
   v28_: bool = eq v27_ v10_;
   v29_: int = add v5_ v8_;

--- a/tests/snapshots/files__small-fib-optimize.snap
+++ b/tests/snapshots/files__small-fib-optimize.snap
@@ -20,7 +20,7 @@ expression: visualization.result
   v12_: bool = lt v7_ v10_;
   br v12_ .v13_ .v14_;
 .v13_:
-  v15_: int = add v8_ v9_;
+  v15_: int = add v9_ v8_;
   print v15_;
   v16_: bool = const true;
   v17_: int = const 1;

--- a/tests/snapshots/files__strong_loop-optimize.snap
+++ b/tests/snapshots/files__strong_loop-optimize.snap
@@ -4,7 +4,7 @@ expression: visualization.result
 ---
 @main(v0: int) {
   v1_: int = const 3;
-  v2_: int = add v0 v1_;
+  v2_: int = add v1_ v0;
   v3_: int = const 0;
   v4_: int = id v1_;
   v5_: int = id v2_;
@@ -12,11 +12,11 @@ expression: visualization.result
   v7_: int = id v0;
 .v8_:
   v9_: int = const 7;
-  v10_: int = mul v9_ v4_;
+  v10_: int = mul v4_ v9_;
   print v10_;
   v11_: int = const 2;
   v12_: int = add v11_ v4_;
-  v13_: int = add v6_ v10_;
+  v13_: int = add v10_ v6_;
   v14_: bool = lt v4_ v7_;
   v4_: int = id v12_;
   v5_: int = id v5_;

--- a/tests/snapshots/files__strong_loop-optimize.snap
+++ b/tests/snapshots/files__strong_loop-optimize.snap
@@ -4,7 +4,7 @@ expression: visualization.result
 ---
 @main(v0: int) {
   v1_: int = const 3;
-  v2_: int = add v1_ v0;
+  v2_: int = add v0 v1_;
   v3_: int = const 0;
   v4_: int = id v1_;
   v5_: int = id v2_;

--- a/tests/snapshots/files__unroll_multiple_4-optimize.snap
+++ b/tests/snapshots/files__unroll_multiple_4-optimize.snap
@@ -9,7 +9,7 @@ expression: visualization.result
   v3_: int = id v1_;
   v4_: int = id v0_;
 .v5_:
-  v6_: int = add v4_ v2_;
+  v6_: int = add v2_ v4_;
   v7_: bool = lt v6_ v3_;
   v2_: int = id v6_;
   v3_: int = id v3_;


### PR DESCRIPTION
so that there will be no sharing among expressions in different functions. A follow-up task is to re-enable function inlining based on this refactor.