### PR TITLE
Improve extraction's memory usage by filtering to correct types

### DIFF
--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -82,6 +82,10 @@ impl<'a> EgraphInfo<'a> {
             }
         }
 
+        if relavent_nodes.len() > egraph.classes().len() * 3 {
+            eprintln!("Warning: significant sharing between region roots, {}x blowup. May cause bad extraction performance. Eclasses: {}. (Root, eclass) pairs: {}. Region roots: {}", relavent_nodes.len() / egraph.classes().len(), egraph.classes().len(), relavent_nodes.len(), region_roots.len());
+        }
+
         let mut roots = vec![];
         // find all the (root, enode) pairs that are root nodes (no children)
         for (root, eclass) in &relavent_nodes {

--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -187,7 +187,7 @@ pub fn check_roundtrip_egraph(program: &TreeProgram) {
     let (serialized, unextractables) = serialized_egraph(egraph);
     let (_res_cost, res) = extract(
         program,
-        &serialized,
+        serialized,
         unextractables,
         &mut termdag,
         DefaultCostModel,
@@ -209,7 +209,7 @@ pub fn optimize(program: &TreeProgram) -> std::result::Result<TreeProgram, egglo
     let mut termdag = egglog::TermDag::default();
     let (_res_cost, res) = extract(
         program,
-        &serialized,
+        serialized,
         unextractables,
         &mut termdag,
         DefaultCostModel,

--- a/dag_in_context/src/linearity.rs
+++ b/dag_in_context/src/linearity.rs
@@ -46,7 +46,7 @@ impl<'a> Extractor<'a> {
             .map(|(node_id, node)| (node_id.clone(), node.eclass.clone()))
             .collect();
 
-        let prog_root_id = get_root(egraph_info.egraph); // should be the id of prog
+        let prog_root_id = get_root(&egraph_info.egraph); // should be the id of prog
         let prog_root_id = egraph_info.egraph.nid_to_cid(&prog_root_id);
         let mut linearity = Linearity {
             effectful_nodes: vec![],

--- a/dag_in_context/src/schema_helpers.rs
+++ b/dag_in_context/src/schema_helpers.rs
@@ -410,7 +410,7 @@ impl TreeProgram {
 
 use std::iter;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, EnumIter)]
 pub(crate) enum Sort {
     Expr,
     ListExpr,
@@ -418,10 +418,14 @@ pub(crate) enum Sort {
     UnaryOp,
     TernaryOp,
     I64,
+    Bool,
     Type,
     String,
     Constant,
     Assumption,
+    BaseType,
+    TypeList,
+    ProgramType,
 }
 
 impl Sort {
@@ -430,6 +434,7 @@ impl Sort {
             Sort::Expr => "Expr",
             Sort::ListExpr => "ListExpr",
             Sort::I64 => "i64",
+            Sort::Bool => "bool",
             Sort::String => "String",
             Sort::Type => "Type",
             Sort::BinaryOp => "BinaryOp",
@@ -437,6 +442,9 @@ impl Sort {
             Sort::TernaryOp => "TernaryOp",
             Sort::Constant => "Constant",
             Sort::Assumption => "Assumption",
+            Sort::BaseType => "BaseType",
+            Sort::TypeList => "TypeList",
+            Sort::ProgramType => "ProgramType",
         }
     }
 }


### PR DESCRIPTION
The main change in this PR is to check the sort of nodes during the reachability query.
Other than that, this PR refactors costsets to get more sharing.

This PR reduces memory usage by 10x on hard benchmarks