### PR TITLE
Peepholes in nonopt llvm

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         submodules: 'true'
     - uses: Swatinem/rust-cache@v2
-    - run: sudo apt install graphviz && cargo install cargo-insta && make test
+    - run: sudo apt install graphviz llvm && cargo install cargo-insta && make test
   nits:
     runs-on: ubuntu-latest
     steps:

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,12 +3,10 @@ use crate::rvsdg::from_dag::dag_to_rvsdg;
 use crate::{EggCCError, Optimizer};
 use bril_rs::Program;
 use clap::ValueEnum;
+use dag_in_context::dag2svg::tree_to_svg;
 use dag_in_context::{build_program, check_roundtrip_egraph};
 
 use dag_in_context::schema::TreeProgram;
-use graphviz_rust::cmd::Format;
-use graphviz_rust::exec;
-use graphviz_rust::printer::PrinterContext;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -105,19 +103,6 @@ pub fn visualize(test: TestProgram, output_dir: PathBuf) -> io::Result<()> {
     }
 
     Ok(())
-}
-
-pub fn tree_to_svg(prog: &TreeProgram) -> String {
-    let dot_code = prog.to_dot();
-    String::from_utf8(
-        exec(
-            dot_code,
-            &mut PrinterContext::default(),
-            vec![Format::Svg.into()],
-        )
-        .unwrap(),
-    )
-    .unwrap()
 }
 
 /// Invokes some program with the given arguments, piping the given input to the program.
@@ -410,6 +395,8 @@ impl Run {
                     ..default
                 };
                 res.push(interp);
+            } else {
+                res.push(default);
             }
         }
 


### PR DESCRIPTION
This is to get us closer to an apples-to-apples comparison with LLVM, given that
most of its peepholes can't be written as rewrites on pure bril.