### PR TITLE
Fix multiple terms per eclass bug in extraction

### DIFF
--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -33,7 +33,6 @@ pub(crate) struct Extractor<'a> {
     pub(crate) termdag: &'a mut TermDag,
     costsets: Vec<CostSet>,
     costsetmemo: FxHashMap<(NodeId, Vec<CostSetIndex>), CostSetIndex>,
-    dummy_contexts: FxHashMap<ClassId, CostSetIndex>,
     costs: FxHashMap<ClassId, FxHashMap<ClassId, CostSetIndex>>,
 
     // use to get the type of an expression
@@ -252,10 +251,9 @@ impl<'a> Extractor<'a> {
                 total: 0.0.try_into().unwrap(),
                 term,
             };
-            let classid = info.egraph.nid_to_cid(node_id);
             self.costsets.push(costset);
-            self.dummy_contexts
-                .insert(classid.clone(), self.costsets.len() - 1);
+            self.costsetmemo
+                .insert((node_id.clone(), vec![]), self.costsets.len() - 1);
             self.costsets.len() - 1
         }
     }
@@ -265,7 +263,6 @@ impl<'a> Extractor<'a> {
             termdag,
             costsets: Default::default(),
             costsetmemo: Default::default(),
-            dummy_contexts: Default::default(),
             correspondence: Default::default(),
             costs: Default::default(),
             term_to_expr: Default::default(),

--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -33,6 +33,7 @@ pub(crate) struct Extractor<'a> {
     pub(crate) termdag: &'a mut TermDag,
     costsets: Vec<CostSet>,
     costsetmemo: FxHashMap<(NodeId, Vec<CostSetIndex>), CostSetIndex>,
+    dummy_contexts: FxHashMap<ClassId, CostSetIndex>,
     costs: FxHashMap<ClassId, FxHashMap<ClassId, CostSetIndex>>,
 
     // use to get the type of an expression
@@ -40,7 +41,7 @@ pub(crate) struct Extractor<'a> {
 
     // Each term must correspond to a node in the egraph. We store that here
     // Use an indexmap for deterministic order of iteration
-    pub(crate) correspondence: IndexMap<Term, HashSet<NodeId>>,
+    pub(crate) correspondence: IndexMap<Term, NodeId>,
     // Get the expression corresponding to a term.
     // This is computed after the extraction is done.
     pub(crate) term_to_expr: Option<HashMap<Term, RcExpr>>,
@@ -199,20 +200,18 @@ impl<'a> Extractor<'a> {
         };
         let mut node_to_type: HashMap<ClassId, Type> = Default::default();
 
-        for (term, nodes) in &self.correspondence {
-            for node_id in nodes {
-                let node = info.egraph.nodes.get(node_id).unwrap();
-                let eclass = info.egraph.nid_to_cid(node_id);
-                let sort_of_eclass = info.get_sort_of_eclass(eclass);
-                // only convert expressions (that are not functions)
-                if sort_of_eclass == "Expr" && node.op != "Function" {
-                    let expr = converter.expr_from_egglog(term.clone());
-                    let ty = self
-                        .typechecker
-                        .add_arg_types_to_expr(expr.clone(), &None)
-                        .0;
-                    node_to_type.insert(eclass.clone(), ty);
-                }
+        for (term, node_id) in &self.correspondence {
+            let node = info.egraph.nodes.get(node_id).unwrap();
+            let eclass = info.egraph.nid_to_cid(node_id);
+            let sort_of_eclass = info.get_sort_of_eclass(eclass);
+            // only convert expressions (that are not functions)
+            if sort_of_eclass == "Expr" && node.op != "Function" {
+                let expr = converter.expr_from_egglog(term.clone());
+                let ty = self
+                    .typechecker
+                    .add_arg_types_to_expr(expr.clone(), &None)
+                    .0;
+                node_to_type.insert(eclass.clone(), ty);
             }
         }
 
@@ -225,31 +224,47 @@ impl<'a> Extractor<'a> {
         converted_prog
     }
 
-    /// A term can correspond to multiple nodes in the egraph.
-    /// This is because we forget the context when building the term, so
-    /// multiple nodes in different context are the same as far as the term is concerned.
-    pub(crate) fn term_nodes(&self, term: &Term) -> HashSet<NodeId> {
+    pub(crate) fn term_node(&self, term: &Term) -> NodeId {
         self.correspondence
             .get(term)
             .unwrap_or_else(|| panic!("Failed to find correspondence for term {:?}", term))
             .clone()
     }
 
-    pub(crate) fn new(original_prog: &'a TreeProgram, termdag: &'a mut TermDag) -> Self {
-        // first element is always a dummy costset
-        let costsets = vec![CostSet {
-            costs: Default::default(),
-            total: 0.0.try_into().unwrap(),
-            term: {
-                let dummy = termdag.lit(Literal::String("dummy".into()));
-                termdag.app("InFunc".into(), vec![dummy])
-            },
-        }];
+    pub(crate) fn get_dummy_context(
+        &mut self,
+        info: &EgraphInfo,
+        class_id: ClassId,
+    ) -> CostSetIndex {
+        // get any node in the class
+        let node_id = info.egraph.classes()[&class_id].nodes.first().unwrap();
+        if let Some(existing) = self.costsetmemo.get(&(node_id.clone(), vec![])) {
+            *existing
+        } else {
+            let dummy = self
+                .termdag
+                .lit(Literal::String(format!("dummy{}", node_id).into()));
+            let term = self.termdag.app("InFunc".into(), vec![dummy]);
+            Self::add_correspondence(&mut self.correspondence, term.clone(), node_id.clone());
+            let costset = CostSet {
+                costs: Default::default(),
+                total: 0.0.try_into().unwrap(),
+                term,
+            };
+            let classid = info.egraph.nid_to_cid(node_id);
+            self.costsets.push(costset);
+            self.dummy_contexts
+                .insert(classid.clone(), self.costsets.len() - 1);
+            self.costsets.len() - 1
+        }
+    }
 
+    pub(crate) fn new(original_prog: &'a TreeProgram, termdag: &'a mut TermDag) -> Self {
         Extractor {
             termdag,
-            costsets,
+            costsets: Default::default(),
             costsetmemo: Default::default(),
+            dummy_contexts: Default::default(),
             correspondence: Default::default(),
             costs: Default::default(),
             term_to_expr: Default::default(),
@@ -298,10 +313,12 @@ type CostSetIndex = usize;
 
 #[derive(Clone, Debug)]
 pub struct CostSet {
+    /// Total cost of this term, taking sharing into account
     pub total: Cost,
-    // TODO perhaps more efficient as
-    // persistent data structure?
-    pub costs: HashTrieMap<ClassId, Cost>,
+    /// Maps classes to the chosen term for the eclass,
+    /// along with the cost for that term (excluding child costs).
+    pub costs: HashTrieMap<ClassId, (Term, Cost)>,
+    /// The resulting term
     pub term: Term,
 }
 
@@ -310,6 +327,10 @@ impl<'a> Extractor<'a> {
     /// We also need to add this term to the correspondence map so we can
     /// find its enode id later.
     fn get_term(&mut self, info: &EgraphInfo, node_id: NodeId, children: Vec<Term>) -> Term {
+        eprintln!(
+            "Getting term for node {:?} with children {:?}",
+            node_id, children
+        );
         let node = &info.egraph[&node_id];
         let op = &node.op;
         let term = if children.is_empty() {
@@ -329,12 +350,71 @@ impl<'a> Extractor<'a> {
             self.termdag.app(op.into(), children)
         };
 
-        self.correspondence
-            .entry(term.clone())
-            .or_default()
-            .insert(node_id);
+        Self::add_correspondence(&mut self.correspondence, term.clone(), node_id.clone());
 
         term
+    }
+
+    fn add_correspondence(
+        correspondence: &mut IndexMap<Term, NodeId>,
+        term: Term,
+        node_id: NodeId,
+    ) {
+        eprintln!("Adding correspondence for {:?}", term);
+        if let Some(existing) = correspondence.insert(term.clone(), node_id.clone()) {
+            assert_eq!(existing, node_id);
+        }
+    }
+
+    /// Add `term` to `current_costs`, returning
+    /// 1) a new term that takes advantage of sharing
+    /// with respect to `current_costs` and
+    /// 2) the net cost of adding the new term
+    fn add_term_to_cost_set(
+        &self,
+        info: &EgraphInfo,
+        correspondance: &mut IndexMap<Term, NodeId>,
+        termdag: &mut TermDag,
+        current_costs: &mut HashTrieMap<ClassId, (Term, Cost)>,
+        term: Term,
+        other_costs: &HashTrieMap<ClassId, (Term, Cost)>,
+    ) -> (Term, Cost) {
+        let nodeid = &self.term_node(&term);
+        let eclass = info.egraph.nid_to_cid(nodeid);
+        if let Some(existing) = current_costs.get(eclass) {
+            existing.clone()
+        } else {
+            let unshared_cost = match other_costs.get(eclass) {
+                Some((_, cost)) => *cost,
+                None => NotNan::new(0.).unwrap(),
+            };
+            let mut cost = unshared_cost;
+            let new_term = match term {
+                Term::App(head, children) => {
+                    let mut new_children = vec![];
+                    for child in children {
+                        let child = termdag.get(child);
+                        let (new_child, child_cost) = self.add_term_to_cost_set(
+                            info,
+                            correspondance,
+                            termdag,
+                            current_costs,
+                            child,
+                            other_costs,
+                        );
+                        new_children.push(new_child);
+                        cost += child_cost;
+                    }
+                    termdag.app(head, new_children)
+                }
+                _ => term,
+            };
+            Self::add_correspondence(correspondance, new_term.clone(), nodeid.clone());
+            *current_costs =
+                current_costs.insert(eclass.clone(), (new_term.clone(), unshared_cost));
+
+            (new_term, cost)
+        }
     }
 
     fn calculate_cost_set(
@@ -371,7 +451,7 @@ impl<'a> Extractor<'a> {
 
         let mut shared_total = NotNan::new(0.).unwrap();
         let mut unshared_total = info.cm.get_op_cost(&node.op);
-        let mut costs: HashTrieMap<ClassId, NotNan<f64>> = Default::default();
+        let mut costs: HashTrieMap<ClassId, (Term, Cost)> = Default::default();
         let index_of_biggest_child = child_cost_sets
             .iter()
             .enumerate()
@@ -393,6 +473,13 @@ impl<'a> Extractor<'a> {
             }
         }
 
+        let mut children_terms = vec![];
+        let mut termdag_tmp = TermDag::default();
+        let mut correspondance_tmp = IndexMap::default();
+        // swap out the termdag and correspondance for the temporary one
+        std::mem::swap(self.termdag, &mut termdag_tmp);
+        std::mem::swap(&mut self.correspondence, &mut correspondance_tmp);
+
         if !info.cm.ignore_children(&node.op) {
             for (index, (child_set, is_region_root)) in child_cost_sets.iter().enumerate() {
                 if *is_region_root {
@@ -400,49 +487,43 @@ impl<'a> Extractor<'a> {
                 } else {
                     // costs is empty, replace it with the child one
                     if Some(index) == index_of_biggest_child {
-                        // skip the biggest child
+                        // skip the biggest child's cost
+                        children_terms.push(child_set.term.clone());
                     } else {
-                        for (child_cid, child_cost) in &child_set.costs {
-                            // it was already present in the set
-                            if let Some(existing) = costs.get(child_cid) {
-                                if existing > child_cost {
-                                    // if we found a lower-cost alternative for this child, use that and decrease cost
-                                    shared_total -= existing - *child_cost;
-                                    costs =
-                                        costs.insert(child_cid.clone(), *existing.min(child_cost));
-                                }
-                            } else {
-                                costs = costs.insert(child_cid.clone(), *child_cost);
-                                shared_total += child_cost;
-                            }
-                        }
+                        eprintln!("Adding child cost set for {:?}", child_set.term);
+                        let (child_term, net_cost) = self.add_term_to_cost_set(
+                            info,
+                            &mut correspondance_tmp,
+                            &mut termdag_tmp,
+                            &mut costs,
+                            child_set.term.clone(),
+                            &child_set.costs,
+                        );
+                        shared_total += net_cost;
+                        children_terms.push(child_term);
                     }
                 }
             }
         }
 
+        // swap back the termdag and correspondance
+        std::mem::swap(self.termdag, &mut termdag_tmp);
+        std::mem::swap(&mut self.correspondence, &mut correspondance_tmp);
+
+        let term = self.get_term(info, nodeid.clone(), children_terms);
+
         // no need to add something that costs 0 to the set
         if unshared_total > NotNan::new(0.).unwrap() {
-            costs = costs.insert(cid.clone(), unshared_total);
+            costs = costs.insert(cid.clone(), (term.clone(), unshared_total));
         }
         let total = unshared_total + shared_total;
 
-        let sub_terms: Vec<Term> = child_cost_sets
-            .iter()
-            .map(|(cs, _)| cs.term.clone())
-            .collect();
-
-        let term = self.get_term(info, nodeid.clone(), sub_terms);
         self.costsets.push(CostSet { total, costs, term });
         let index = self.costsets.len() - 1;
         self.costsetmemo
             .insert((nodeid, child_cost_set_indecies), index);
 
         Some(index)
-    }
-
-    pub(crate) fn dummy_costset(&self) -> CostSetIndex {
-        0
     }
 }
 
@@ -457,8 +538,6 @@ fn calculate_node_cost_set(
 ) -> Option<CostSetIndex> {
     let node = &info.egraph[&node_id];
 
-    let region_costs = extractor.costs.get(&rootid).unwrap();
-
     // get the cost sets for the children
     let child_cost_sets = enode_children(&info.egraph, node)
         .iter()
@@ -470,10 +549,11 @@ fn calculate_node_cost_set(
              }| {
                 // for assumptions, just return a dummy context every time
                 if *is_assumption {
-                    Some(extractor.dummy_costset())
+                    Some(extractor.get_dummy_context(info, child.clone()))
                 } else if *is_subregion {
                     extractor.costs.get(child)?.get(child).copied()
                 } else {
+                    let region_costs = extractor.costs.get(&rootid).unwrap();
                     region_costs.get(child).copied()
                 }
             },

--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -374,8 +374,8 @@ impl<'a> Extractor<'a> {
     ) -> (Term, Cost) {
         let nodeid = &self.term_node(&term);
         let eclass = info.egraph.nid_to_cid(nodeid);
-        if let Some(existing) = current_costs.get(eclass) {
-            existing.clone()
+        if let Some((existing_term, _existing_cost)) = current_costs.get(eclass) {
+            (existing_term.clone(), NotNan::new(0.).unwrap())
         } else {
             let unshared_cost = match other_costs.get(eclass) {
                 Some((_, cost)) => *cost,
@@ -1097,8 +1097,9 @@ fn test_dag_extract() {
     let cost_of_one_func = cost_model.get_op_cost("Add") * 2.
         + cost_model.get_op_cost("DoWhile")
         + cost_model.get_op_cost("LessThan")
-        // while the same const is used three times, it is only counted twice
+        // while the same const is used several times, it is only counted twice
         + cost_model.get_op_cost("Const") * 2.;
+    // two of the same function
     let expected_cost = cost_of_one_func * 2.;
     dag_extraction_test(&prog, expected_cost);
 }

--- a/dag_in_context/src/linearity.rs
+++ b/dag_in_context/src/linearity.rs
@@ -64,13 +64,13 @@ impl<'a> Extractor<'a> {
             .map(|(k, v)| {
                 let v = v
                     .into_iter()
-                    .flat_map(|expr| self.term_nodes(linearity.expr_to_term.get(&expr).unwrap()))
+                    .map(|expr| self.term_node(linearity.expr_to_term.get(&expr).unwrap()))
                     .collect();
                 (k, v)
             })
             .collect();
 
-        // assert that we only find one node per eclass
+        // assert that we only find one node per eclass (otherwise the extractor is incorrect)
         for nodes in effectful_nodes.values() {
             let mut eclasses = HashSet::new();
             for node in nodes {
@@ -81,34 +81,29 @@ impl<'a> Extractor<'a> {
         effectful_nodes
     }
 
-    fn classes_of_expr(&self, linearity: &Linearity, expr: &RcExpr) -> HashSet<ClassId> {
+    fn class_of_expr(&self, linearity: &Linearity, expr: &RcExpr) -> ClassId {
         let term = linearity.expr_to_term.get(&Rc::as_ptr(expr)).unwrap();
-        let nodeids = self.term_nodes(term);
-        nodeids
-            .iter()
-            .map(|nodeid| linearity.n2c.get(nodeid).unwrap().clone())
-            .collect()
+        let nodeid = self.term_node(term);
+        linearity.n2c.get(&nodeid).unwrap().clone()
     }
 
     /// Start finding effectful nodes from the root of the region
     /// If we've already visited this region, we should not visit again
     /// (otherwise, we may pick two paths to the same region, which is unsound)
     fn find_effectful_nodes_in_region(&mut self, expr: &RcExpr, linearity: &mut Linearity) {
-        let rootids = self.classes_of_expr(linearity, expr);
-        for rootid in rootids {
-            // if we have already visited this region, we should not visit again
-            if linearity.effectful_nodes.contains_key(&rootid) {
-                continue;
-            }
-            let mut res = Default::default();
-            self.find_effectful_nodes_in_expr(expr, linearity, &mut res);
-
-            if linearity.effectful_nodes.contains_key(&rootid) {
-                panic!("The same region was visited twice before being set by `find_effectful_nodes_in_region`");
-            }
-
-            linearity.effectful_nodes.insert(rootid.clone(), res);
+        let rootid = self.class_of_expr(linearity, expr);
+        // if we have already visited this region, we should not visit again
+        if linearity.effectful_nodes.contains_key(&rootid) {
+            return;
         }
+        let mut res = Default::default();
+        self.find_effectful_nodes_in_expr(expr, linearity, &mut res);
+
+        if linearity.effectful_nodes.contains_key(&rootid) {
+            panic!("The same region was visited twice before being set by `find_effectful_nodes_in_region`");
+        }
+
+        linearity.effectful_nodes.insert(rootid.clone(), res);
     }
 
     /// Finds all the effectful nodes along the state edge

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -33,23 +33,23 @@ pub fn mk_schedule() -> String {
   
     
   (unstable-combined-ruleset optimizations
-    loop-simplify
-    memory
-    loop-unroll
-    peepholes
+    ;loop-simplify
+    ;memory
+    ;loop-unroll
+    ;peepholes
   )
 
   (unstable-combined-ruleset expensive-optimizations
     optimizations
     ;; TODO why is this expensive? On `adler32.bril` it blows up with 3 iterations
     switch_rewrite
-    loop-inv-motion
-    loop-strength-reduction
+    ;loop-inv-motion
+    ;loop-strength-reduction
   )
   
   (run-schedule
     {helpers}
-    loop-peel
+    ;loop-peel
     (repeat 2
       {helpers}
       expensive-optimizations)

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -33,23 +33,23 @@ pub fn mk_schedule() -> String {
   
     
   (unstable-combined-ruleset optimizations
-    ;loop-simplify
-    ;memory
-    ;loop-unroll
-    ;peepholes
+    loop-simplify
+    memory
+    loop-unroll
+    peepholes
   )
 
   (unstable-combined-ruleset expensive-optimizations
     optimizations
     ;; TODO why is this expensive? On `adler32.bril` it blows up with 3 iterations
     switch_rewrite
-    ;loop-inv-motion
-    ;loop-strength-reduction
+    loop-inv-motion
+    loop-strength-reduction
   )
   
   (run-schedule
     {helpers}
-    ;loop-peel
+    loop-peel
     (repeat 2
       {helpers}
       expensive-optimizations)

--- a/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
@@ -9,35 +9,22 @@ expression: visualization.result
   v4_: ptr<int> = ptradd v2_ v3_;
   v5_: int = const 2;
   v6_: ptr<int> = ptradd v2_ v5_;
-  br v0 .v7_ .v8_;
-.v7_:
-  v9_: ptr<int> = id v2_;
-  v10_: ptr<int> = id v4_;
-  v11_: ptr<int> = id v6_;
-  v12_: bool = id v0;
-.v13_:
-  v9_: ptr<int> = id v10_;
-  v10_: ptr<int> = id v9_;
-  v11_: ptr<int> = id v11_;
-  v12_: bool = id v12_;
-  br v12_ .v13_ .v14_;
-.v14_:
-  v15_: ptr<int> = id v9_;
-  v16_: ptr<int> = id v10_;
-  v17_: ptr<int> = id v11_;
-  v18_: bool = id v12_;
-  jmp .v19_;
-.v8_:
-  v15_: ptr<int> = id v2_;
-  v16_: ptr<int> = id v4_;
-  v17_: ptr<int> = id v6_;
-  v18_: bool = id v0;
-.v19_:
-  v20_: int = const 10;
-  v21_: int = const 20;
-  store v16_ v20_;
-  store v17_ v21_;
-  v22_: int = load v16_;
-  print v20_;
-  free v15_;
+  v7_: ptr<int> = id v4_;
+  v8_: ptr<int> = id v2_;
+  v9_: ptr<int> = id v6_;
+  v10_: bool = id v0;
+.v11_:
+  v7_: ptr<int> = id v8_;
+  v8_: ptr<int> = id v7_;
+  v9_: ptr<int> = id v9_;
+  v10_: bool = id v10_;
+  br v10_ .v11_ .v12_;
+.v12_:
+  v13_: int = const 10;
+  v14_: int = const 20;
+  store v8_ v13_;
+  store v9_ v14_;
+  v15_: int = load v8_;
+  print v13_;
+  free v7_;
 }


### PR DESCRIPTION
Finding multiple terms for the same eclass results in linearity bugs. This PR fixes that.