### PR TITLE
Improve perf of testing by increasing sharing, disabling brilift

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -198,6 +198,11 @@ pub enum RunType {
     /// Converts to an executable using brilift
     CompileBrilift,
     CompileBrilLLVM,
+    /// Tests a benchmark by running several different configurations of CompileBrilLLVM
+    /// and comparing the results.
+    /// The different configurations are with and without egglog optimization, and with and without
+    /// llvm optimization.
+    TestBenchmark,
 }
 
 impl Display for RunType {
@@ -229,7 +234,8 @@ impl RunType {
             | RunType::OptimizedRvsdg
             | RunType::CheckExtractIdentical
             | RunType::ToCfg
-            | RunType::OptimizedCfg => false,
+            | RunType::OptimizedCfg
+            | RunType::TestBenchmark => false,
             RunType::BrilToJson => false,
         }
     }
@@ -374,22 +380,19 @@ impl Run {
         }
     }
 
-    pub fn compile_llvm_config(
-        test: TestProgram,
-        optimize_egglog: bool,
-        optimize_bril_llvm: bool,
-        interp: InterpMode,
-    ) -> Run {
+    pub fn test_benchmark_config(test: TestProgram) -> Run {
         Run {
-            test_type: RunType::CompileBrilLLVM,
-            interp,
+            test_type: RunType::TestBenchmark,
+            // testing does interpretation separately, ignoring this flag
+            interp: InterpMode::None,
             prog_with_args: test.read_program(),
             profile_out: None,
             output_path: None,
             llvm_output_dir: None,
-            optimize_egglog: Some(optimize_egglog),
+            // no need to set optimization flags, since all combinations are tested
+            optimize_egglog: None,
             optimize_brilift: None,
-            optimize_bril_llvm: Some(optimize_bril_llvm),
+            optimize_bril_llvm: None,
         }
     }
 
@@ -723,6 +726,58 @@ impl Run {
             RunType::CompileBrilLLVM => {
                 let interpretable = self.run_bril_llvm()?;
                 (vec![], Some(interpretable))
+            }
+            RunType::TestBenchmark => {
+                // optimize_egglog and optimize_brilift should not be set
+                assert!(self.optimize_egglog.is_none());
+                assert!(self.optimize_brilift.is_none());
+                let mut interpreted = None;
+
+                for optimize_egglog in [true, false] {
+                    let resulting_bril = if optimize_egglog {
+                        Run::optimize_bril(&self.prog_with_args.program)?
+                    } else {
+                        self.prog_with_args.program.clone()
+                    };
+
+                    for optimize_llvm in [true, false] {
+                        let test_run_mode = Run {
+                            test_type: RunType::CompileBrilLLVM,
+                            interp: InterpMode::None,
+                            prog_with_args: ProgWithArguments {
+                                program: resulting_bril.clone(),
+                                name: self.prog_with_args.name.clone(),
+                                args: self.prog_with_args.args.clone(),
+                            },
+                            profile_out: None,
+                            output_path: None,
+                            llvm_output_dir: None,
+                            optimize_egglog: Some(false), // no need to optimize again
+                            optimize_brilift: None,
+                            optimize_bril_llvm: Some(optimize_llvm),
+                        };
+
+                        let interpretable = test_run_mode.run_bril_llvm()?;
+                        let new_interpreted = Optimizer::interp(
+                            &interpretable,
+                            self.prog_with_args.args.clone(),
+                            None,
+                        );
+                        if let Some(old_interpreted) = interpreted.clone() {
+                            if old_interpreted != new_interpreted {
+                                panic!(
+                                    "Interpreted outputs differ for {} with optimize_egglog={} and optimize_llvm={}.",
+                                    self.name(), optimize_egglog, optimize_llvm
+                                );
+                            }
+                            assert_eq!(old_interpreted, new_interpreted);
+                        } else {
+                            interpreted = Some(new_interpreted);
+                        }
+                    }
+                }
+
+                (vec![], None)
             }
         };
 

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use eggcc::util::{InterpMode, Run, RunType, TestProgram};
+use eggcc::util::{Run, RunType, TestProgram};
 use insta::assert_snapshot;
 use libtest_mimic::Trial;
 
@@ -47,28 +47,10 @@ fn generate_tests(glob: &str, benchmark_mode: bool) -> Vec<Trial> {
 
         let snapshot = f.to_str().unwrap().contains("small");
 
-        // in benchmark mode, run fewer tests and use binaries to interpret
         let configurations = if benchmark_mode {
-            // use InterpFast, which runs brilift
-            // with optimization but without egglog optimization
-            let mut res = vec![Run::compile_brilift_config(
-                TestProgram::BrilFile(f.clone()),
-                true,
-                true,
-                InterpMode::InterpFast,
-            )];
-            for optimize_egglog in [true, false].iter() {
-                for optimize_llvm in [true, false].iter() {
-                    res.push(Run::compile_llvm_config(
-                        TestProgram::BrilFile(f.clone()),
-                        *optimize_egglog,
-                        *optimize_llvm,
-                        InterpMode::InterpFast,
-                    ));
-                }
-            }
-
-            res
+            // in benchmark mode, run a special test pipeline that only runs
+            // a few modes, and shares intermediate results
+            vec![Run::test_benchmark_config(TestProgram::BrilFile(f.clone()))]
         } else {
             Run::all_configurations_for(TestProgram::BrilFile(f))
         };


### PR DESCRIPTION
This PR refactors the testing of benchmarks to increase sharing of work. Now each benchmark is only optimized once instead of twice. Also, the resulting binaries are executed once per treatment instead of twice.
Brillift is still tested on our smaller tests, but is disabled for the benchmarks.

Overall, this makes running tests about twice as fast