### PR TITLE
Add script to dump llvm/eggccir for benchmarks

### DIFF
--- a/benchmarks/for_debugging/dump_all.sh
+++ b/benchmarks/for_debugging/dump_all.sh
@@ -1,0 +1,13 @@
+#!/bin/zsh
+
+# Generate optimized and unoptimized LLVM IR for all passing benchmarks
+
+for f in ../passing/**/*.bril; do
+    echo $f # ../passing/bril/mem/bubblesort.bril
+    output=$(dirname $(echo $f | cut -c4-)) # passing/bril/mem
+    ./dump_one.sh $f $output
+    st=$?
+    if [ $st -ne 0 ]; then
+        exit $st
+    fi
+done

--- a/benchmarks/for_debugging/dump_one.sh
+++ b/benchmarks/for_debugging/dump_one.sh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+
+if [ ! -d "$EGGCC_ROOT" ]; then
+    echo "Please set \$EGGCC_ROOT to your eggcc repo root directory. Current value: $EGGCC_ROOT"
+    exit 1
+fi
+
+try() {
+    echo $1
+    eval $1
+    st=$?
+    if [ $st -ne 0 ]; then
+        exit $st
+    fi
+}
+# argument 1 is input file, argument 2 is output directory
+# e.g. 1=../passing/bril/mem/bubblesort.bril
+#      2=passing/bril/mem
+base=$(basename $1 .bril) # bubblesort
+try "cargo run -r $1 --optimize-egglog=false --optimize-bril-llvm=true --run-mode=compile-bril-llvm --llvm-output-dir=$2"
+try "cargo run -r $1 --optimize-egglog=false --optimize-bril-llvm=false --run-mode=compile-bril-llvm --llvm-output-dir=$2"
+try "cargo run -r $1 --run-mode=dag-conversion > $2/$base.svg"
+try "cargo run -r $1 --run-mode=dag-optimize > $2/${base}_egglog_opt.svg"

--- a/benchmarks/for_debugging/dump_one.sh
+++ b/benchmarks/for_debugging/dump_one.sh
@@ -19,5 +19,6 @@ try() {
 base=$(basename $1 .bril) # bubblesort
 try "cargo run -r $1 --optimize-egglog=false --optimize-bril-llvm=true --run-mode=compile-bril-llvm --llvm-output-dir=$2"
 try "cargo run -r $1 --optimize-egglog=false --optimize-bril-llvm=false --run-mode=compile-bril-llvm --llvm-output-dir=$2"
+try "cargo run -r $1 --optimize-egglog=true --optimize-bril-llvm=false --run-mode=compile-bril-llvm --llvm-output-dir=$2"
 try "cargo run -r $1 --run-mode=dag-conversion > $2/$base.svg"
 try "cargo run -r $1 --run-mode=dag-optimize > $2/${base}_egglog_opt.svg"


### PR DESCRIPTION
See the output here:
https://github.com/egraphs-good/eggcc/tree/script-output/benchmarks/for_debugging/passing

To regenerate, go to `benchmarks/for_debugging` then:
```
#             input file                         output dir
./dump_one.sh ../passing/bril/core/bitshift.bril passing/bril/core
# all benchmarks:
./dump_all.sh
```