### PR TITLE
Cleaner RVSDG translation using Phi nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=7f9f22784ec2685ee416d68a441a48d10c7f54f8#7f9f22784ec2685ee416d68a441a48d10c7f54f8"
+source = "git+https://github.com/uwplse/bril#5652d6ac53d727c0901a53a0484e8241db887d04"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,53 +36,54 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -90,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "arbitrary"
@@ -129,7 +130,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -152,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bit-set"
@@ -258,7 +259,7 @@ dependencies = [
 [[package]]
 name = "brillvm"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04#5652d6ac53d727c0901a53a0484e8241db887d04"
+source = "git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57#78881c45aa53231915f333d1d6dcc26cedc63b57"
 dependencies = [
  "bril-rs 0.1.0 (git+https://github.com/uwplse/bril)",
  "clap",
@@ -267,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -279,9 +280,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"
@@ -320,7 +321,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -331,9 +332,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "console"
@@ -358,18 +359,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3775cc6cc00c90d29eebea55feedb2b0168e23f5415bab7859c4004d7323d1"
+checksum = "3b57d4f3ffc28bbd6ef1ca7b50b20126717232f97487efe027d135d9d87eb29c"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637f3184ba5bfa48d425bad1d2e4faf5fcf619f5e0ca107edc6dc02f589d4d74"
+checksum = "d1f7d0ac7fd53f2c29db3ff9a063f6ff5a8be2abaa8f6942aceb6e1521e70df7"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -379,7 +380,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "log",
  "regalloc2",
  "smallvec",
@@ -388,39 +389,39 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b35b8240462341d94d31aab807cad704683988708261aecae3d57db48b7212"
+checksum = "b40bf21460a600178956cb7fd900a7408c6587fbb988a8063f7215361801a1da"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3cd1555aa9df1d6d8375732de41b4cb0d787006948d55b6d004d521e9efeb0"
+checksum = "d792ecc1243b7ebec4a7f77d9ed428ef27456eeb1f8c780587a6f5c38841be19"
 
 [[package]]
 name = "cranelift-control"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b31a562a10e98ab148fa146801e20665c5f9eda4fce9b2c5a3836575887d74"
+checksum = "cea2808043df964b73ad7582e09afbbe06a31f3fb9db834d53e74b4e16facaeb"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1e0467700a3f4fccf5feddbaebdf8b0eb82535b06a9600c4bc5df40872e75d"
+checksum = "f1930946836da6f514da87625cd1a0331f3908e0de454628c24a0b97b130c4d4"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb918ee2c23939262efd1b99d76a21212ac7bd35129582133e21a22a6ff0467"
+checksum = "5482a5fcdf98f2f31b21093643bdcfe9030866b8be6481117022e7f52baa0f2b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -430,15 +431,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966e4cfb23cf6d7f1d285d53a912baaffc5f06bcd9c9b0a2d8c66a184fae534b"
+checksum = "6f6e1869b6053383bdb356900e42e33555b4c9ebee05699469b7c53cdafc82ea"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66823211608f4966518d23f57571d8771c55430b626a8ab377479b24a4535f40"
+checksum = "3357baa7fcc29de13a2f6e4da2285753d6d7ca38515aa26b776fb7e6af61c8ed"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -456,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec3c5879608f8073782974e2c6dda461eb4038c754e1ab02904eb94a0ee0e9f"
+checksum = "0fd7ba7c3e028b3f25b7bcd5fc700aa4c5e6d4f641567df57fa7e38b38a8c8cd"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -467,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea803aadfc4aabdfae7c3870f1b1f6dd4332f4091859e9758ef5fca6bf8cc87"
+checksum = "a91446e8045f1c4bc164b7bba68e2419c623904580d4b730877a663c6da38964"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -478,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.106.1"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2734474e6b011263cf0ea0ca36378a29e8a9795f8a71b46b3fbb1f7657173c"
+checksum = "014effb46f23d749598adc54b3dde1010f96f0e7f97a4fb80bdc792c6de7c24c"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -611,7 +612,7 @@ dependencies = [
  "fixedbitset",
  "glob",
  "graphviz-rust 0.8.0",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap",
  "insta",
  "lalrpop-util",
@@ -622,7 +623,7 @@ dependencies = [
  "rs2bril",
  "serde_json",
  "smallvec",
- "syn 2.0.58",
+ "syn 2.0.64",
  "tempfile",
  "thiserror",
 ]
@@ -636,7 +637,7 @@ dependencies = [
  "egraph-serialize",
  "env_logger 0.10.2",
  "generic_symbolic_expressions",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap",
  "instant",
  "lalrpop",
@@ -671,15 +672,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "ena"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
@@ -707,7 +708,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -754,9 +755,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys",
@@ -770,9 +771,9 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fixedbitset"
@@ -806,9 +807,9 @@ source = "git+https://github.com/oflatt/symbolic-expressions?rev=655b6a4c06b4b3d
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -884,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -923,14 +924,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/TheDan64/inkwell.git#7684346e8156e4adbaf5029e8eba760e1de3c5cd"
+source = "git+https://github.com/TheDan64/inkwell.git?rev=6c0fb56b3554e939f9ca61b465043d6a84fb7b95#6c0fb56b3554e939f9ca61b465043d6a84fb7b95"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -943,18 +944,18 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/TheDan64/inkwell.git#7684346e8156e4adbaf5029e8eba760e1de3c5cd"
+source = "git+https://github.com/TheDan64/inkwell.git?rev=6c0fb56b3554e939f9ca61b465043d6a84fb7b95#6c0fb56b3554e939f9ca61b465043d6a84fb7b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
 name = "insta"
-version = "1.38.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
 dependencies = [
  "console",
  "lazy_static",
@@ -1004,6 +1005,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1065,9 +1072,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+checksum = "81eb4061c0582dedea1cbc7aff2240300dd6982e0239d1c99e65c1dbf4a30ba7"
 dependencies = [
  "cc",
  "libc",
@@ -1122,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1159,9 +1166,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+checksum = "9f41a2280ded0da56c8cf898babb86e8f10651a34adcfff190ae9a1159c6908d"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1174,11 +1181,10 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1200,11 +1206,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1212,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1245,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap",
  "memchr",
 ]
@@ -1269,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1279,22 +1284,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1303,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1313,22 +1318,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -1337,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1380,18 +1385,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1430,11 +1435,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -1525,7 +1530,7 @@ dependencies = [
  "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "clap",
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1536,9 +1541,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1549,15 +1554,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1582,29 +1587,29 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1705,7 +1710,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1731,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1780,22 +1785,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1809,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1832,9 +1837,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1909,9 +1914,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "19.0.1"
+version = "19.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c48eb4223d6556ffbf3decb146d0da124f1fd043f41c98b705252cb6a5c186"
+checksum = "c22ca2ef4d87b23d400660373453e274b2251bc2d674e3102497f690135e04b0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1936,11 +1941,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1955,139 +1960,89 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
+name = "windows_i686_gnullvm"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,17 +195,7 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04#5652d6ac53d727c0901a53a0484e8241db887d04"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "bril-rs"
-version = "0.1.0"
-source = "git+https://github.com/uwplse/bril#5652d6ac53d727c0901a53a0484e8241db887d04"
+source = "git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57#78881c45aa53231915f333d1d6dcc26cedc63b57"
 dependencies = [
  "serde",
  "serde_json",
@@ -225,9 +215,9 @@ dependencies = [
 [[package]]
 name = "bril2json"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04#5652d6ac53d727c0901a53a0484e8241db887d04"
+source = "git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57#78881c45aa53231915f333d1d6dcc26cedc63b57"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "clap",
  "lalrpop",
  "lalrpop-util",
@@ -237,10 +227,10 @@ dependencies = [
 [[package]]
 name = "brilift"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04#5652d6ac53d727c0901a53a0484e8241db887d04"
+source = "git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57#78881c45aa53231915f333d1d6dcc26cedc63b57"
 dependencies = [
  "argh",
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -254,9 +244,9 @@ dependencies = [
 [[package]]
 name = "brilirs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04#5652d6ac53d727c0901a53a0484e8241db887d04"
+source = "git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57#78881c45aa53231915f333d1d6dcc26cedc63b57"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "bril2json",
  "clap",
  "fxhash",
@@ -530,7 +520,7 @@ dependencies = [
 name = "dag_in_context"
 version = "0.1.0"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=7f9f22784ec2685ee416d68a441a48d10c7f54f8)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "dot-structures",
  "egglog",
  "egraph-serialize",
@@ -607,7 +597,7 @@ checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
 name = "eggcc"
 version = "0.1.0"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "bril2json",
  "brilift",
  "brilirs",
@@ -940,7 +930,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/TheDan64/inkwell.git#6c0fb56b3554e939f9ca61b465043d6a84fb7b95"
+source = "git+https://github.com/TheDan64/inkwell.git#7684346e8156e4adbaf5029e8eba760e1de3c5cd"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -953,7 +943,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/TheDan64/inkwell.git#6c0fb56b3554e939f9ca61b465043d6a84fb7b95"
+source = "git+https://github.com/TheDan64/inkwell.git#7684346e8156e4adbaf5029e8eba760e1de3c5cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1530,9 +1520,9 @@ dependencies = [
 [[package]]
 name = "rs2bril"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04#5652d6ac53d727c0901a53a0484e8241db887d04"
+source = "git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57#78881c45aa53231915f333d1d6dcc26cedc63b57"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=5652d6ac53d727c0901a53a0484e8241db887d04)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=78881c45aa53231915f333d1d6dcc26cedc63b57)",
  "clap",
  "proc-macro2",
  "syn 2.0.58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ smallvec = "1.11.1"
 
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 # currently using the uwplse/bril fork of bril, on eggcc-main
-bril2json = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" }
-brilirs = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" }
-bril-rs = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" }
-brilift = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" }
-rs2bril = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" ,features = [
+bril2json = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" }
+brilirs = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" }
+bril-rs = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" }
+brilift = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" }
+rs2bril = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" ,features = [
   "import",
 ] }
 brillvm = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ brilift = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f33
 rs2bril = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" ,features = [
   "import",
 ] }
-brillvm = { git = "https://github.com/uwplse/bril", rev = "5652d6ac53d727c0901a53a0484e8241db887d04" }
+brillvm = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" }
 
 
 ordered-float = { version = "3.7" }

--- a/dag_in_context/Cargo.toml
+++ b/dag_in_context/Cargo.toml
@@ -12,7 +12,7 @@ strum_macros = "0.25"
 main_error = "0.1.2"
 thiserror = "1.0"
 egraph-serialize = "0.1.0"
-bril-rs = { git = "https://github.com/uwplse/bril", rev = "7f9f22784ec2685ee416d68a441a48d10c7f54f8" }
+bril-rs = { git = "https://github.com/uwplse/bril", rev = "78881c45aa53231915f333d1d6dcc26cedc63b57" }
 indexmap = "2.0.0"
 rustc-hash = "1.1.0"
 ordered-float = "3"

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -1,5 +1,5 @@
 const COLORS = {
-  "rvsdg_roundtrip": "red",
+  rvsdg_roundtrip: "red",
   "cranelift-O3": "blue",
   "llvm-peep": "purple",
   "llvm-peep-eggcc": "pink",

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -1,9 +1,5 @@
 const COLORS = {
   rvsdg_roundtrip: "red",
-  "cranelift-O0": "orange",
-  "cranelift-O0-eggcc": "yellow",
-  "cranelift-O3": "green",
-  "cranelift-O3-eggcc": "blue",
   "llvm-peep": "purple",
   "llvm-peep-eggcc": "pink",
   "llvm-O3": "gray",

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -1,5 +1,6 @@
 const COLORS = {
-  rvsdg_roundtrip: "red",
+  "rvsdg_roundtrip": "red",
+  "cranelift-O3": "blue",
   "llvm-peep": "purple",
   "llvm-peep-eggcc": "pink",
   "llvm-O3": "gray",

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -2,11 +2,6 @@
 const treatments = [
   "rvsdg_roundtrip",
 
-  "cranelift-O0",
-  "cranelift-O0-eggcc",
-  "cranelift-O3",
-  "cranelift-O3-eggcc",
-
   "llvm-peep",
   "llvm-peep-eggcc",
   "llvm-O3",

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -1,7 +1,7 @@
 // copied from profile.py
 const treatments = [
   "rvsdg_roundtrip",
-
+  "cranelift-O3",
   "llvm-peep",
   "llvm-peep-eggcc",
   "llvm-O3",

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -49,13 +49,12 @@ pushd $TOP_DIR
 # create temporary directory structure necessary for bench runs
 mkdir -p ./tmp/bench
 
-export LLVM_SYS_180_PREFIX="/usr/lib/llvm-18/"
-make runtime
-
 # locally, run on argument
 if [ "$LOCAL" != "" ]; then
   ./infra/profile.py "$@" "$NIGHTLY_DIR"
 else
+  export LLVM_SYS_180_PREFIX="/usr/lib/llvm-18/"
+  make runtime
   # run on all benchmarks in nightly
   ./infra/profile.py benchmarks/passing "$NIGHTLY_DIR"
 fi

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -12,6 +12,8 @@ from gen_linecount import gen_linecount_table
 import concurrent.futures
 
 treatments = [
+  "rvsdg_roundtrip",
+  "cranelift-O3",
   "llvm-peep",
   "llvm-peep-eggcc",
   "llvm-O3",
@@ -22,6 +24,8 @@ def get_eggcc_options(name, profile_dir):
   match name:
     case "rvsdg_roundtrip":
       return '--run-mode rvsdg-round-trip-to-executable'
+    case "cranelift-O3":
+      return f'--run-mode cranelift --optimize-egglog false --optimize-brilift true'
     case "llvm-peep":
       return f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm false --llvm-output-dir {profile_dir}/llvm-{name}'
     case "llvm-O3":
@@ -60,8 +64,9 @@ def setup_benchmark(benchmark_path):
 def optimize(benchmark):
   print(f'[{benchmark.index}/{benchmark.total}] Optimizing {benchmark.path} with {benchmark.treatment}')
   profile_dir = benchmark_profile_dir(benchmark.path)
-  print(f'Running: cargo run --release {benchmark.path} {get_eggcc_options(benchmark.treatment, profile_dir)} -o {profile_dir}/{benchmark.treatment}')
-  subprocess.call(f'cargo run --release {benchmark.path} {get_eggcc_options(benchmark.treatment, profile_dir)} -o {profile_dir}/{benchmark.treatment}', shell=True)
+  cmd = f'cargo run --release {benchmark.path} {get_eggcc_options(benchmark.treatment, profile_dir)} -o {profile_dir}/{benchmark.treatment}'
+  print(f'Running: {cmd}')
+  subprocess.call(cmd, shell=True)
 
 
 
@@ -80,8 +85,9 @@ def bench(benchmark):
       pass
     else:
       # TODO for final nightly results, remove `--max-runs 2` and let hyperfine find stable results
-      print(f'Running: hyperfine --warmup 1 --max-runs 2 --export-json {profile_dir}/{benchmark.treatment}.json "{profile_dir}/{benchmark.treatment} {args}"')
-      subprocess.call(f'hyperfine --warmup 1 --max-runs 2 --export-json {profile_dir}/{benchmark.treatment}.json "{profile_dir}/{benchmark.treatment} {args}"', shell=True)
+      cmd = f'hyperfine --warmup 1 --max-runs 2 --export-json {profile_dir}/{benchmark.treatment}.json "{profile_dir}/{benchmark.treatment} {args}"'
+      print(f'Running: {cmd}')
+      subprocess.call(cmd, shell=True)
 
 def get_llvm(runMethod, benchmark):
   path = f'./tmp/bench/{benchmark}/llvm-{runMethod}/{benchmark}-{runMethod}.ll'

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -12,13 +12,6 @@ from gen_linecount import gen_linecount_table
 import concurrent.futures
 
 treatments = [
-  "rvsdg_roundtrip",
-
-  "cranelift-O0",
-  "cranelift-O0-eggcc",
-  "cranelift-O3",
-  "cranelift-O3-eggcc",
-
   "llvm-peep",
   "llvm-peep-eggcc",
   "llvm-O3",
@@ -29,14 +22,6 @@ def get_eggcc_options(name, profile_dir):
   match name:
     case "rvsdg_roundtrip":
       return '--run-mode rvsdg-round-trip-to-executable'
-    case "cranelift-O0":
-      return '--run-mode cranelift --optimize-egglog false --optimize-brilift false'
-    case "cranelift-O3":
-      return '--run-mode cranelift --optimize-egglog false --optimize-brilift true'
-    case "cranelift-O0-eggcc":
-      return '--run-mode cranelift --optimize-egglog true --optimize-brilift false'
-    case "cranelift-O3-eggcc":
-      return '--run-mode cranelift --optimize-egglog true --optimize-brilift true'
     case "llvm-peep":
       return f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm false --llvm-output-dir {profile_dir}/llvm-{name}'
     case "llvm-O3":

--- a/runtime/install.sh
+++ b/runtime/install.sh
@@ -13,7 +13,7 @@ fi
 
 cd runtime
 cargo rustc --release -- --emit=llvm-bc 
-mv ./target/release/deps/runtime-*.bc ./rt.bc
+cp ./target/release/deps/runtime-*.bc ./rt.bc
 cc -c rt.c -o rt.o
 
 

--- a/src/cfg/to_bril.rs
+++ b/src/cfg/to_bril.rs
@@ -55,10 +55,10 @@ impl SimpleCfgFunction {
                 "logic bug: DFS of graph visited node {node:?} twice"
             );
         }
+        self.push_label(&mut func, self.entry);
         self.node_to_bril(self.entry, &mut func, &node_order);
         Dfs::new(&self.graph, self.entry)
             .iter(&self.graph)
-            // don't do the exit or entry
             .filter(|node| node != &self.entry && node != &self.exit)
             .for_each(|node| {
                 // Add a label for the block

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,16 +35,14 @@ struct Args {
     /// Where to put intermediary files (only for OptimizeBrilLLVM mode)
     #[clap(long)]
     llvm_output_dir: Option<String>,
-    /// Run the eggcc optimizer (only for the CompileBrilfit run mode)
-    /// Defaults to true.
+    /// For the LLVM run mode, choose whether to first run eggcc
+    /// to optimize the bril program before going to LLVM.
     #[clap(long)]
     optimize_egglog: Option<bool>,
-    /// Run the brilift optimizer (only for the CompileBrilfit run mode)
-    /// Defaults to false.
+    /// For the Cranelift run mode, choose between O0 optimization and O3.
     #[clap(long)]
     optimize_brilift: Option<bool>,
-    /// Run the LLVM optimizer (only for the CompileBrilLLVM run mode)
-    /// Defaults to false.
+    /// For the LLVM run mode, choose between peepholes only and O3.
     #[clap(long)]
     optimize_bril_llvm: Option<bool>,
 }

--- a/src/rvsdg/optimize_direct_jumps.rs
+++ b/src/rvsdg/optimize_direct_jumps.rs
@@ -92,15 +92,11 @@ impl SimpleCfgFunction {
 
         let mut label_mapping = HashMap::<String, String>::new();
         for (old, new) in node_mapping.iter() {
-            assert!(
-                label_mapping
-                    .insert(
-                        self.graph[*old].name.to_string(),
-                        resulting_graph[*new].name.to_string(),
-                    )
-                    .is_none(),
-                "Duplicate labels in graph"
+            let old_entry = label_mapping.insert(
+                self.graph[*old].name.to_string(),
+                resulting_graph[*new].name.to_string(),
             );
+            assert!(old_entry.is_none(), "Duplicate labels in graph");
         }
 
         // now fix up all Phi instructions based on the node mapping

--- a/src/rvsdg/optimize_direct_jumps.rs
+++ b/src/rvsdg/optimize_direct_jumps.rs
@@ -200,8 +200,7 @@ impl SimpleCfgFunction {
 
     fn get_parent_skipping_empty(&self, parent_block: NodeIndex) -> NodeIndex {
         if let Some((source_edge, _)) = self.get_single_in_single_out(parent_block) {
-            let source = self.graph.edge_endpoints(source_edge).unwrap().0;
-            source
+            self.graph.edge_endpoints(source_edge).unwrap().0
         } else {
             parent_block
         }

--- a/src/rvsdg/snapshots/eggcc__rvsdg__optimize_direct_jumps__add_block_ind_test.snap
+++ b/src/rvsdg/snapshots/eggcc__rvsdg__optimize_direct_jumps__add_block_ind_test.snap
@@ -3,9 +3,9 @@ source: src/rvsdg/optimize_direct_jumps.rs
 expression: cfg.optimize_jumps().to_bril().to_string()
 ---
 @main {
+.entry___:
   v0: int = const 1;
   v1: int = const 2;
   v2: int = add v0 v1;
   print v2;
 }
-

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -326,6 +326,7 @@ fn rvsdg_state_mem_to_cfg() {
         prog.to_string(),
         "\
 @main {
+.__0__:
   v1: int = const 1;
   v4: ptr<int> = alloc v1;
   v8: int = const 10;
@@ -371,27 +372,28 @@ fn rvsdg_state_mem_to_cfg_more_blocks() {
         prog.to_string(),
         "\
 @main {
+.__0__:
   v1: int = const 1;
   v4: ptr<int> = alloc v1;
   v7: int = const 10;
   store v4 v7;
   v11: int = load v4;
   v14: bool = lt v11 v7;
-  br v14 .__33__ .__22__;
-.__33__:
+  br v14 .__31__ .__22__;
+.__31__:
   print v11;
   free v4;
-  v31: int = id v7;
-  jmp .__40__;
+  jmp .__37__;
 .__22__:
   v24: int = add v11 v1;
   free v4;
   print v24;
-  v31: int = id v7;
-.__40__:
-  print v31;
+.__37__:
+  print v7;
 }
-"
+",
+        "Expected program to match, but got:\n{}",
+        prog
     );
 }
 

--- a/src/rvsdg/to_cfg.rs
+++ b/src/rvsdg/to_cfg.rs
@@ -334,6 +334,51 @@ impl<'a> RvsdgToCfg<'a> {
         }
     }
 
+    fn merge_vars(
+        &mut self,
+        branch1_vars: &[RvsdgValue],
+        branch2_vars: &[RvsdgValue],
+        branch1_label: String,
+        branch2_label: String,
+    ) -> TranslationResult {
+        let mut instructions = vec![];
+        assert_eq!(branch1_vars.len(), branch2_vars.len());
+
+        let mut resulting_vars = vec![];
+        for (b1, b2) in branch1_vars.iter().zip(branch2_vars.iter()) {
+            match (b1, b2) {
+                (RvsdgValue::StateEdge, RvsdgValue::StateEdge) => {
+                    resulting_vars.push(RvsdgValue::StateEdge);
+                }
+                (RvsdgValue::BrilValue(name1, ty1), RvsdgValue::BrilValue(name2, ty2)) => {
+                    assert_eq!(ty1, ty2);
+                    if name1 == name2 {
+                        resulting_vars.push(RvsdgValue::BrilValue(name1.clone(), ty1.clone()));
+                    } else {
+                        let new_name = self.get_fresh();
+                        instructions.push(Instruction::Value {
+                            dest: new_name.clone(),
+                            op: ValueOps::Phi,
+                            args: vec![name1.clone(), name2.clone()],
+                            funcs: vec![],
+                            labels: vec![branch1_label.clone(), branch2_label.clone()],
+                            pos: None,
+                            op_type: ty1.clone(),
+                        });
+                        resulting_vars.push(RvsdgValue::BrilValue(new_name, ty1.clone()));
+                    }
+                }
+                _ => panic!("Incompatible values in merge_vars: {:?} {:?}", b1, b2),
+            }
+        }
+        let block = self.make_block(instructions);
+        TranslationResult {
+            start: block,
+            end: block,
+            values: resulting_vars,
+        }
+    }
+
     fn fresh_variables_for(&mut self, values: &[RvsdgValue]) -> Vec<RvsdgValue> {
         values
             .iter()
@@ -378,6 +423,10 @@ impl<'a> RvsdgToCfg<'a> {
             end: new_block,
             values: vec![RvsdgValue::BrilValue(new_val, Type::Bool)],
         }
+    }
+
+    fn block_name(&self, node: NodeIndex) -> String {
+        self.graph[node].name.to_string()
     }
 
     /// Translates a body to bril.
@@ -430,8 +479,6 @@ impl<'a> RvsdgToCfg<'a> {
                 let pred_and_inputs = self.sequence_results(&[pred_res, inputs_combined.clone()]);
 
                 let mut branch_blocks = vec![];
-                // shared vars will be created an the first iteraion
-                let mut shared_vars = None;
 
                 // for each set of outputs in outputs, make a new block for them
                 for (i, outputs) in outputs.iter().enumerate() {
@@ -451,22 +498,13 @@ impl<'a> RvsdgToCfg<'a> {
                         .collect::<Vec<_>>();
                     let outputs_for_branch = self.combine_results(&translation_results);
 
-                    // make the shared vars on the first iteration
-                    if shared_vars.is_none() {
-                        shared_vars = Some(self.fresh_variables_for(&outputs_for_branch.values));
-                    }
-                    // assign to the shared vars
-                    let output_assigned = self
-                        .assign_to_vars(&outputs_for_branch.values, shared_vars.as_ref().unwrap());
-
-                    branch_blocks
-                        .push(self.sequence_results(&[outputs_for_branch, output_assigned]));
+                    branch_blocks.push(outputs_for_branch);
                 }
 
                 // we need to conditionally jump to each of the branch blocks
                 // based on the predicate
                 // TODO right now we
-                // just handle the case where we branch to two things
+                // just handle the case where we branch to two things, and use phi nodes to join back up
                 assert_eq!(outputs.len(), 2);
                 assert_eq!(branch_blocks.len(), 2);
 
@@ -497,13 +535,18 @@ impl<'a> RvsdgToCfg<'a> {
                 );
 
                 // now make a block at the end
-                let end_block = self.make_block(vec![]);
+                let end_block = self.merge_vars(
+                    &branch_blocks[0].values,
+                    &branch_blocks[1].values,
+                    self.block_name(branch_blocks[0].end),
+                    self.block_name(branch_blocks[1].end),
+                );
 
                 // every branch jumps to the end block
                 for branch_block in branch_blocks {
                     self.graph.add_edge(
                         branch_block.end,
-                        end_block,
+                        end_block.start,
                         Branch {
                             op: BranchOp::Jmp,
                             pos: None,
@@ -513,8 +556,8 @@ impl<'a> RvsdgToCfg<'a> {
 
                 TranslationResult {
                     start: pred_and_inputs.start,
-                    end: end_block,
-                    values: shared_vars.unwrap(),
+                    end: end_block.end,
+                    values: end_block.values,
                 }
             }
             RvsdgBody::Theta {

--- a/src/util.rs
+++ b/src/util.rs
@@ -434,7 +434,7 @@ impl Run {
             }
         }
 
-        for optimize_egglog in [true, false] {
+        /*for optimize_egglog in [true, false] {
             for optimize_brilift in [true, false] {
                 res.push(Run::compile_brilift_config(
                     test.clone(),
@@ -443,7 +443,7 @@ impl Run {
                     InterpMode::Interp,
                 ));
             }
-        }
+        }*/
 
         #[cfg(feature = "llvm")]
         {

--- a/src/util.rs
+++ b/src/util.rs
@@ -195,8 +195,11 @@ pub enum RunType {
     OptimizeDirectJumps,
     /// Convert the original program to a RVSDG and then to a CFG, outputting one SVG per function.
     RvsdgToCfg,
-    /// Converts to an executable using brilift
+    /// Converts to an executable using brilift (not using eggcc).
+    /// Brilift does not support phi nodes right now, so we can't run the optimized program with it.
     Cranelift,
+    /// Converts to an executable using brillvm.
+    /// `optimize_egglog` and `optimize_bril_llvm` must be set.
     LLVM,
     /// Tests a benchmark by running several different configurations of CompileBrilLLVM
     /// and comparing the results.

--- a/src/util.rs
+++ b/src/util.rs
@@ -871,12 +871,7 @@ impl Run {
     ) -> Result<Interpretable, EggCCError> {
         // Make a unique name for this test running bril llvm
         // so we don't have conflicts in /tmp
-        let unique_name = format!(
-            "{}_{}_{}",
-            self.name().to_string(),
-            optimize_egglog,
-            optimize_llvm
-        );
+        let unique_name = format!("{}_{}_{}", self.name(), optimize_egglog, optimize_llvm);
 
         let program = if optimize_egglog {
             Run::optimize_bril(&input_prog)?

--- a/tests/snapshots/files__add-optimize.snap
+++ b/tests/snapshots/files__add-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 3;
-  print v0_;
+.v0_:
+  v1_: int = const 3;
+  print v1_;
 }

--- a/tests/snapshots/files__add_block_indirection-optimize.snap
+++ b/tests/snapshots/files__add_block_indirection-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 3;
-  print v0_;
+.v0_:
+  v1_: int = const 3;
+  print v1_;
 }

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -3,39 +3,31 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 2;
-  v2_: bool = lt v0 v1_;
-  v3_: bool = not v2_;
-  v4_: int = const 0;
-  v5_: int = const 1;
-  v6_: int = const 5;
-  br v2_ .v7_ .v8_;
-.v7_:
-  v9_: int = const 4;
-  v10_: bool = const false;
-  v11_: int = id v9_;
-  v12_: int = id v5_;
-  v13_: int = id v1_;
-  v14_: bool = id v10_;
-.v15_:
-  br v3_ .v16_ .v17_;
-.v16_:
-  v18_: int = add v11_ v1_;
-  v19_: int = id v18_;
-  v20_: int = id v5_;
-  jmp .v21_;
-.v17_:
-  v19_: int = id v11_;
-  v20_: int = id v5_;
-  jmp .v21_;
+.v1_:
+  v2_: int = const 2;
+  v3_: bool = lt v0 v2_;
+  v4_: bool = not v3_;
+  v5_: int = const 0;
+  v6_: int = const 1;
+  v7_: int = const 5;
+  br v3_ .v8_ .v9_;
 .v8_:
-  v22_: bool = const true;
-  v11_: int = id v5_;
-  v12_: int = id v5_;
-  v13_: int = id v1_;
-  v14_: bool = id v22_;
-  jmp .v15_;
-.v21_:
-  v23_: int = add v19_ v5_;
-  print v23_;
+  v10_: int = const 4;
+  v11_: bool = const false;
+.v12_:
+  v13_: int = phi v6_ v10_ .v9_ .v8_;
+  v15_: bool = phi v14_ v11_ .v9_ .v8_;
+  br v4_ .v16_ .v17_;
+.v16_:
+  v18_: int = add v13_ v2_;
+  jmp .v19_;
+.v17_:
+  jmp .v19_;
+.v9_:
+  v14_: bool = const true;
+  jmp .v12_;
+.v19_:
+  v20_: int = phi v13_ v18_ .v17_ .v16_;
+  v21_: int = add v20_ v6_;
+  print v21_;
 }

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -20,14 +20,12 @@ expression: visualization.result
   br v4_ .v16_ .v17_;
 .v16_:
   v18_: int = add v13_ v2_;
-  jmp .v19_;
-.v17_:
-  jmp .v19_;
+  jmp .v17_;
 .v9_:
   v14_: bool = const true;
   jmp .v12_;
-.v19_:
-  v20_: int = phi v13_ v18_ .v17_ .v16_;
-  v21_: int = add v20_ v6_;
-  print v21_;
+.v17_:
+  v19_: int = phi v13_ v18_ .v12_ .v16_;
+  v20_: int = add v19_ v6_;
+  print v20_;
 }

--- a/tests/snapshots/files__bool-optimize.snap
+++ b/tests/snapshots/files__bool-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: bool = const true;
-  print v0_;
+.v0_:
+  v1_: bool = const true;
+  print v1_;
 }

--- a/tests/snapshots/files__branch_duplicate_work-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize.snap
@@ -3,17 +3,17 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 2;
-  v2_: bool = lt v0 v1_;
-  br v2_ .v3_ .v4_;
-.v3_:
-  v5_: int = add v0 v0;
-  v6_: int = id v5_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 2;
+  v3_: bool = lt v0 v2_;
+  br v3_ .v4_ .v5_;
 .v4_:
+  v6_: int = add v0 v0;
+  jmp .v7_;
+.v5_:
   v8_: int = add v0 v0;
-  v9_: int = mul v1_ v8_;
-  v6_: int = id v9_;
+  v9_: int = mul v2_ v8_;
 .v7_:
-  print v6_;
+  v10_: int = phi v9_ v6_ .v5_ .v4_;
+  print v10_;
 }

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -3,16 +3,17 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 1;
-  v2_: int = const 3;
-  v3_: int = const 2;
-  v4_: int = const 0;
-  v5_: int = id v0;
+.v1_:
+  v2_: int = const 1;
+  v3_: int = const 3;
+  v4_: int = const 2;
+  v5_: int = const 0;
   v6_: int = id v0;
-  v7_: int = id v1_;
+  v7_: int = id v0;
   v8_: int = id v2_;
   v9_: int = id v3_;
   v10_: int = id v4_;
+<<<<<<< HEAD
 .v11_:
   v12_: bool = eq v6_ v7_;
   br v12_ .v13_ .v14_;
@@ -73,4 +74,43 @@ expression: visualization.result
   jmp .v42_;
 .v25_:
   print v0;
+=======
+  v11_: int = id v5_;
+.v12_:
+  v13_: bool = eq v7_ v8_;
+  br v13_ .v14_ .v15_;
+.v14_:
+  v16_: bool = const false;
+.v17_:
+  v19_: bool = phi v18_ v16_ .v20_ .v14_;
+  v22_: int = phi v21_ v7_ .v20_ .v14_;
+  v6_: int = id v6_;
+  v7_: int = id v22_;
+  v8_: int = id v8_;
+  v9_: int = id v9_;
+  v10_: int = id v10_;
+  v11_: int = id v11_;
+  br v19_ .v12_ .v23_;
+.v15_:
+  v24_: int = div v7_ v10_;
+  v25_: int = mul v10_ v24_;
+  v26_: int = sub v7_ v25_;
+  v27_: bool = eq v11_ v26_;
+  print v7_;
+  v28_: int = mul v7_ v9_;
+  v29_: int = add v28_ v8_;
+  br v27_ .v30_ .v31_;
+.v30_:
+  v32_: bool = const true;
+.v20_:
+  v34_: bool = phi v33_ v32_ .v31_ .v30_;
+  v21_: int = phi v29_ v24_ .v31_ .v30_;
+  v18_: bool = const true;
+  jmp .v17_;
+.v31_:
+  v33_: bool = const true;
+  jmp .v20_;
+.v23_:
+  print v6_;
+>>>>>>> 71264d0b (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -13,68 +13,6 @@ expression: visualization.result
   v8_: int = id v2_;
   v9_: int = id v3_;
   v10_: int = id v4_;
-<<<<<<< HEAD
-.v11_:
-  v12_: bool = eq v6_ v7_;
-  br v12_ .v13_ .v14_;
-.v13_:
-  v15_: bool = const false;
-  v16_: int = id v5_;
-  v17_: bool = id v15_;
-  v18_: int = id v6_;
-  v19_: int = id v6_;
-  v20_: int = id v8_;
-  v21_: int = id v9_;
-  v22_: int = id v10_;
-.v23_:
-  v24_: bool = not v12_;
-  v5_: int = id v5_;
-  v6_: int = id v18_;
-  v7_: int = id v7_;
-  v8_: int = id v8_;
-  v9_: int = id v9_;
-  v10_: int = id v10_;
-  br v24_ .v11_ .v25_;
-.v14_:
-  print v6_;
-  v26_: int = div v6_ v9_;
-  v27_: int = mul v26_ v9_;
-  v28_: int = sub v6_ v27_;
-  v29_: bool = eq v10_ v28_;
-  v30_: int = mul v6_ v8_;
-  v31_: int = add v30_ v7_;
-  br v29_ .v32_ .v33_;
-.v32_:
-  v34_: bool = const true;
-  v35_: int = id v5_;
-  v36_: bool = id v34_;
-  v37_: int = id v26_;
-  v38_: int = id v7_;
-  v39_: int = id v8_;
-  v40_: int = id v9_;
-  v41_: int = id v10_;
-.v42_:
-  v16_: int = id v35_;
-  v17_: bool = id v36_;
-  v18_: int = id v37_;
-  v19_: int = id v38_;
-  v20_: int = id v39_;
-  v21_: int = id v40_;
-  v22_: int = id v41_;
-  jmp .v23_;
-.v33_:
-  v43_: bool = const true;
-  v35_: int = id v5_;
-  v36_: bool = id v43_;
-  v37_: int = id v31_;
-  v38_: int = id v7_;
-  v39_: int = id v8_;
-  v40_: int = id v9_;
-  v41_: int = id v10_;
-  jmp .v42_;
-.v25_:
-  print v0;
-=======
   v11_: int = id v5_;
 .v12_:
   v13_: bool = eq v7_ v8_;
@@ -84,33 +22,33 @@ expression: visualization.result
 .v17_:
   v19_: bool = phi v18_ v16_ .v20_ .v14_;
   v22_: int = phi v21_ v7_ .v20_ .v14_;
+  v23_: int = phi v8_ v7_ .v20_ .v14_;
+  v24_: bool = not v13_;
   v6_: int = id v6_;
   v7_: int = id v22_;
   v8_: int = id v8_;
   v9_: int = id v9_;
   v10_: int = id v10_;
   v11_: int = id v11_;
-  br v19_ .v12_ .v23_;
+  br v24_ .v12_ .v25_;
 .v15_:
-  v24_: int = div v7_ v10_;
-  v25_: int = mul v10_ v24_;
-  v26_: int = sub v7_ v25_;
-  v27_: bool = eq v11_ v26_;
   print v7_;
-  v28_: int = mul v7_ v9_;
-  v29_: int = add v28_ v8_;
-  br v27_ .v30_ .v31_;
-.v30_:
-  v32_: bool = const true;
+  v26_: int = div v7_ v10_;
+  v27_: int = mul v10_ v26_;
+  v28_: int = sub v7_ v27_;
+  v29_: bool = eq v11_ v28_;
+  v30_: int = mul v7_ v9_;
+  v31_: int = add v30_ v8_;
+  br v29_ .v32_ .v33_;
+.v32_:
+  v34_: bool = const true;
 .v20_:
-  v34_: bool = phi v33_ v32_ .v31_ .v30_;
-  v21_: int = phi v29_ v24_ .v31_ .v30_;
-  v18_: bool = const true;
+  v18_: bool = phi v35_ v34_ .v33_ .v32_;
+  v21_: int = phi v31_ v26_ .v33_ .v32_;
   jmp .v17_;
-.v31_:
-  v33_: bool = const true;
+.v33_:
+  v35_: bool = const true;
   jmp .v20_;
-.v23_:
-  print v6_;
->>>>>>> 71264d0b (working without collapse empty blocks)
+.v25_:
+  print v0;
 }

--- a/tests/snapshots/files__constant_fold_simple-optimize.snap
+++ b/tests/snapshots/files__constant_fold_simple-optimize.snap
@@ -3,8 +3,9 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 3;
-  v1_: int = const 2;
-  v2_: int = div v0_ v1_;
-  print v2_;
+.v0_:
+  v1_: int = const 3;
+  v2_: int = const 2;
+  v3_: int = div v1_ v2_;
+  print v3_;
 }

--- a/tests/snapshots/files__diamond-optimize.snap
+++ b/tests/snapshots/files__diamond-optimize.snap
@@ -3,14 +3,15 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: bool = lt v0 v0;
-  br v1_ .v2_ .v3_;
-.v2_:
-  v4_: int = const 1;
-  print v4_;
-  jmp .v5_;
+.v1_:
+  v2_: bool = lt v0 v0;
+  br v2_ .v3_ .v4_;
 .v3_:
-  v6_: int = const 2;
-  print v6_;
-.v5_:
+  v5_: int = const 1;
+  print v5_;
+  jmp .v6_;
+.v4_:
+  v7_: int = const 2;
+  print v7_;
+.v6_:
 }

--- a/tests/snapshots/files__duplicate_branch-optimize.snap
+++ b/tests/snapshots/files__duplicate_branch-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 4;
-  print v1_;
+.v1_:
+  v2_: int = const 4;
+  print v2_;
 }

--- a/tests/snapshots/files__eliminate_gamma-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 1;
-  print v0_;
+.v0_:
+  v1_: int = const 1;
+  print v1_;
 }

--- a/tests/snapshots/files__eliminate_gamma_interval-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: bool = const false;
-  print v1_;
+.v1_:
+  v2_: bool = const false;
+  print v2_;
 }

--- a/tests/snapshots/files__eliminate_loop-optimize.snap
+++ b/tests/snapshots/files__eliminate_loop-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 1;
-  print v0_;
+.v0_:
+  v1_: int = const 1;
+  print v1_;
 }

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -8,26 +8,24 @@ expression: visualization.result
   v3_: bool = eq v0 v2_;
   v4_: int = const 1;
   br v3_ .v5_ .v6_;
-.v5_:
-  jmp .v7_;
 .v6_:
-  v8_: bool = eq v0 v4_;
-  br v8_ .v9_ .v10_;
+  v7_: bool = eq v0 v4_;
+  br v7_ .v8_ .v9_;
+.v8_:
+  v10_: int = call @fac v2_;
+.v11_:
+  v13_: int = phi v12_ v4_ .v9_ .v8_;
+  jmp .v5_;
 .v9_:
-  v11_: int = call @fac v2_;
-.v12_:
-  v14_: int = phi v13_ v4_ .v10_ .v9_;
-  jmp .v7_;
-.v10_:
-  v15_: int = sub v0 v4_;
-  v16_: int = sub v15_ v4_;
+  v14_: int = sub v0 v4_;
+  v15_: int = sub v14_ v4_;
+  v16_: int = call @fac v14_;
   v17_: int = call @fac v15_;
-  v18_: int = call @fac v16_;
-  v13_: int = add v17_ v18_;
-  jmp .v12_;
-.v7_:
-  v19_: int = phi v14_ v4_ .v12_ .v5_;
-  ret v19_;
+  v12_: int = add v16_ v17_;
+  jmp .v11_;
+.v5_:
+  v18_: int = phi v13_ v4_ .v11_ .v1_;
+  ret v18_;
 }
 @main {
 .v0_:

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -3,35 +3,42 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @fac(v0: int): int {
-  v1_: int = const 0;
-  v2_: bool = eq v0 v1_;
-  v3_: int = const 1;
-  br v2_ .v4_ .v5_;
-.v4_:
-  v6_: int = id v3_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 0;
+  v3_: bool = eq v0 v2_;
+  v4_: int = const 1;
+  br v3_ .v5_ .v6_;
 .v5_:
-  v8_: bool = eq v0 v3_;
+  jmp .v7_;
+.v6_:
+  v8_: bool = eq v0 v4_;
   br v8_ .v9_ .v10_;
 .v9_:
+<<<<<<< HEAD
   v11_: int = call @fac v1_;
   v12_: int = id v3_;
 .v13_:
   v6_: int = id v12_;
+=======
+  v11_: int = call @fac v2_;
+.v12_:
+  v14_: int = phi v13_ v0 .v10_ .v9_;
+>>>>>>> 9c411b53 (working without collapse empty blocks)
   jmp .v7_;
 .v10_:
-  v14_: int = sub v0 v3_;
-  v15_: int = sub v14_ v3_;
-  v16_: int = call @fac v14_;
+  v15_: int = sub v0 v4_;
+  v16_: int = sub v15_ v4_;
   v17_: int = call @fac v15_;
-  v18_: int = add v16_ v17_;
-  v12_: int = id v18_;
-  jmp .v13_;
+  v18_: int = call @fac v16_;
+  v13_: int = add v17_ v18_;
+  jmp .v12_;
 .v7_:
-  ret v6_;
+  v19_: int = phi v14_ v4_ .v12_ .v5_;
+  ret v19_;
 }
 @main {
-  v0_: int = const 2;
-  v1_: int = call @fac v0_;
-  print v1_;
+.v0_:
+  v1_: int = const 2;
+  v2_: int = call @fac v1_;
+  print v2_;
 }

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -14,16 +14,9 @@ expression: visualization.result
   v8_: bool = eq v0 v4_;
   br v8_ .v9_ .v10_;
 .v9_:
-<<<<<<< HEAD
-  v11_: int = call @fac v1_;
-  v12_: int = id v3_;
-.v13_:
-  v6_: int = id v12_;
-=======
   v11_: int = call @fac v2_;
 .v12_:
-  v14_: int = phi v13_ v0 .v10_ .v9_;
->>>>>>> 9c411b53 (working without collapse empty blocks)
+  v14_: int = phi v13_ v4_ .v10_ .v9_;
   jmp .v7_;
 .v10_:
   v15_: int = sub v0 v4_;

--- a/tests/snapshots/files__fib_shape-optimize.snap
+++ b/tests/snapshots/files__fib_shape-optimize.snap
@@ -14,14 +14,12 @@ expression: visualization.result
   br v8_ .v9_ .v10_;
 .v9_:
   v11_: int = add v4_ v5_;
-.v12_:
-  v13_: int = phi v4_ v11_ .v10_ .v9_;
-  v4_: int = id v13_;
+.v10_:
+  v12_: int = phi v4_ v11_ .v7_ .v9_;
+  v4_: int = id v12_;
   v5_: int = id v5_;
   v6_: int = id v6_;
-  br v8_ .v7_ .v14_;
-.v10_:
-  jmp .v12_;
-.v14_:
+  br v8_ .v7_ .v13_;
+.v13_:
   print v4_;
 }

--- a/tests/snapshots/files__fib_shape-optimize.snap
+++ b/tests/snapshots/files__fib_shape-optimize.snap
@@ -3,29 +3,25 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 0;
-  v2_: int = const 1;
-  v3_: int = id v1_;
+.v1_:
+  v2_: int = const 0;
+  v3_: int = const 1;
   v4_: int = id v2_;
-  v5_: int = id v0;
-.v6_:
-  v7_: bool = lt v3_ v5_;
-  br v7_ .v8_ .v9_;
-.v8_:
-  v10_: int = add v3_ v4_;
-  v11_: int = id v10_;
-  v12_: int = id v4_;
-  v13_: int = id v5_;
-.v14_:
-  v3_: int = id v11_;
-  v4_: int = id v12_;
-  v5_: int = id v13_;
-  br v7_ .v6_ .v15_;
+  v5_: int = id v3_;
+  v6_: int = id v0;
+.v7_:
+  v8_: bool = lt v4_ v6_;
+  br v8_ .v9_ .v10_;
 .v9_:
-  v11_: int = id v3_;
-  v12_: int = id v4_;
-  v13_: int = id v5_;
-  jmp .v14_;
-.v15_:
-  print v3_;
+  v11_: int = add v4_ v5_;
+.v12_:
+  v13_: int = phi v4_ v11_ .v10_ .v9_;
+  v4_: int = id v13_;
+  v5_: int = id v5_;
+  v6_: int = id v6_;
+  br v8_ .v7_ .v14_;
+.v10_:
+  jmp .v12_;
+.v14_:
+  print v4_;
 }

--- a/tests/snapshots/files__flatten_loop-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-optimize.snap
@@ -3,67 +3,52 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int, v1: int) {
-  v2_: int = const 0;
-  v3_: int = const 1;
-  v4_: int = id v2_;
+.v2_:
+  v3_: int = const 0;
+  v4_: int = const 1;
   v5_: int = id v3_;
-  v6_: int = id v1;
-  v7_: int = id v0;
-.v8_:
-  v9_: bool = lt v4_ v7_;
-  br v9_ .v10_ .v11_;
-.v10_:
-  v12_: int = const 0;
-  v13_: int = id v4_;
-  v14_: int = id v5_;
-  v15_: int = id v12_;
-  v16_: int = id v6_;
-  v17_: int = id v7_;
-.v18_:
-  v19_: bool = lt v15_ v16_;
-  br v19_ .v20_ .v21_;
-.v20_:
-  v22_: int = mul v13_ v16_;
-  v23_: int = add v15_ v22_;
-  print v23_;
-  v24_: int = add v14_ v15_;
-  v25_: int = id v13_;
-  v26_: int = id v14_;
-  v27_: int = id v24_;
-  v28_: int = id v16_;
-  v29_: int = id v17_;
-.v30_:
-  v13_: int = id v25_;
-  v14_: int = id v26_;
-  v15_: int = id v27_;
-  v16_: int = id v28_;
-  v17_: int = id v29_;
-  br v19_ .v18_ .v31_;
-.v31_:
-  v32_: int = add v4_ v5_;
-  v33_: int = id v32_;
-  v34_: int = id v5_;
-  v35_: int = id v6_;
-  v36_: int = id v7_;
-.v37_:
-  v4_: int = id v33_;
-  v5_: int = id v34_;
-  v6_: int = id v35_;
-  v7_: int = id v36_;
-  br v9_ .v8_ .v38_;
-.v21_:
-  v25_: int = id v13_;
-  v26_: int = id v14_;
-  v27_: int = id v15_;
-  v28_: int = id v16_;
-  v29_: int = id v17_;
-  jmp .v30_;
+  v6_: int = id v4_;
+  v7_: int = id v1;
+  v8_: int = id v0;
+.v9_:
+  v10_: bool = lt v5_ v8_;
+  br v10_ .v11_ .v12_;
 .v11_:
-  v33_: int = id v4_;
-  v34_: int = id v5_;
-  v35_: int = id v6_;
-  v36_: int = id v7_;
-  jmp .v37_;
-.v38_:
-  print v4_;
+  v13_: int = const 0;
+  v14_: int = id v5_;
+  v15_: int = id v6_;
+  v16_: int = id v13_;
+  v17_: int = id v7_;
+  v18_: int = id v8_;
+.v19_:
+  v20_: bool = lt v16_ v17_;
+  br v20_ .v21_ .v22_;
+.v21_:
+  v23_: int = mul v14_ v17_;
+  v24_: int = add v16_ v23_;
+  print v24_;
+  v25_: int = add v15_ v16_;
+.v26_:
+  v27_: int = phi v16_ v25_ .v22_ .v21_;
+  v14_: int = id v14_;
+  v15_: int = id v15_;
+  v16_: int = id v27_;
+  v17_: int = id v17_;
+  v18_: int = id v18_;
+  br v20_ .v19_ .v28_;
+.v28_:
+  v29_: int = add v5_ v6_;
+.v30_:
+  v31_: int = phi v5_ v29_ .v12_ .v28_;
+  v5_: int = id v31_;
+  v6_: int = id v6_;
+  v7_: int = id v7_;
+  v8_: int = id v8_;
+  br v10_ .v9_ .v32_;
+.v22_:
+  jmp .v26_;
+.v12_:
+  jmp .v30_;
+.v32_:
+  print v5_;
 }

--- a/tests/snapshots/files__flatten_loop-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-optimize.snap
@@ -28,27 +28,23 @@ expression: visualization.result
   v24_: int = add v16_ v23_;
   print v24_;
   v25_: int = add v15_ v16_;
-.v26_:
-  v27_: int = phi v16_ v25_ .v22_ .v21_;
+.v22_:
+  v26_: int = phi v16_ v25_ .v19_ .v21_;
   v14_: int = id v14_;
   v15_: int = id v15_;
-  v16_: int = id v27_;
+  v16_: int = id v26_;
   v17_: int = id v17_;
   v18_: int = id v18_;
-  br v20_ .v19_ .v28_;
-.v28_:
-  v29_: int = add v5_ v6_;
-.v30_:
-  v31_: int = phi v5_ v29_ .v12_ .v28_;
-  v5_: int = id v31_;
+  br v20_ .v19_ .v27_;
+.v27_:
+  v28_: int = add v5_ v6_;
+.v12_:
+  v29_: int = phi v5_ v28_ .v9_ .v27_;
+  v5_: int = id v29_;
   v6_: int = id v6_;
   v7_: int = id v7_;
   v8_: int = id v8_;
-  br v10_ .v9_ .v32_;
-.v22_:
-  jmp .v26_;
-.v12_:
-  jmp .v30_;
-.v32_:
+  br v10_ .v9_ .v30_;
+.v30_:
   print v5_;
 }

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -3,31 +3,10 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-  v1_: int = const 0;
-  v2_: bool = lt v0 v1_;
-  v3_: bool = lt v1_ v0;
-  v4_: int = const 1;
-  br v2_ .v5_ .v6_;
-.v5_:
-  br v3_ .v7_ .v8_;
-.v7_:
-  v9_: int = id v4_;
-.v10_:
-  v11_: int = id v9_;
-  jmp .v12_;
-.v8_:
-  v13_: int = const 3;
-  v9_: int = id v13_;
-  jmp .v10_;
-=======
-=======
->>>>>>> 485da000 (snapshots)
 .v1_:
   v2_: int = const 0;
-  v3_: bool = lt v2_ v0;
-  v4_: bool = lt v0 v2_;
+  v3_: bool = lt v0 v2_;
+  v4_: bool = lt v2_ v0;
   v5_: int = const 1;
   br v3_ .v6_ .v7_;
 .v6_:

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -32,16 +32,14 @@ expression: visualization.result
   br v3_ .v6_ .v7_;
 .v6_:
   br v4_ .v8_ .v9_;
-.v8_:
-.v10_:
-  v12_: int = phi v11_ v5_ .v9_ .v8_;
-  jmp .v13_;
 .v9_:
-  v11_: int = const 3;
-  jmp .v10_;
+  v10_: int = const 3;
+.v8_:
+  v11_: int = phi v10_ v5_ .v9_ .v6_;
+  jmp .v12_;
 .v7_:
-  v14_: int = const 3;
-.v13_:
-  v15_: int = phi v14_ v12_ .v7_ .v10_;
-  print v15_;
+  v13_: int = const 3;
+.v12_:
+  v14_: int = phi v13_ v11_ .v7_ .v8_;
+  print v14_;
 }

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
+<<<<<<< HEAD
   v1_: int = const 0;
   v2_: bool = lt v0 v1_;
   v3_: bool = lt v1_ v0;
@@ -19,9 +20,26 @@ expression: visualization.result
   v13_: int = const 3;
   v9_: int = id v13_;
   jmp .v10_;
+=======
+.v1_:
+  v2_: int = const 0;
+  v3_: bool = lt v0 v2_;
+  v4_: bool = gt v0 v2_;
+  v5_: int = const 1;
+  br v3_ .v6_ .v7_;
+>>>>>>> 9c411b53 (working without collapse empty blocks)
 .v6_:
+  br v4_ .v8_ .v9_;
+.v8_:
+.v10_:
+  v12_: int = phi v11_ v5_ .v9_ .v8_;
+  jmp .v13_;
+.v9_:
+  v11_: int = const 3;
+  jmp .v10_;
+.v7_:
   v14_: int = const 3;
-  v11_: int = id v14_;
-.v12_:
-  print v11_;
+.v13_:
+  v15_: int = phi v14_ v12_ .v7_ .v10_;
+  print v15_;
 }

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -4,6 +4,7 @@ expression: visualization.result
 ---
 @main(v0: int) {
 <<<<<<< HEAD
+<<<<<<< HEAD
   v1_: int = const 0;
   v2_: bool = lt v0 v1_;
   v3_: bool = lt v1_ v0;
@@ -21,13 +22,14 @@ expression: visualization.result
   v9_: int = id v13_;
   jmp .v10_;
 =======
+=======
+>>>>>>> 485da000 (snapshots)
 .v1_:
   v2_: int = const 0;
-  v3_: bool = lt v0 v2_;
-  v4_: bool = gt v0 v2_;
+  v3_: bool = lt v2_ v0;
+  v4_: bool = lt v0 v2_;
   v5_: int = const 1;
   br v3_ .v6_ .v7_;
->>>>>>> 9c411b53 (working without collapse empty blocks)
 .v6_:
   br v4_ .v8_ .v9_;
 .v8_:

--- a/tests/snapshots/files__gamma_pull_in-optimize.snap
+++ b/tests/snapshots/files__gamma_pull_in-optimize.snap
@@ -3,17 +3,17 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 10;
-  v2_: bool = lt v0 v1_;
-  br v2_ .v3_ .v4_;
-.v3_:
-  v5_: int = const 2;
-  v6_: int = id v5_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 10;
+  v3_: bool = lt v0 v2_;
+  br v3_ .v4_ .v5_;
 .v4_:
+  v6_: int = const 2;
+  jmp .v7_;
+.v5_:
   v8_: int = const 3;
-  v6_: int = id v8_;
 .v7_:
-  v9_: int = add v6_ v6_;
-  print v9_;
+  v9_: int = phi v8_ v6_ .v5_ .v4_;
+  v10_: int = add v9_ v9_;
+  print v10_;
 }

--- a/tests/snapshots/files__if_constant_fold-optimize.snap
+++ b/tests/snapshots/files__if_constant_fold-optimize.snap
@@ -3,8 +3,9 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 6;
-  v2_: int = const 3;
+.v1_:
+  v2_: int = const 6;
+  v3_: int = const 3;
+  print v3_;
   print v2_;
-  print v1_;
 }

--- a/tests/snapshots/files__if_constant_fold2-optimize.snap
+++ b/tests/snapshots/files__if_constant_fold2-optimize.snap
@@ -9,19 +9,14 @@ expression: visualization.result
   v4_: int = const 4;
   v5_: int = const 20;
   br v3_ .v6_ .v7_;
-.v6_:
-  jmp .v8_;
 .v7_:
-  v9_: bool = eq v0 v4_;
-  br v9_ .v10_ .v11_;
+  v8_: bool = eq v0 v4_;
+  br v8_ .v9_ .v10_;
+.v9_:
+  v11_: int = const 20;
 .v10_:
-  v12_: int = const 20;
-.v13_:
-  v14_: int = phi v5_ v12_ .v11_ .v10_;
-  jmp .v8_;
-.v11_:
-  jmp .v13_;
-.v8_:
-  v15_: int = phi v14_ v5_ .v13_ .v6_;
-  print v15_;
+  v12_: int = phi v5_ v11_ .v7_ .v9_;
+.v6_:
+  v13_: int = phi v12_ v5_ .v10_ .v1_;
+  print v13_;
 }

--- a/tests/snapshots/files__if_constant_fold2-optimize.snap
+++ b/tests/snapshots/files__if_constant_fold2-optimize.snap
@@ -3,26 +3,25 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 5;
-  v2_: bool = eq v0 v1_;
-  v3_: int = const 4;
-  v4_: int = const 20;
-  br v2_ .v5_ .v6_;
-.v5_:
-  v7_: int = id v4_;
-  jmp .v8_;
+.v1_:
+  v2_: int = const 5;
+  v3_: bool = eq v0 v2_;
+  v4_: int = const 4;
+  v5_: int = const 20;
+  br v3_ .v6_ .v7_;
 .v6_:
-  v9_: bool = eq v0 v3_;
+  jmp .v8_;
+.v7_:
+  v9_: bool = eq v0 v4_;
   br v9_ .v10_ .v11_;
 .v10_:
   v12_: int = const 20;
-  v13_: int = id v12_;
-.v14_:
-  v7_: int = id v13_;
+.v13_:
+  v14_: int = phi v5_ v12_ .v11_ .v10_;
   jmp .v8_;
 .v11_:
-  v13_: int = id v4_;
-  jmp .v14_;
+  jmp .v13_;
 .v8_:
-  print v7_;
+  v15_: int = phi v14_ v5_ .v13_ .v6_;
+  print v15_;
 }

--- a/tests/snapshots/files__if_context-optimize.snap
+++ b/tests/snapshots/files__if_context-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: bool = const true;
-  print v1_;
+.v1_:
+  v2_: bool = const true;
+  print v2_;
 }

--- a/tests/snapshots/files__if_dead_code-optimize.snap
+++ b/tests/snapshots/files__if_dead_code-optimize.snap
@@ -3,17 +3,17 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 0;
-  v2_: bool = lt v0 v1_;
-  br v2_ .v3_ .v4_;
-.v3_:
-  v5_: int = const 1;
-  v6_: int = id v5_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 0;
+  v3_: bool = lt v0 v2_;
+  br v3_ .v4_ .v5_;
 .v4_:
+  v6_: int = const 1;
+  jmp .v7_;
+.v5_:
   v8_: int = const 0;
-  v6_: int = id v8_;
 .v7_:
-  print v6_;
-  print v2_;
+  v9_: int = phi v8_ v6_ .v5_ .v4_;
+  print v9_;
+  print v3_;
 }

--- a/tests/snapshots/files__if_interval-optimize.snap
+++ b/tests/snapshots/files__if_interval-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: bool = const true;
-  print v1_;
+.v1_:
+  v2_: bool = const true;
+  print v2_;
 }

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -3,68 +3,31 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @pow(v0: int, v1: int) {
-<<<<<<< HEAD
-  v2_: int = const 0;
-  v3_: int = id v0;
-  v4_: int = id v2_;
-  v5_: int = id v0;
-  v6_: int = id v1;
-.v7_:
-  v8_: int = const 1;
-  v9_: int = sub v6_ v8_;
-  v10_: bool = lt v4_ v9_;
-  br v10_ .v11_ .v12_;
-.v11_:
-  v13_: int = mul v3_ v5_;
-  v14_: int = const 1;
-  v15_: int = add v14_ v4_;
-  v16_: int = id v13_;
-  v17_: int = id v15_;
-  v18_: int = id v5_;
-  v19_: int = id v6_;
-.v20_:
-  v3_: int = id v16_;
-  v4_: int = id v17_;
-  v5_: int = id v18_;
-  v6_: int = id v19_;
-  br v10_ .v7_ .v21_;
-.v12_:
-  v16_: int = id v3_;
-  v17_: int = id v4_;
-  v18_: int = id v5_;
-  v19_: int = id v6_;
-  jmp .v20_;
-.v21_:
-  print v3_;
-=======
 .v2_:
   v3_: int = const 0;
-  v4_: int = const 1;
-  v5_: int = sub v1 v4_;
+  v4_: int = id v0;
+  v5_: int = id v3_;
   v6_: int = id v0;
-  v7_: int = id v3_;
-  v8_: int = id v0;
-  v9_: int = id v1;
-  v10_: int = id v5_;
-.v11_:
-  v12_: bool = lt v7_ v10_;
-  br v12_ .v13_ .v14_;
+  v7_: int = id v1;
+.v8_:
+  v9_: int = const 1;
+  v10_: int = sub v7_ v9_;
+  v11_: bool = lt v5_ v10_;
+  br v11_ .v12_ .v13_;
+.v12_:
+  v14_: int = mul v4_ v6_;
+  v15_: int = const 1;
+  v16_: int = add v15_ v5_;
 .v13_:
-  v15_: int = mul v6_ v8_;
-  v16_: int = const 1;
-  v17_: int = add v16_ v7_;
-.v14_:
-  v18_: int = phi v6_ v15_ .v11_ .v13_;
-  v19_: int = phi v7_ v17_ .v11_ .v13_;
-  v6_: int = id v18_;
-  v7_: int = id v19_;
-  v8_: int = id v8_;
-  v9_: int = id v9_;
-  v10_: int = id v10_;
-  br v12_ .v11_ .v20_;
-.v20_:
-  print v6_;
->>>>>>> 71264d0b (working without collapse empty blocks)
+  v17_: int = phi v4_ v14_ .v8_ .v12_;
+  v18_: int = phi v5_ v16_ .v8_ .v12_;
+  v4_: int = id v17_;
+  v5_: int = id v18_;
+  v6_: int = id v6_;
+  v7_: int = id v7_;
+  br v11_ .v8_ .v19_;
+.v19_:
+  print v4_;
 }
 @main {
 .v0_:

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -53,18 +53,16 @@ expression: visualization.result
   v15_: int = mul v6_ v8_;
   v16_: int = const 1;
   v17_: int = add v16_ v7_;
-.v18_:
-  v19_: int = phi v6_ v15_ .v14_ .v13_;
-  v20_: int = phi v7_ v17_ .v14_ .v13_;
-  v6_: int = id v19_;
-  v7_: int = id v20_;
+.v14_:
+  v18_: int = phi v6_ v15_ .v11_ .v13_;
+  v19_: int = phi v7_ v17_ .v11_ .v13_;
+  v6_: int = id v18_;
+  v7_: int = id v19_;
   v8_: int = id v8_;
   v9_: int = id v9_;
   v10_: int = id v10_;
-  br v12_ .v11_ .v21_;
-.v14_:
-  jmp .v18_;
-.v21_:
+  br v12_ .v11_ .v20_;
+.v20_:
   print v6_;
 >>>>>>> 71264d0b (working without collapse empty blocks)
 }
@@ -89,23 +87,18 @@ expression: visualization.result
   v17_: int = mul v10_ v8_;
   v18_: int = const 1;
   v19_: int = add v18_ v9_;
-.v20_:
-  v21_: int = phi v8_ v17_ .v16_ .v15_;
-  v22_: int = phi v9_ v19_ .v16_ .v15_;
-  v8_: int = id v21_;
-  v9_: int = id v22_;
+.v16_:
+  v20_: int = phi v8_ v17_ .v12_ .v15_;
+  v21_: int = phi v9_ v19_ .v12_ .v15_;
+  v8_: int = id v20_;
+  v9_: int = id v21_;
   v10_: int = id v10_;
   v11_: int = id v11_;
-  br v14_ .v12_ .v23_;
-.v23_:
-  jmp .v24_;
-.v16_:
-  jmp .v20_;
+  br v14_ .v12_ .v7_;
 .v7_:
-.v24_:
-  v25_: int = phi v2_ v8_ .v7_ .v23_;
-  v26_: int = phi v3_ v9_ .v7_ .v23_;
-  v27_: int = phi v4_ v10_ .v7_ .v23_;
-  v28_: int = phi v5_ v11_ .v7_ .v23_;
-  print v25_;
+  v22_: int = phi v2_ v8_ .v0_ .v16_;
+  v23_: int = phi v3_ v9_ .v0_ .v16_;
+  v24_: int = phi v4_ v10_ .v0_ .v16_;
+  v25_: int = phi v5_ v11_ .v0_ .v16_;
+  print v22_;
 }

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @pow(v0: int, v1: int) {
+<<<<<<< HEAD
   v2_: int = const 0;
   v3_: int = id v0;
   v4_: int = id v2_;
@@ -35,54 +36,76 @@ expression: visualization.result
   jmp .v20_;
 .v21_:
   print v3_;
+=======
+.v2_:
+  v3_: int = const 0;
+  v4_: int = const 1;
+  v5_: int = sub v1 v4_;
+  v6_: int = id v0;
+  v7_: int = id v3_;
+  v8_: int = id v0;
+  v9_: int = id v1;
+  v10_: int = id v5_;
+.v11_:
+  v12_: bool = lt v7_ v10_;
+  br v12_ .v13_ .v14_;
+.v13_:
+  v15_: int = mul v6_ v8_;
+  v16_: int = const 1;
+  v17_: int = add v16_ v7_;
+.v18_:
+  v19_: int = phi v6_ v15_ .v14_ .v13_;
+  v20_: int = phi v7_ v17_ .v14_ .v13_;
+  v6_: int = id v19_;
+  v7_: int = id v20_;
+  v8_: int = id v8_;
+  v9_: int = id v9_;
+  v10_: int = id v10_;
+  br v12_ .v11_ .v21_;
+.v14_:
+  jmp .v18_;
+.v21_:
+  print v6_;
+>>>>>>> 71264d0b (working without collapse empty blocks)
 }
 @main {
-  v0_: bool = const true;
-  v1_: int = const 16;
-  v2_: int = const 1;
-  v3_: int = const 4;
-  v4_: int = const 15;
-  br v0_ .v5_ .v6_;
-.v5_:
-  v7_: int = id v1_;
+.v0_:
+  v1_: bool = const true;
+  v2_: int = const 16;
+  v3_: int = const 1;
+  v4_: int = const 4;
+  v5_: int = const 15;
+  br v1_ .v6_ .v7_;
+.v6_:
   v8_: int = id v2_;
   v9_: int = id v3_;
   v10_: int = id v4_;
-.v11_:
-  v12_: int = const 14;
-  v13_: bool = lt v8_ v12_;
-  br v13_ .v14_ .v15_;
-.v14_:
-  v16_: int = mul v7_ v9_;
-  v17_: int = const 1;
-  v18_: int = add v17_ v8_;
-  v19_: int = id v16_;
-  v20_: int = id v18_;
-  v21_: int = id v9_;
-  v22_: int = id v10_;
-.v23_:
-  v7_: int = id v19_;
-  v8_: int = id v20_;
-  v9_: int = id v21_;
-  v10_: int = id v22_;
-  br v13_ .v11_ .v24_;
-.v24_:
-  v25_: int = id v7_;
-  v26_: int = id v8_;
-  v27_: int = id v9_;
-  v28_: int = id v10_;
-  jmp .v29_;
+  v11_: int = id v5_;
+.v12_:
+  v13_: int = const 14;
+  v14_: bool = lt v9_ v13_;
+  br v14_ .v15_ .v16_;
 .v15_:
-  v19_: int = id v7_;
-  v20_: int = id v8_;
-  v21_: int = id v9_;
-  v22_: int = id v10_;
-  jmp .v23_;
-.v6_:
-  v25_: int = id v1_;
-  v26_: int = id v2_;
-  v27_: int = id v3_;
-  v28_: int = id v4_;
-.v29_:
+  v17_: int = mul v10_ v8_;
+  v18_: int = const 1;
+  v19_: int = add v18_ v9_;
+.v20_:
+  v21_: int = phi v8_ v17_ .v16_ .v15_;
+  v22_: int = phi v9_ v19_ .v16_ .v15_;
+  v8_: int = id v21_;
+  v9_: int = id v22_;
+  v10_: int = id v10_;
+  v11_: int = id v11_;
+  br v14_ .v12_ .v23_;
+.v23_:
+  jmp .v24_;
+.v16_:
+  jmp .v20_;
+.v7_:
+.v24_:
+  v25_: int = phi v2_ v8_ .v7_ .v23_;
+  v26_: int = phi v3_ v9_ .v7_ .v23_;
+  v27_: int = phi v4_ v10_ .v7_ .v23_;
+  v28_: int = phi v5_ v11_ .v7_ .v23_;
   print v25_;
 }

--- a/tests/snapshots/files__impossible_if-optimize.snap
+++ b/tests/snapshots/files__impossible_if-optimize.snap
@@ -3,17 +3,16 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 1;
-  v2_: int = const 2;
-  v3_: bool = lt v0 v2_;
-  br v3_ .v4_ .v5_;
-.v4_:
-  print v1_;
-  v6_: int = id v1_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 1;
+  v3_: int = const 2;
+  v4_: bool = lt v0 v3_;
+  br v4_ .v5_ .v6_;
 .v5_:
-  print v1_;
-  v6_: int = id v1_;
+  print v2_;
+  jmp .v7_;
+.v6_:
+  print v2_;
 .v7_:
-  print v1_;
+  print v2_;
 }

--- a/tests/snapshots/files__loop_hoist-optimize.snap
+++ b/tests/snapshots/files__loop_hoist-optimize.snap
@@ -3,25 +3,26 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 1;
-  v1_: int = const 4;
-  v2_: int = const 3;
-  v3_: int = const 2;
-  v4_: int = id v0_;
+.v0_:
+  v1_: int = const 1;
+  v2_: int = const 4;
+  v3_: int = const 3;
+  v4_: int = const 2;
   v5_: int = id v1_;
   v6_: int = id v2_;
   v7_: int = id v3_;
-.v8_:
-  v9_: int = const 1;
-  print v9_;
-  v10_: int = add v4_ v9_;
-  v11_: bool = lt v10_ v5_;
-  v12_: bool = not v11_;
-  v4_: int = id v10_;
-  v5_: int = id v5_;
+  v8_: int = id v4_;
+.v9_:
+  v10_: int = const 1;
+  print v10_;
+  v11_: int = add v10_ v5_;
+  v12_: bool = lt v11_ v6_;
+  v13_: bool = not v12_;
+  v5_: int = id v11_;
   v6_: int = id v6_;
   v7_: int = id v7_;
-  br v12_ .v8_ .v13_;
-.v13_:
-  print v4_;
+  v8_: int = id v8_;
+  br v13_ .v9_ .v14_;
+.v14_:
+  print v5_;
 }

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -10,19 +10,17 @@ expression: visualization.result
 .v4_:
   v5_: bool = eq v2_ v3_;
   br v5_ .v6_ .v7_;
+.v7_:
+  v8_: int = const 1;
+  v9_: int = add v2_ v8_;
+  v10_: int = add v3_ v8_;
 .v6_:
-.v8_:
-  v10_: int = phi v9_ v2_ .v7_ .v6_;
-  v12_: int = phi v11_ v3_ .v7_ .v6_;
+  v11_: int = phi v9_ v2_ .v7_ .v4_;
+  v12_: int = phi v10_ v3_ .v7_ .v4_;
   v13_: bool = not v5_;
-  v2_: int = id v10_;
+  v2_: int = id v11_;
   v3_: int = id v12_;
   br v13_ .v4_ .v14_;
-.v7_:
-  v15_: int = const 1;
-  v9_: int = add v15_ v2_;
-  v11_: int = add v15_ v3_;
-  jmp .v8_;
 .v14_:
   print v2_;
 }

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -3,29 +3,26 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 0;
-  v1_: int = id v0_;
-  v2_: int = id v0_;
-.v3_:
-  v4_: bool = eq v1_ v2_;
-  br v4_ .v5_ .v6_;
-.v5_:
-  v7_: int = id v1_;
-  v8_: bool = id v4_;
-  v9_: int = id v2_;
-.v10_:
-  v11_: bool = not v4_;
-  v1_: int = id v7_;
-  v2_: int = id v9_;
-  br v11_ .v3_ .v12_;
+.v0_:
+  v1_: int = const 0;
+  v2_: int = id v1_;
+  v3_: int = id v1_;
+.v4_:
+  v5_: bool = eq v2_ v3_;
+  br v5_ .v6_ .v7_;
 .v6_:
-  v13_: int = const 1;
-  v14_: int = add v13_ v1_;
-  v15_: int = add v13_ v2_;
-  v7_: int = id v14_;
-  v8_: bool = id v4_;
-  v9_: int = id v15_;
-  jmp .v10_;
-.v12_:
-  print v1_;
+.v8_:
+  v10_: int = phi v9_ v2_ .v7_ .v6_;
+  v12_: int = phi v11_ v3_ .v7_ .v6_;
+  v13_: bool = not v5_;
+  v2_: int = id v10_;
+  v3_: int = id v12_;
+  br v13_ .v4_ .v14_;
+.v7_:
+  v15_: int = const 1;
+  v9_: int = add v15_ v2_;
+  v11_: int = add v15_ v3_;
+  jmp .v8_;
+.v14_:
+  print v2_;
 }

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -4,6 +4,7 @@ expression: visualization.result
 ---
 @main(v0: int) {
 <<<<<<< HEAD
+<<<<<<< HEAD
   v1_: int = const 2;
 =======
 <<<<<<< HEAD
@@ -22,8 +23,10 @@ expression: visualization.result
   v9_: int = add v0 v2_;
   print v9_;
 =======
+=======
+>>>>>>> 485da000 (snapshots)
 .v1_:
-  v2_: int = const 2;
+  v2_: int = const 1;
   v3_: int = id v2_;
   v4_: int = id v0;
 .v5_:
@@ -36,5 +39,4 @@ expression: visualization.result
 .v9_:
   v10_: int = add v0 v3_;
   print v10_;
->>>>>>> 9c411b53 (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -3,7 +3,12 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
+<<<<<<< HEAD
   v1_: int = const 2;
+=======
+<<<<<<< HEAD
+  v1_: int = const 1;
+>>>>>>> 71264d0b (working without collapse empty blocks)
   v2_: int = id v1_;
   v3_: int = id v0;
 .v4_:
@@ -16,4 +21,20 @@ expression: visualization.result
 .v8_:
   v9_: int = add v0 v2_;
   print v9_;
+=======
+.v1_:
+  v2_: int = const 2;
+  v3_: int = id v2_;
+  v4_: int = id v0;
+.v5_:
+  v6_: int = add v3_ v3_;
+  v7_: int = const 10;
+  v8_: bool = lt v3_ v7_;
+  v3_: int = id v6_;
+  v4_: int = id v4_;
+  br v8_ .v5_ .v9_;
+.v9_:
+  v10_: int = add v0 v3_;
+  print v10_;
+>>>>>>> 9c411b53 (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -3,30 +3,8 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-  v1_: int = const 2;
-=======
-<<<<<<< HEAD
-  v1_: int = const 1;
->>>>>>> 71264d0b (working without collapse empty blocks)
-  v2_: int = id v1_;
-  v3_: int = id v0;
-.v4_:
-  v5_: int = add v2_ v2_;
-  v6_: int = const 10;
-  v7_: bool = lt v2_ v6_;
-  v2_: int = id v5_;
-  v3_: int = id v3_;
-  br v7_ .v4_ .v8_;
-.v8_:
-  v9_: int = add v0 v2_;
-  print v9_;
-=======
-=======
->>>>>>> 485da000 (snapshots)
 .v1_:
-  v2_: int = const 1;
+  v2_: int = const 2;
   v3_: int = id v2_;
   v4_: int = id v0;
 .v5_:

--- a/tests/snapshots/files__loop_with_mul_by_inv-optimize.snap
+++ b/tests/snapshots/files__loop_with_mul_by_inv-optimize.snap
@@ -3,25 +3,26 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 0;
-  v2_: int = const 5;
-  v3_: int = id v1_;
-  v4_: int = id v1_;
+.v1_:
+  v2_: int = const 0;
+  v3_: int = const 5;
+  v4_: int = id v2_;
   v5_: int = id v2_;
-  v6_: int = id v0;
-  v7_: int = id v1_;
-.v8_:
-  v9_: int = add v3_ v7_;
-  v10_: int = const 1;
-  v11_: int = add v10_ v4_;
-  v12_: int = add v5_ v7_;
-  v13_: bool = lt v4_ v6_;
-  v3_: int = id v9_;
-  v4_: int = id v11_;
-  v5_: int = id v5_;
+  v6_: int = id v3_;
+  v7_: int = id v0;
+  v8_: int = id v2_;
+.v9_:
+  v10_: int = add v4_ v8_;
+  v11_: int = const 1;
+  v12_: int = add v11_ v5_;
+  v13_: int = add v6_ v8_;
+  v14_: bool = lt v5_ v7_;
+  v4_: int = id v10_;
+  v5_: int = id v12_;
   v6_: int = id v6_;
-  v7_: int = id v12_;
-  br v13_ .v8_ .v14_;
-.v14_:
-  print v3_;
+  v7_: int = id v7_;
+  v8_: int = id v13_;
+  br v14_ .v9_ .v15_;
+.v15_:
+  print v4_;
 }

--- a/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
@@ -3,28 +3,29 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: bool) {
-  v1_: int = const 3;
-  v2_: ptr<int> = alloc v1_;
-  v3_: int = const 1;
-  v4_: ptr<int> = ptradd v2_ v3_;
-  v5_: int = const 2;
-  v6_: ptr<int> = ptradd v2_ v5_;
-  v7_: ptr<int> = id v4_;
-  v8_: ptr<int> = id v2_;
-  v9_: ptr<int> = id v6_;
-  v10_: bool = id v0;
-.v11_:
-  v7_: ptr<int> = id v8_;
-  v8_: ptr<int> = id v7_;
-  v9_: ptr<int> = id v9_;
-  v10_: bool = id v10_;
-  br v10_ .v11_ .v12_;
+.v1_:
+  v2_: int = const 3;
+  v3_: ptr<int> = alloc v2_;
+  v4_: int = const 1;
+  v5_: ptr<int> = ptradd v3_ v4_;
+  v6_: int = const 2;
+  v7_: ptr<int> = ptradd v3_ v6_;
+  v8_: ptr<int> = id v5_;
+  v9_: ptr<int> = id v3_;
+  v10_: ptr<int> = id v7_;
+  v11_: bool = id v0;
 .v12_:
-  v13_: int = const 10;
-  v14_: int = const 20;
-  store v8_ v13_;
+  v8_: ptr<int> = id v9_;
+  v9_: ptr<int> = id v8_;
+  v10_: ptr<int> = id v10_;
+  v11_: bool = id v11_;
+  br v11_ .v12_ .v13_;
+.v13_:
+  v14_: int = const 10;
+  v15_: int = const 20;
   store v9_ v14_;
-  v15_: int = load v8_;
-  print v13_;
-  free v7_;
+  store v10_ v15_;
+  v16_: int = load v9_;
+  print v14_;
+  free v8_;
 }

--- a/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
+++ b/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
@@ -3,21 +3,20 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: bool) {
-  v1_: int = const 1;
-  v2_: ptr<int> = alloc v1_;
-  br v0 .v3_ .v4_;
-.v3_:
-  v5_: int = const 2;
-  store v2_ v5_;
-  v6_: ptr<int> = id v2_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 1;
+  v3_: ptr<int> = alloc v2_;
+  br v0 .v4_ .v5_;
 .v4_:
+  v6_: int = const 2;
+  store v3_ v6_;
+  jmp .v7_;
+.v5_:
   v8_: int = const 3;
-  store v2_ v8_;
-  v6_: ptr<int> = id v2_;
+  store v3_ v8_;
 .v7_:
-  v9_: int = load v2_;
-  v10_: int = load v2_;
+  v9_: int = load v3_;
+  v10_: int = load v3_;
   print v9_;
-  free v2_;
+  free v3_;
 }

--- a/tests/snapshots/files__mem_simple_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_simple_store_forwarding-optimize.snap
@@ -3,15 +3,16 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 2;
-  v1_: ptr<int> = alloc v0_;
-  v2_: int = const 10;
-  v3_: int = const 1;
-  v4_: ptr<int> = ptradd v1_ v3_;
-  v5_: int = const 20;
-  store v1_ v2_;
-  store v4_ v5_;
-  v6_: int = load v1_;
-  print v2_;
-  free v1_;
+.v0_:
+  v1_: int = const 2;
+  v2_: ptr<int> = alloc v1_;
+  v3_: int = const 10;
+  v4_: int = const 1;
+  v5_: ptr<int> = ptradd v2_ v4_;
+  v6_: int = const 20;
+  store v2_ v3_;
+  store v5_ v6_;
+  v7_: int = load v2_;
+  print v3_;
+  free v2_;
 }

--- a/tests/snapshots/files__nested_call-optimize.snap
+++ b/tests/snapshots/files__nested_call-optimize.snap
@@ -3,19 +3,22 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @inc(v0: int): int {
-  v1_: int = const 1;
-  v2_: int = add v0 v1_;
-  v3_: int = const 2;
-  v4_: int = mul v2_ v3_;
-  ret v4_;
+.v1_:
+  v2_: int = const 1;
+  v3_: int = add v0 v2_;
+  v4_: int = const 2;
+  v5_: int = mul v3_ v4_;
+  ret v5_;
 }
 @double(v0: int): int {
-  v1_: int = const 2;
-  v2_: int = mul v0 v1_;
-  ret v2_;
+.v1_:
+  v2_: int = const 2;
+  v3_: int = mul v0 v2_;
+  ret v3_;
 }
 @main {
-  v0_: int = const 2;
-  print v0_;
-  print v0_;
+.v0_:
+  v1_: int = const 2;
+  print v1_;
+  print v1_;
 }

--- a/tests/snapshots/files__range_check-optimize.snap
+++ b/tests/snapshots/files__range_check-optimize.snap
@@ -3,37 +3,35 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: bool = const true;
-  v1_: int = const 1;
-  print v1_;
-  br v0_ .v2_ .v3_;
-.v2_:
-  v4_: int = id v1_;
-.v5_:
-  v6_: int = const 5;
-  v7_: bool = lt v4_ v6_;
-  br v7_ .v8_ .v9_;
-.v8_:
-  v10_: int = const 1;
-  print v10_;
-  v11_: int = id v4_;
+.v0_:
+  v1_: bool = const true;
+  v2_: int = const 1;
+  print v2_;
+  br v1_ .v3_ .v4_;
+.v3_:
+  v5_: int = id v2_;
+.v6_:
+  v7_: int = const 5;
+  v8_: bool = lt v5_ v7_;
+  br v8_ .v9_ .v10_;
+.v9_:
+  v11_: int = const 1;
+  print v11_;
 .v12_:
   v13_: int = const 1;
-  v14_: int = add v13_ v4_;
+  v14_: int = add v13_ v5_;
   v15_: int = const 6;
-  v16_: bool = lt v4_ v15_;
-  v4_: int = id v14_;
-  br v16_ .v5_ .v17_;
+  v16_: bool = lt v5_ v15_;
+  v5_: int = id v14_;
+  br v16_ .v6_ .v17_;
 .v17_:
-  v18_: int = id v4_;
-  jmp .v19_;
-.v9_:
-  v20_: int = const 2;
-  print v20_;
-  v11_: int = id v4_;
+  jmp .v18_;
+.v10_:
+  v19_: int = const 2;
+  print v19_;
   jmp .v12_;
-.v3_:
-  v18_: int = id v1_;
-.v19_:
-  print v18_;
+.v4_:
+.v18_:
+  v20_: int = phi v2_ v5_ .v4_ .v17_;
+  print v20_;
 }

--- a/tests/snapshots/files__range_check-optimize.snap
+++ b/tests/snapshots/files__range_check-optimize.snap
@@ -23,15 +23,12 @@ expression: visualization.result
   v15_: int = const 6;
   v16_: bool = lt v5_ v15_;
   v5_: int = id v14_;
-  br v16_ .v6_ .v17_;
-.v17_:
-  jmp .v18_;
+  br v16_ .v6_ .v4_;
 .v10_:
-  v19_: int = const 2;
-  print v19_;
+  v17_: int = const 2;
+  print v17_;
   jmp .v12_;
 .v4_:
-.v18_:
-  v20_: int = phi v2_ v5_ .v4_ .v17_;
-  print v20_;
+  v18_: int = phi v2_ v5_ .v0_ .v12_;
+  print v18_;
 }

--- a/tests/snapshots/files__range_splitting-optimize.snap
+++ b/tests/snapshots/files__range_splitting-optimize.snap
@@ -22,15 +22,12 @@ expression: visualization.result
   v14_: int = add v13_ v5_;
   v15_: bool = lt v14_ v7_;
   v5_: int = id v14_;
-  br v15_ .v6_ .v16_;
-.v16_:
-  jmp .v17_;
+  br v15_ .v6_ .v4_;
 .v10_:
-  v18_: int = const 2;
-  print v18_;
+  v16_: int = const 2;
+  print v16_;
   jmp .v12_;
 .v4_:
-.v17_:
-  v19_: int = phi v2_ v5_ .v4_ .v16_;
-  print v19_;
+  v17_: int = phi v2_ v5_ .v0_ .v12_;
+  print v17_;
 }

--- a/tests/snapshots/files__range_splitting-optimize.snap
+++ b/tests/snapshots/files__range_splitting-optimize.snap
@@ -3,36 +3,34 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: bool = const true;
-  v1_: int = const 1;
-  print v1_;
-  br v0_ .v2_ .v3_;
-.v2_:
-  v4_: int = id v1_;
-.v5_:
-  v6_: int = const 5;
-  v7_: bool = lt v4_ v6_;
-  br v7_ .v8_ .v9_;
-.v8_:
-  v10_: int = const 1;
-  print v10_;
-  v11_: int = id v4_;
+.v0_:
+  v1_: bool = const true;
+  v2_: int = const 1;
+  print v2_;
+  br v1_ .v3_ .v4_;
+.v3_:
+  v5_: int = id v2_;
+.v6_:
+  v7_: int = const 5;
+  v8_: bool = lt v5_ v7_;
+  br v8_ .v9_ .v10_;
+.v9_:
+  v11_: int = const 1;
+  print v11_;
 .v12_:
   v13_: int = const 1;
-  v14_: int = add v13_ v4_;
-  v15_: bool = lt v14_ v6_;
-  v4_: int = id v14_;
-  br v15_ .v5_ .v16_;
+  v14_: int = add v13_ v5_;
+  v15_: bool = lt v14_ v7_;
+  v5_: int = id v14_;
+  br v15_ .v6_ .v16_;
 .v16_:
-  v17_: int = id v4_;
-  jmp .v18_;
-.v9_:
-  v19_: int = const 2;
-  print v19_;
-  v11_: int = id v4_;
+  jmp .v17_;
+.v10_:
+  v18_: int = const 2;
+  print v18_;
   jmp .v12_;
-.v3_:
-  v17_: int = id v1_;
-.v18_:
-  print v17_;
+.v4_:
+.v17_:
+  v19_: int = phi v2_ v5_ .v4_ .v16_;
+  print v19_;
 }

--- a/tests/snapshots/files__reassoc-optimize.snap
+++ b/tests/snapshots/files__reassoc-optimize.snap
@@ -3,36 +3,13 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int, v1: int) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-  v2_: int = const 1;
-  v3_: int = const 4;
-  v4_: int = add v1 v3_;
-  v5_: int = const 3;
-  v6_: int = add v0 v5_;
-  v7_: int = add v4_ v6_;
-  v8_: int = add v2_ v7_;
-=======
-<<<<<<< HEAD
-  v2_: int = const 3;
-  v3_: int = add v0 v2_;
+.v2_:
+  v3_: int = const 1;
   v4_: int = const 4;
   v5_: int = add v1 v4_;
-  v6_: int = add v3_ v5_;
-  v7_: int = const 1;
-  v8_: int = add v6_ v7_;
->>>>>>> 71264d0b (working without collapse empty blocks)
-  print v8_;
-=======
-=======
->>>>>>> 485da000 (snapshots)
-.v2_:
-  v3_: int = const 3;
-  v4_: int = add v0 v3_;
-  v5_: int = const 4;
-  v6_: int = add v1 v5_;
-  v7_: int = add v4_ v6_;
-  v8_: int = const 1;
-  v9_: int = add v7_ v8_;
+  v6_: int = const 3;
+  v7_: int = add v0 v6_;
+  v8_: int = add v5_ v7_;
+  v9_: int = add v3_ v8_;
   print v9_;
 }

--- a/tests/snapshots/files__reassoc-optimize.snap
+++ b/tests/snapshots/files__reassoc-optimize.snap
@@ -4,6 +4,7 @@ expression: visualization.result
 ---
 @main(v0: int, v1: int) {
 <<<<<<< HEAD
+<<<<<<< HEAD
   v2_: int = const 1;
   v3_: int = const 4;
   v4_: int = add v1 v3_;
@@ -23,14 +24,15 @@ expression: visualization.result
 >>>>>>> 71264d0b (working without collapse empty blocks)
   print v8_;
 =======
+=======
+>>>>>>> 485da000 (snapshots)
 .v2_:
-  v3_: int = const 4;
-  v4_: int = add v1 v3_;
-  v5_: int = const 3;
-  v6_: int = add v0 v5_;
+  v3_: int = const 3;
+  v4_: int = add v0 v3_;
+  v5_: int = const 4;
+  v6_: int = add v1 v5_;
   v7_: int = add v4_ v6_;
   v8_: int = const 1;
   v9_: int = add v7_ v8_;
   print v9_;
->>>>>>> 9c411b53 (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__reassoc-optimize.snap
+++ b/tests/snapshots/files__reassoc-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int, v1: int) {
+<<<<<<< HEAD
   v2_: int = const 1;
   v3_: int = const 4;
   v4_: int = add v1 v3_;
@@ -10,5 +11,26 @@ expression: visualization.result
   v6_: int = add v0 v5_;
   v7_: int = add v4_ v6_;
   v8_: int = add v2_ v7_;
+=======
+<<<<<<< HEAD
+  v2_: int = const 3;
+  v3_: int = add v0 v2_;
+  v4_: int = const 4;
+  v5_: int = add v1 v4_;
+  v6_: int = add v3_ v5_;
+  v7_: int = const 1;
+  v8_: int = add v6_ v7_;
+>>>>>>> 71264d0b (working without collapse empty blocks)
   print v8_;
+=======
+.v2_:
+  v3_: int = const 4;
+  v4_: int = add v1 v3_;
+  v5_: int = const 3;
+  v6_: int = add v0 v5_;
+  v7_: int = add v4_ v6_;
+  v8_: int = const 1;
+  v9_: int = add v7_ v8_;
+  print v9_;
+>>>>>>> 9c411b53 (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__recurse_once-optimize.snap
+++ b/tests/snapshots/files__recurse_once-optimize.snap
@@ -11,11 +11,9 @@ expression: visualization.result
   v6_: int = const 1;
   v7_: int = sub v0 v6_;
   v8_: int = call @to_zero v7_;
-  jmp .v9_;
 .v5_:
-.v9_:
-  v10_: int = phi v0 v8_ .v5_ .v4_;
-  ret v10_;
+  v9_: int = phi v0 v8_ .v1_ .v4_;
+  ret v9_;
 }
 @main {
 .v0_:

--- a/tests/snapshots/files__recurse_once-optimize.snap
+++ b/tests/snapshots/files__recurse_once-optimize.snap
@@ -3,21 +3,22 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @to_zero(v0: int): int {
-  v1_: int = const 0;
-  v2_: bool = lt v1_ v0;
-  br v2_ .v3_ .v4_;
-.v3_:
-  v5_: int = const 1;
-  v6_: int = sub v0 v5_;
-  v7_: int = call @to_zero v6_;
-  v8_: int = id v7_;
-  jmp .v9_;
+.v1_:
+  v2_: int = const 0;
+  v3_: bool = lt v2_ v0;
+  br v3_ .v4_ .v5_;
 .v4_:
-  v8_: int = id v0;
+  v6_: int = const 1;
+  v7_: int = sub v0 v6_;
+  v8_: int = call @to_zero v7_;
+  jmp .v9_;
+.v5_:
 .v9_:
-  ret v8_;
+  v10_: int = phi v0 v8_ .v5_ .v4_;
+  ret v10_;
 }
 @main {
-  v0_: int = const 0;
-  print v0_;
+.v0_:
+  v1_: int = const 0;
+  print v1_;
 }

--- a/tests/snapshots/files__simple-call-optimize.snap
+++ b/tests/snapshots/files__simple-call-optimize.snap
@@ -3,11 +3,13 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @inc(v0: int): int {
-  v1_: int = const 1;
-  v2_: int = add v0 v1_;
-  ret v2_;
+.v1_:
+  v2_: int = const 1;
+  v3_: int = add v0 v2_;
+  ret v3_;
 }
 @main {
-  v0_: int = const 1;
-  print v0_;
+.v0_:
+  v1_: int = const 1;
+  print v1_;
 }

--- a/tests/snapshots/files__simple_branch-optimize.snap
+++ b/tests/snapshots/files__simple_branch-optimize.snap
@@ -3,16 +3,16 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 0;
-  v2_: bool = lt v0 v1_;
-  br v2_ .v3_ .v4_;
-.v3_:
-  v5_: int = const 1;
-  v6_: int = id v5_;
-  jmp .v7_;
+.v1_:
+  v2_: int = const 0;
+  v3_: bool = lt v0 v2_;
+  br v3_ .v4_ .v5_;
 .v4_:
+  v6_: int = const 1;
+  jmp .v7_;
+.v5_:
   v8_: int = const 0;
-  v6_: int = id v8_;
 .v7_:
-  print v6_;
+  v9_: int = phi v8_ v6_ .v5_ .v4_;
+  print v9_;
 }

--- a/tests/snapshots/files__simple_call-optimize.snap
+++ b/tests/snapshots/files__simple_call-optimize.snap
@@ -3,11 +3,13 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @inc(v0: int) {
-  v1_: int = const 1;
-  v2_: int = add v0 v1_;
-  print v2_;
+.v1_:
+  v2_: int = const 1;
+  v3_: int = add v0 v2_;
+  print v3_;
 }
 @main {
-  v0_: int = const 1;
-  print v0_;
+.v0_:
+  v1_: int = const 1;
+  print v1_;
 }

--- a/tests/snapshots/files__simple_loop-optimize.snap
+++ b/tests/snapshots/files__simple_loop-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 0;
-  print v0_;
+.v0_:
+  v1_: int = const 0;
+  print v1_;
 }

--- a/tests/snapshots/files__simple_loop_swap-optimize.snap
+++ b/tests/snapshots/files__simple_loop_swap-optimize.snap
@@ -3,15 +3,16 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 2;
-  v1_: ptr<int> = alloc v0_;
-  v2_: int = const 10;
-  v3_: int = const 1;
-  v4_: ptr<int> = ptradd v1_ v3_;
-  v5_: int = const 20;
-  store v1_ v2_;
-  store v4_ v5_;
-  v6_: int = load v1_;
-  print v2_;
-  free v1_;
+.v0_:
+  v1_: int = const 2;
+  v2_: ptr<int> = alloc v1_;
+  v3_: int = const 10;
+  v4_: int = const 1;
+  v5_: ptr<int> = ptradd v2_ v4_;
+  v6_: int = const 20;
+  store v2_ v3_;
+  store v5_ v6_;
+  v7_: int = load v2_;
+  print v3_;
+  free v2_;
 }

--- a/tests/snapshots/files__simple_recursive-optimize.snap
+++ b/tests/snapshots/files__simple_recursive-optimize.snap
@@ -12,11 +12,9 @@ expression: visualization.result
   v7_: int = add v0 v6_;
   print v7_;
   v8_: int = call @inc v7_;
-  jmp .v9_;
 .v5_:
-.v9_:
-  v10_: int = phi v0 v8_ .v5_ .v4_;
-  ret v10_;
+  v9_: int = phi v0 v8_ .v1_ .v4_;
+  ret v9_;
 }
 @main {
 .v0_:

--- a/tests/snapshots/files__simple_recursive-optimize.snap
+++ b/tests/snapshots/files__simple_recursive-optimize.snap
@@ -3,23 +3,24 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @inc(v0: int): int {
-  v1_: int = const 2;
-  v2_: bool = lt v0 v1_;
-  br v2_ .v3_ .v4_;
-.v3_:
-  v5_: int = const 1;
-  v6_: int = add v0 v5_;
-  print v6_;
-  v7_: int = call @inc v6_;
-  v8_: int = id v7_;
-  jmp .v9_;
+.v1_:
+  v2_: int = const 2;
+  v3_: bool = lt v0 v2_;
+  br v3_ .v4_ .v5_;
 .v4_:
-  v8_: int = id v0;
+  v6_: int = const 1;
+  v7_: int = add v0 v6_;
+  print v7_;
+  v8_: int = call @inc v7_;
+  jmp .v9_;
+.v5_:
 .v9_:
-  ret v8_;
+  v10_: int = phi v0 v8_ .v5_ .v4_;
+  ret v10_;
 }
 @main {
-  v0_: int = const 0;
-  v1_: int = call @inc v0_;
-  print v1_;
+.v0_:
+  v1_: int = const 0;
+  v2_: int = call @inc v1_;
+  print v2_;
 }

--- a/tests/snapshots/files__simplest_loop-optimize.snap
+++ b/tests/snapshots/files__simplest_loop-optimize.snap
@@ -3,17 +3,18 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 1;
-  v1_: int = const 5;
-  v2_: int = id v0_;
+.v0_:
+  v1_: int = const 1;
+  v2_: int = const 5;
   v3_: int = id v1_;
-  v4_: int = id v0_;
-.v5_:
-  v6_: int = add v2_ v4_;
-  v7_: bool = lt v6_ v3_;
-  v2_: int = id v6_;
-  v3_: int = id v3_;
+  v4_: int = id v2_;
+  v5_: int = id v1_;
+.v6_:
+  v7_: int = add v3_ v5_;
+  v8_: bool = lt v7_ v4_;
+  v3_: int = id v7_;
   v4_: int = id v4_;
-  br v7_ .v5_ .v8_;
-.v8_:
+  v5_: int = id v5_;
+  br v8_ .v6_ .v9_;
+.v9_:
 }

--- a/tests/snapshots/files__small-collatz-optimize.snap
+++ b/tests/snapshots/files__small-collatz-optimize.snap
@@ -12,70 +12,6 @@ expression: visualization.result
   v7_: int = id v0;
   v8_: int = id v3_;
   v9_: int = id v4_;
-<<<<<<< HEAD
-  v10_: int = id v1_;
-.v11_:
-  v12_: bool = eq v6_ v8_;
-  br v12_ .v13_ .v14_;
-.v13_:
-  v15_: bool = const false;
-  v16_: int = id v5_;
-  v17_: bool = id v15_;
-  v18_: int = id v8_;
-  v19_: int = id v7_;
-  v20_: int = id v8_;
-  v21_: int = id v9_;
-  v22_: int = id v10_;
-.v23_:
-  v24_: bool = not v12_;
-  v5_: int = id v16_;
-  v6_: int = id v18_;
-  v7_: int = id v7_;
-  v8_: int = id v8_;
-  v9_: int = id v9_;
-  v10_: int = id v10_;
-  br v24_ .v11_ .v25_;
-.v14_:
-  v26_: int = div v6_ v7_;
-  v27_: int = mul v26_ v7_;
-  v28_: int = sub v6_ v27_;
-  v29_: bool = eq v10_ v28_;
-  v30_: int = add v5_ v8_;
-  br v29_ .v31_ .v32_;
-.v31_:
-  v33_: bool = const true;
-  v34_: int = div v6_ v7_;
-  v35_: int = id v30_;
-  v36_: bool = id v33_;
-  v37_: int = id v34_;
-  v38_: int = id v7_;
-  v39_: int = id v8_;
-  v40_: int = id v9_;
-  v41_: int = id v10_;
-.v42_:
-  v16_: int = id v35_;
-  v17_: bool = id v36_;
-  v18_: int = id v37_;
-  v19_: int = id v38_;
-  v20_: int = id v39_;
-  v21_: int = id v40_;
-  v22_: int = id v41_;
-  jmp .v23_;
-.v32_:
-  v43_: bool = const true;
-  v44_: int = mul v6_ v9_;
-  v45_: int = add v44_ v8_;
-  v35_: int = id v30_;
-  v36_: bool = id v43_;
-  v37_: int = id v45_;
-  v38_: int = id v7_;
-  v39_: int = id v8_;
-  v40_: int = id v9_;
-  v41_: int = id v10_;
-  jmp .v42_;
-.v25_:
-  print v5_;
-=======
   v10_: int = id v5_;
   v11_: int = id v2_;
 .v12_:
@@ -86,34 +22,34 @@ expression: visualization.result
 .v17_:
   v19_: int = phi v18_ v6_ .v20_ .v14_;
   v22_: bool = phi v21_ v16_ .v20_ .v14_;
-  v24_: int = phi v23_ v7_ .v20_ .v14_;
+  v24_: int = phi v23_ v9_ .v20_ .v14_;
+  v25_: bool = not v13_;
   v6_: int = id v19_;
   v7_: int = id v24_;
   v8_: int = id v8_;
   v9_: int = id v9_;
   v10_: int = id v10_;
   v11_: int = id v11_;
-  br v22_ .v12_ .v25_;
+  br v25_ .v12_ .v26_;
 .v15_:
-  v26_: int = div v7_ v8_;
-  v27_: int = mul v26_ v8_;
-  v28_: int = sub v7_ v27_;
-  v29_: bool = eq v11_ v28_;
+  v27_: int = div v7_ v8_;
+  v28_: int = mul v27_ v8_;
+  v29_: int = sub v7_ v28_;
+  v30_: bool = eq v11_ v29_;
   v18_: int = add v6_ v9_;
-  br v29_ .v30_ .v31_;
-.v30_:
-  v32_: bool = const true;
-  v33_: int = div v7_ v8_;
-.v20_:
-  v21_: bool = phi v34_ v32_ .v31_ .v30_;
-  v23_: int = phi v35_ v33_ .v31_ .v30_;
-  jmp .v17_;
+  br v30_ .v31_ .v32_;
 .v31_:
-  v34_: bool = const true;
-  v36_: int = mul v10_ v7_;
-  v35_: int = add v36_ v9_;
+  v33_: bool = const true;
+  v34_: int = div v7_ v8_;
+.v20_:
+  v21_: bool = phi v35_ v33_ .v32_ .v31_;
+  v23_: int = phi v36_ v34_ .v32_ .v31_;
+  jmp .v17_;
+.v32_:
+  v35_: bool = const true;
+  v37_: int = mul v10_ v7_;
+  v36_: int = add v37_ v9_;
   jmp .v20_;
-.v25_:
+.v26_:
   print v6_;
->>>>>>> 71264d0b (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__small-collatz-optimize.snap
+++ b/tests/snapshots/files__small-collatz-optimize.snap
@@ -3,15 +3,16 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 0;
-  v2_: int = const 2;
-  v3_: int = const 1;
-  v4_: int = const 3;
-  v5_: int = id v1_;
-  v6_: int = id v0;
-  v7_: int = id v2_;
+.v1_:
+  v2_: int = const 0;
+  v3_: int = const 2;
+  v4_: int = const 1;
+  v5_: int = const 3;
+  v6_: int = id v2_;
+  v7_: int = id v0;
   v8_: int = id v3_;
   v9_: int = id v4_;
+<<<<<<< HEAD
   v10_: int = id v1_;
 .v11_:
   v12_: bool = eq v6_ v8_;
@@ -74,4 +75,45 @@ expression: visualization.result
   jmp .v42_;
 .v25_:
   print v5_;
+=======
+  v10_: int = id v5_;
+  v11_: int = id v2_;
+.v12_:
+  v13_: bool = eq v7_ v9_;
+  br v13_ .v14_ .v15_;
+.v14_:
+  v16_: bool = const false;
+.v17_:
+  v19_: int = phi v18_ v6_ .v20_ .v14_;
+  v22_: bool = phi v21_ v16_ .v20_ .v14_;
+  v24_: int = phi v23_ v7_ .v20_ .v14_;
+  v6_: int = id v19_;
+  v7_: int = id v24_;
+  v8_: int = id v8_;
+  v9_: int = id v9_;
+  v10_: int = id v10_;
+  v11_: int = id v11_;
+  br v22_ .v12_ .v25_;
+.v15_:
+  v26_: int = div v7_ v8_;
+  v27_: int = mul v26_ v8_;
+  v28_: int = sub v7_ v27_;
+  v29_: bool = eq v11_ v28_;
+  v18_: int = add v6_ v9_;
+  br v29_ .v30_ .v31_;
+.v30_:
+  v32_: bool = const true;
+  v33_: int = div v7_ v8_;
+.v20_:
+  v21_: bool = phi v34_ v32_ .v31_ .v30_;
+  v23_: int = phi v35_ v33_ .v31_ .v30_;
+  jmp .v17_;
+.v31_:
+  v34_: bool = const true;
+  v36_: int = mul v10_ v7_;
+  v35_: int = add v36_ v9_;
+  jmp .v20_;
+.v25_:
+  print v6_;
+>>>>>>> 71264d0b (working without collapse empty blocks)
 }

--- a/tests/snapshots/files__small-fib-optimize.snap
+++ b/tests/snapshots/files__small-fib-optimize.snap
@@ -3,40 +3,40 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 0;
-  v2_: bool = eq v0 v1_;
-  v3_: int = const 1;
-  print v3_;
-  br v2_ .v4_ .v5_;
+.v1_:
+  v2_: int = const 0;
+  v3_: bool = eq v0 v2_;
+  v4_: int = const 1;
+  print v4_;
+  br v3_ .v5_ .v6_;
 .v5_:
-  print v3_;
-  v6_: int = id v3_;
-  v7_: int = id v3_;
-  v8_: int = id v3_;
-  v9_: int = id v0;
-.v10_:
-  v11_: bool = lt v6_ v9_;
-  br v11_ .v12_ .v13_;
+  jmp .v7_;
+.v6_:
+  print v4_;
+  v8_: int = id v4_;
+  v9_: int = id v4_;
+  v10_: int = id v4_;
+  v11_: int = id v0;
 .v12_:
-  v14_: int = add v7_ v8_;
-  print v14_;
-  v15_: int = const 1;
-  v16_: int = add v15_ v6_;
-  v17_: int = id v16_;
-  v18_: int = id v14_;
-  v19_: int = id v7_;
-  v20_: int = id v9_;
-.v21_:
-  v6_: int = id v17_;
-  v7_: int = id v18_;
-  v8_: int = id v19_;
-  v9_: int = id v20_;
-  br v11_ .v10_ .v4_;
-.v13_:
-  v17_: int = id v6_;
-  v18_: int = id v7_;
-  v19_: int = id v8_;
-  v20_: int = id v9_;
-  jmp .v21_;
-.v4_:
+  v13_: bool = lt v8_ v11_;
+  br v13_ .v14_ .v15_;
+.v14_:
+  v16_: int = add v10_ v9_;
+  print v16_;
+  v17_: int = const 1;
+  v18_: int = add v17_ v8_;
+.v19_:
+  v20_: int = phi v8_ v18_ .v15_ .v14_;
+  v21_: int = phi v9_ v16_ .v15_ .v14_;
+  v22_: int = phi v10_ v9_ .v15_ .v14_;
+  v8_: int = id v20_;
+  v9_: int = id v21_;
+  v10_: int = id v22_;
+  v11_: int = id v11_;
+  br v13_ .v12_ .v23_;
+.v23_:
+  jmp .v7_;
+.v15_:
+  jmp .v19_;
+.v7_:
 }

--- a/tests/snapshots/files__small-fib-optimize.snap
+++ b/tests/snapshots/files__small-fib-optimize.snap
@@ -9,34 +9,28 @@ expression: visualization.result
   v4_: int = const 1;
   print v4_;
   br v3_ .v5_ .v6_;
-.v5_:
-  jmp .v7_;
 .v6_:
   print v4_;
+  v7_: int = id v4_;
   v8_: int = id v4_;
   v9_: int = id v4_;
-  v10_: int = id v4_;
-  v11_: int = id v0;
-.v12_:
-  v13_: bool = lt v8_ v11_;
-  br v13_ .v14_ .v15_;
+  v10_: int = id v0;
+.v11_:
+  v12_: bool = lt v7_ v10_;
+  br v12_ .v13_ .v14_;
+.v13_:
+  v15_: int = add v8_ v9_;
+  print v15_;
+  v16_: int = const 1;
+  v17_: int = add v16_ v7_;
 .v14_:
-  v16_: int = add v10_ v9_;
-  print v16_;
-  v17_: int = const 1;
-  v18_: int = add v17_ v8_;
-.v19_:
-  v20_: int = phi v8_ v18_ .v15_ .v14_;
-  v21_: int = phi v9_ v16_ .v15_ .v14_;
-  v22_: int = phi v10_ v9_ .v15_ .v14_;
-  v8_: int = id v20_;
-  v9_: int = id v21_;
-  v10_: int = id v22_;
-  v11_: int = id v11_;
-  br v13_ .v12_ .v23_;
-.v23_:
-  jmp .v7_;
-.v15_:
-  jmp .v19_;
-.v7_:
+  v18_: int = phi v7_ v17_ .v11_ .v13_;
+  v19_: int = phi v8_ v15_ .v11_ .v13_;
+  v20_: int = phi v9_ v8_ .v11_ .v13_;
+  v7_: int = id v18_;
+  v8_: int = id v19_;
+  v9_: int = id v20_;
+  v10_: int = id v10_;
+  br v12_ .v11_ .v5_;
+.v5_:
 }

--- a/tests/snapshots/files__sqrt-optimize.snap
+++ b/tests/snapshots/files__sqrt-optimize.snap
@@ -8,63 +8,8 @@ expression: visualization.result
   v3_: bool = feq v0 v2_;
   br v3_ .v4_ .v5_;
 .v4_:
-<<<<<<< HEAD
-  v6_: bool = feq v0 v0;
-  v7_: bool = const true;
-  br v6_ .v8_ .v9_;
-.v8_:
-  v10_: bool = flt v0 v1_;
-  br v10_ .v11_ .v12_;
-.v11_:
-  v13_: float = id v1_;
-.v14_:
-  v15_: float = id v13_;
-  v16_: bool = id v10_;
-.v17_:
-  br v16_ .v18_ .v5_;
-.v18_:
-  v19_: float = fdiv v15_ v15_;
-  print v19_;
-  jmp .v5_;
-.v12_:
-  v20_: float = const 1;
-  v21_: float = const 1.0000000001;
-  v22_: float = const 0.9999999999;
-  v23_: float = const 2;
-  v24_: float = id v1_;
-  v25_: float = id v20_;
-  v26_: float = id v21_;
-  v27_: float = id v22_;
-  v28_: float = id v23_;
-  v29_: float = id v0;
-.v30_:
-  v31_: float = fdiv v29_ v25_;
-  v32_: float = fadd v25_ v31_;
-  v33_: float = fdiv v32_ v28_;
-  v34_: float = fdiv v33_ v25_;
-  v35_: bool = fle v34_ v26_;
-  v36_: bool = fge v34_ v27_;
-  v37_: bool = and v35_ v36_;
-  v38_: bool = not v37_;
-  v24_: float = id v24_;
-  v25_: float = id v33_;
-  v26_: float = id v26_;
-  v27_: float = id v27_;
-  v28_: float = id v28_;
-  v29_: float = id v29_;
-  br v38_ .v30_ .v39_;
-.v39_:
-  print v25_;
-  v13_: float = id v24_;
-  jmp .v14_;
-.v9_:
-  v15_: float = id v1_;
-  v16_: bool = id v7_;
-  jmp .v17_;
-=======
   print v2_;
   jmp .v6_;
->>>>>>> 0ae7c06b (snapshot)
 .v5_:
   v7_: bool = feq v0 v0;
   v8_: bool = const true;
@@ -88,39 +33,28 @@ expression: visualization.result
   v26_: float = fadd v19_ v25_;
   v27_: float = fdiv v26_ v22_;
   v28_: float = fdiv v27_ v19_;
-  v29_: bool = fge v28_ v21_;
-  v30_: bool = fle v28_ v20_;
+  v29_: bool = fle v28_ v20_;
+  v30_: bool = fge v28_ v21_;
   v31_: bool = and v29_ v30_;
-  br v31_ .v32_ .v33_;
-.v32_:
-  v34_: bool = const false;
-.v35_:
-  v37_: bool = phi v36_ v34_ .v33_ .v32_;
-  v38_: bool = not v31_;
+  v32_: bool = not v31_;
   v18_: float = id v18_;
   v19_: float = id v27_;
   v20_: float = id v20_;
   v21_: float = id v21_;
   v22_: float = id v22_;
   v23_: float = id v23_;
-  br v38_ .v24_ .v39_;
-.v39_:
-  print v19_;
-  v40_: bool = const false;
-.v12_:
-  v41_: float = phi v18_ v2_ .v39_ .v9_;
-  v42_: bool = phi v40_ v8_ .v39_ .v9_;
-.v10_:
-  v43_: float = phi v2_ v41_ .v5_ .v12_;
-  v44_: bool = phi v8_ v42_ .v5_ .v12_;
-  br v44_ .v45_ .v46_;
-.v45_:
-  v47_: float = fdiv v43_ v43_;
-  print v47_;
-.v46_:
-  jmp .v6_;
+  br v32_ .v24_ .v33_;
 .v33_:
-  v36_: bool = const true;
-  jmp .v35_;
+  print v19_;
+.v12_:
+  v34_: float = phi v18_ v2_ .v33_ .v9_;
+.v10_:
+  v35_: float = phi v2_ v34_ .v5_ .v12_;
+  v36_: bool = phi v8_ v11_ .v5_ .v12_;
+  br v36_ .v37_ .v38_;
+.v37_:
+  v39_: float = fdiv v35_ v35_;
+  print v39_;
+.v38_:
 .v6_:
 }

--- a/tests/snapshots/files__sqrt-optimize.snap
+++ b/tests/snapshots/files__sqrt-optimize.snap
@@ -3,13 +3,12 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: float) {
-  v1_: float = const 0;
-  v2_: bool = feq v0 v1_;
-  br v2_ .v3_ .v4_;
-.v3_:
-  print v1_;
-  jmp .v5_;
+.v1_:
+  v2_: float = const 0;
+  v3_: bool = feq v0 v2_;
+  br v3_ .v4_ .v5_;
 .v4_:
+<<<<<<< HEAD
   v6_: bool = feq v0 v0;
   v7_: bool = const true;
   br v6_ .v8_ .v9_;
@@ -62,5 +61,66 @@ expression: visualization.result
   v15_: float = id v1_;
   v16_: bool = id v7_;
   jmp .v17_;
+=======
+  print v2_;
+  jmp .v6_;
+>>>>>>> 0ae7c06b (snapshot)
 .v5_:
+  v7_: bool = feq v0 v0;
+  v8_: bool = const true;
+  br v7_ .v9_ .v10_;
+.v9_:
+  v11_: bool = flt v0 v2_;
+  br v11_ .v12_ .v13_;
+.v13_:
+  v14_: float = const 1;
+  v15_: float = const 1.0000000001;
+  v16_: float = const 0.9999999999;
+  v17_: float = const 2;
+  v18_: float = id v2_;
+  v19_: float = id v14_;
+  v20_: float = id v15_;
+  v21_: float = id v16_;
+  v22_: float = id v17_;
+  v23_: float = id v0;
+.v24_:
+  v25_: float = fdiv v23_ v19_;
+  v26_: float = fadd v19_ v25_;
+  v27_: float = fdiv v26_ v22_;
+  v28_: float = fdiv v27_ v19_;
+  v29_: bool = fge v28_ v21_;
+  v30_: bool = fle v28_ v20_;
+  v31_: bool = and v29_ v30_;
+  br v31_ .v32_ .v33_;
+.v32_:
+  v34_: bool = const false;
+.v35_:
+  v37_: bool = phi v36_ v34_ .v33_ .v32_;
+  v38_: bool = not v31_;
+  v18_: float = id v18_;
+  v19_: float = id v27_;
+  v20_: float = id v20_;
+  v21_: float = id v21_;
+  v22_: float = id v22_;
+  v23_: float = id v23_;
+  br v38_ .v24_ .v39_;
+.v39_:
+  print v19_;
+  v40_: bool = const false;
+.v12_:
+  v41_: float = phi v18_ v2_ .v39_ .v9_;
+  v42_: bool = phi v40_ v8_ .v39_ .v9_;
+.v10_:
+  v43_: float = phi v2_ v41_ .v5_ .v12_;
+  v44_: bool = phi v8_ v42_ .v5_ .v12_;
+  br v44_ .v45_ .v46_;
+.v45_:
+  v47_: float = fdiv v43_ v43_;
+  print v47_;
+.v46_:
+  jmp .v6_;
+.v33_:
+  v36_: bool = const true;
+  jmp .v35_;
+.v6_:
 }

--- a/tests/snapshots/files__strong_loop-optimize.snap
+++ b/tests/snapshots/files__strong_loop-optimize.snap
@@ -3,31 +3,32 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v1_: int = const 3;
-  v2_: int = add v0 v1_;
-  v3_: int = const 0;
-  v4_: int = const 21;
-  v5_: int = id v1_;
+.v1_:
+  v2_: int = const 3;
+  v3_: int = add v0 v2_;
+  v4_: int = const 0;
+  v5_: int = const 21;
   v6_: int = id v2_;
   v7_: int = id v3_;
-  v8_: int = id v0;
-  v9_: int = id v4_;
-.v10_:
-  print v9_;
-  v11_: int = const 1;
-  v12_: int = add v11_ v5_;
-  v13_: int = add v7_ v9_;
-  v14_: int = const 7;
-  v15_: int = add v14_ v9_;
-  v16_: bool = lt v5_ v8_;
-  v5_: int = id v12_;
-  v6_: int = id v6_;
-  v7_: int = id v13_;
-  v8_: int = id v8_;
-  v9_: int = id v15_;
-  br v16_ .v10_ .v17_;
-.v17_:
-  print v7_;
-  print v2_;
-  print v5_;
+  v8_: int = id v4_;
+  v9_: int = id v0;
+  v10_: int = id v5_;
+.v11_:
+  print v10_;
+  v12_: int = const 1;
+  v13_: int = add v12_ v6_;
+  v14_: int = add v10_ v8_;
+  v15_: int = const 7;
+  v16_: int = add v10_ v15_;
+  v17_: bool = lt v6_ v9_;
+  v6_: int = id v13_;
+  v7_: int = id v7_;
+  v8_: int = id v14_;
+  v9_: int = id v9_;
+  v10_: int = id v16_;
+  br v17_ .v11_ .v18_;
+.v18_:
+  print v8_;
+  print v3_;
+  print v6_;
 }

--- a/tests/snapshots/files__two_fns-optimize.snap
+++ b/tests/snapshots/files__two_fns-optimize.snap
@@ -3,10 +3,12 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @sub: int {
-  v0_: int = const -1;
-  ret v0_;
+.v0_:
+  v1_: int = const -1;
+  ret v1_;
 }
 @main {
-  v0_: int = const 3;
-  print v0_;
+.v0_:
+  v1_: int = const 3;
+  print v1_;
 }

--- a/tests/snapshots/files__unroll_and_constant_fold-optimize.snap
+++ b/tests/snapshots/files__unroll_and_constant_fold-optimize.snap
@@ -3,6 +3,7 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 1;
-  print v0_;
+.v0_:
+  v1_: int = const 1;
+  print v1_;
 }

--- a/tests/snapshots/files__unroll_multiple_4-optimize.snap
+++ b/tests/snapshots/files__unroll_multiple_4-optimize.snap
@@ -3,22 +3,23 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v0_: int = const 0;
-  v1_: int = const 16;
-  v2_: int = const 1;
-  v3_: int = id v0_;
+.v0_:
+  v1_: int = const 0;
+  v2_: int = const 16;
+  v3_: int = const 1;
   v4_: int = id v1_;
   v5_: int = id v2_;
-.v6_:
-  v7_: int = add v3_ v5_;
-  v8_: int = add v5_ v7_;
-  v9_: int = add v5_ v8_;
-  v10_: int = add v5_ v9_;
-  v11_: bool = lt v10_ v4_;
-  v3_: int = id v10_;
-  v4_: int = id v4_;
+  v6_: int = id v3_;
+.v7_:
+  v8_: int = add v4_ v6_;
+  v9_: int = add v6_ v8_;
+  v10_: int = add v6_ v9_;
+  v11_: int = add v10_ v6_;
+  v12_: bool = lt v11_ v5_;
+  v4_: int = id v11_;
   v5_: int = id v5_;
-  br v11_ .v6_ .v12_;
-.v12_:
-  print v3_;
+  v6_: int = id v6_;
+  br v12_ .v7_ .v13_;
+.v13_:
+  print v4_;
 }


### PR DESCRIPTION
This PR avoids extra blocks by using `phi` nodes to select between different values.
This uncovered a bug in brillvm, and also our direct jump optimizer had to take into account phi nodes.