### PR TITLE
Fix frontend crash error

### DIFF
--- a/infra/nightly-resources/previousRuns.js
+++ b/infra/nightly-resources/previousRuns.js
@@ -42,10 +42,10 @@ async function getPreviousRuns() {
     return 0;
   });
 
-  return comparisons.slice(
-    0,
-    comparisons.length < 30 ? comparisons.length : 30,
-  );
+  // Make sure we have at least one main run in the set of benchmarks we return.
+  const firstMainIdx = comparisons.findIndex(run => run.branch === "main");
+  
+  return comparisons.slice(0, Math.max(30, firstMainIdx + 1));
 }
 
 // findBenchToCompare will find the last benchmark run on the main branch that is not itself

--- a/infra/nightly-resources/previousRuns.js
+++ b/infra/nightly-resources/previousRuns.js
@@ -43,8 +43,8 @@ async function getPreviousRuns() {
   });
 
   // Make sure we have at least one main run in the set of benchmarks we return.
-  const firstMainIdx = comparisons.findIndex(run => run.branch === "main");
-  
+  const firstMainIdx = comparisons.findIndex((run) => run.branch === "main");
+
   return comparisons.slice(0, Math.max(30, firstMainIdx + 1));
 }
 

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -92,8 +92,11 @@ def bench(benchmark):
 def get_llvm(runMethod, benchmark):
   path = f'./tmp/bench/{benchmark}/llvm-{runMethod}/{benchmark}-{runMethod}.ll'
 
-  with open(path) as f:
-    return f.read()
+  try:
+    with open(path) as f:
+      return f.read()
+  except OSError:
+    return ""
 
 
 # aggregate all profile info into a single json array.


### PR DESCRIPTION
We were seeing this error:
![image](https://github.com/egraphs-good/eggcc/assets/8787187/1c6607ba-9977-40f2-94ca-f898b38e18c0)
If there was no previous run to compare to

Turns out, there wasn't a `main` run in the last 30 runs, so the slice of previous runs we returned didn't have a `main` run.
Fix is to make sure we have at least on `main` run in the slice.