### PR TITLE
Store LLVM separately on nightly

### DIFF
--- a/infra/generate_line_counts.py
+++ b/infra/generate_line_counts.py
@@ -82,7 +82,7 @@ def get_rows_for_benchmark(bench, profile_data):
     data_for_bench = [x for x in profile_data if x["benchmark"] == bench]
     rows = []
     for (idx, entry) in enumerate(data_for_bench):
-        fst_col = r'\multirow{' + str(len(data_for_bench)) + r'}{*}{' + bench + r'}' if idx == 0 else ''
+        fst_col = r'\multirow{' + str(len(data_for_bench)) + r'}{*}{' + bench.replace("_", r'\_') + r'}' if idx == 0 else ''
         res = entry["hyperfine"]["results"][0]
         row = " ".join([
             r'\multicolumn{1}{|l|}{' + fst_col + r'} &',

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -36,7 +36,7 @@ function shouldHaveLlvm(runMethod) {
     "llvm-O0-eggcc",
     "llvm-O3",
     "llvm-O3-eggcc",
-  ].includes(runMethod)
+  ].includes(runMethod);
 }
 
 function getDataForBenchmark(benchmark) {

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -29,6 +29,16 @@ function getBaselineHyperfine(benchmark, runMethod) {
   }
 }
 
+function shouldHaveLlvm(runMethod) {
+  return [
+    "rvsdg-round-trip-to-executable",
+    "llvm-O0",
+    "llvm-O0-eggcc",
+    "llvm-O3",
+    "llvm-O3-eggcc",
+  ].includes(runMethod)
+}
+
 function getDataForBenchmark(benchmark) {
   const executions = GLOBAL_DATA.currentRun
     ?.filter((o) => o.benchmark === benchmark)
@@ -47,10 +57,7 @@ function getDataForBenchmark(benchmark) {
         medianVsBaseline: diffAttribute(hyperfine, baselineHyperfine, "median"),
         stddev: { class: "", value: tryRound(hyperfine.stddev) },
       };
-      if (o.hasOwnProperty("llvm_ir")) {
-        if (o.llvm_ir === "") {
-          addWarning(`missing LLVM IR for ${o.benchmark} ${o.runMethod}`);
-        }
+      if (shouldHaveLlvm(o.runMethod)) {
         rowData.runMethod = `<a target="_blank" rel="noopener noreferrer" href="llvm.html?benchmark=${benchmark}&runmode=${o.runMethod}">${o.runMethod}</a>`;
       }
       return rowData;

--- a/infra/nightly-resources/handlers.js
+++ b/infra/nightly-resources/handlers.js
@@ -31,15 +31,8 @@ async function load_llvm() {
   if (!benchmark || !runMode) {
     console.error("missing query params, this probably shouldn't happen");
   }
-  const entry = GLOBAL_DATA.currentRun.filter(
-    (entry) => entry.benchmark === benchmark && entry.runMethod === runMode,
-  );
-  if (entry.length !== 1) {
-    console.error(
-      `missing or duplicate entries for ${benchmark} and ${runMode}, this probably shouldn't happen`,
-    );
-  }
-  document.getElementById("llvm").innerText = entry[0].llvm_ir;
+  const llvm = await fetchText(`./data/llvm/${benchmark}-${runMode}.ll`);
+  document.getElementById("llvm").innerText = llvm;
 }
 
 async function load_table() {

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -40,7 +40,7 @@ echo "Switching to nighly script directory: $MYDIR"
 rm -rf $NIGHTLY_DIR
 
 # Prepare output directories
-mkdir -p "$NIGHTLY_DIR/data" "$NIGHTLY_DIR/output"
+mkdir -p "$NIGHTLY_DIR/data" "$NIGHTLY_DIR/data/llvm" "$NIGHTLY_DIR/output"
 
 
 pushd $TOP_DIR

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -100,18 +100,16 @@ def should_have_llvm_ir(runMethod):
     "llvm-O3-eggcc",
   ]
 
-def get_llvm_ir(runMethod, benchmark):
-  path = f'./tmp/bench/{benchmark}/llvm-{runMethod}/{benchmark}-{runMethod}.ll'
+def dump_llvm_ir(runMethod, benchmark, output_directory):
+  from_path = f'./tmp/bench/{benchmark}/llvm-{runMethod}/{benchmark}-{runMethod}.ll'
 
-  try:
-    with open(path) as f:
-      return f.read()
-  except OSError:
-    return ""
+  to_path = f'{output_directory}/data/llvm/{benchmark}-{runMethod}.ll'
+
+  os.system(f'cp {from_path} {to_path}')
 
 
 # aggregate all profile info into a single json array.
-def aggregate(compile_times, bench_times):
+def aggregate(compile_times, bench_times, output_directory):
     res = []
 
     for path in sorted(compile_times.keys()):
@@ -119,7 +117,7 @@ def aggregate(compile_times, bench_times):
       runMethod = path.split("/")[-1]
       result = {"runMethod": runMethod, "benchmark": name, "hyperfine": bench_times[path], "compileTime": compile_times[path]}
       if should_have_llvm_ir(runMethod):
-        result["llvm_ir"] = get_llvm_ir(runMethod, name)
+        dump_llvm_ir(runMethod, name, output_directory)
 
       res.append(result)
     return res
@@ -183,6 +181,6 @@ if __name__ == '__main__':
       (path, _bench_data) = res
       bench_data[path] = _bench_data
 
-  nightly_data = aggregate(compile_times, bench_data)
+  nightly_data = aggregate(compile_times, bench_data, output_path)
   with open(f"{output_path}/data/profile.json", "w") as profile:
     json.dump(nightly_data, profile, indent=2)


### PR DESCRIPTION
The latest nightly ([link](https://nightly.cs.washington.edu/reports/eggcc/1716340359:nightly:main:30dbf39f86/)) is broken because the profile.json is huge (half a gig!)

To mitigate, we should store the LLVM separately for each run mode and benchmark
This has the added benefit that we can periodically go delete these files from nightly without losing the rest of the profile info