### PR TITLE
Replace jumps to the exit block with rets.

### DIFF
--- a/src/rvsdg/snapshots/eggcc__rvsdg__tests__rvsdg_state_mem_to_cfg_more_blocks_snapshot.snap
+++ b/src/rvsdg/snapshots/eggcc__rvsdg__tests__rvsdg_state_mem_to_cfg_more_blocks_snapshot.snap
@@ -15,7 +15,8 @@ expression: prog.to_string()
   print v11;
   free v4;
   v31: int = id v7;
-  jmp .__42__;
+  print v31;
+  ret;
 .__32__:
   v24: int = add v11 v1;
   free v4;

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -21,7 +21,6 @@ fn generate_tests(glob: &str, benchmark_mode: bool) -> Vec<Trial> {
                 }
                 Ok(res) => res,
             };
-
             if run.interp.should_interp()
                 && result.original_interpreted.as_ref().unwrap()
                     != result.result_interpreted.as_ref().unwrap()

--- a/tests/snapshots/files__branch_duplicate_work-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize.snap
@@ -10,11 +10,12 @@ expression: visualization.result
 .v4_:
   v6_: int = add v0 v0;
   v7_: int = id v6_;
-  jmp .v8_;
+  print v7_;
+  ret;
 .v5_:
-  v9_: int = add v0 v0;
-  v10_: int = mul v2_ v9_;
-  v7_: int = id v10_;
-.v8_:
+  v8_: int = add v0 v0;
+  v9_: int = mul v2_ v8_;
+  v7_: int = id v9_;
+.v10_:
   print v7_;
 }

--- a/tests/snapshots/files__diamond-optimize.snap
+++ b/tests/snapshots/files__diamond-optimize.snap
@@ -9,9 +9,9 @@ expression: visualization.result
 .v3_:
   v5_: int = const 1;
   print v5_;
-  jmp .v6_;
+  ret;
 .v4_:
-  v7_: int = const 2;
-  print v7_;
-.v6_:
+  v6_: int = const 2;
+  print v6_;
+.v7_:
 }

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -39,7 +39,7 @@ expression: visualization.result
   v30_: int = id v4_;
 .v31_:
   v5_: int = id v30_;
-  jmp .v6_;
+  ret v5_;
 .v24_:
   v32_: int = const -1;
   v33_: int = sub v32_ v4_;
@@ -284,7 +284,8 @@ expression: visualization.result
   v21_: int = id v4_;
 .v22_:
   v5_: int = id v21_;
-  jmp .v6_;
+  print v5_;
+  ret;
 .v17_:
   v23_: int = const -1;
   v24_: int = sub v23_ v4_;

--- a/tests/snapshots/files__impossible_if-optimize.snap
+++ b/tests/snapshots/files__impossible_if-optimize.snap
@@ -11,7 +11,8 @@ expression: visualization.result
 .v5_:
   print v2_;
   v7_: int = id v2_;
-  jmp .v8_;
+  print v2_;
+  ret;
 .v6_:
   print v2_;
   v7_: int = id v2_;

--- a/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
+++ b/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
@@ -11,14 +11,18 @@ expression: visualization.result
   v6_: int = const 2;
   store v3_ v6_;
   v7_: ptr<int> = id v3_;
-  jmp .v8_;
+  v8_: int = load v3_;
+  v9_: int = load v3_;
+  print v8_;
+  free v3_;
+  ret;
 .v5_:
-  v9_: int = const 3;
-  store v3_ v9_;
+  v10_: int = const 3;
+  store v3_ v10_;
   v7_: ptr<int> = id v3_;
-.v8_:
-  v10_: int = load v3_;
-  v11_: int = load v3_;
-  print v10_;
+.v11_:
+  v8_: int = load v3_;
+  v9_: int = load v3_;
+  print v8_;
   free v3_;
 }

--- a/tests/snapshots/files__range_check-optimize.snap
+++ b/tests/snapshots/files__range_check-optimize.snap
@@ -33,7 +33,8 @@ expression: visualization.result
   br v9_ .v7_ .v22_;
 .v22_:
   v3_: int = id v6_;
-  jmp .v5_;
+  print v3_;
+  ret;
 .v13_:
   v23_: int = const 2;
   print v23_;

--- a/tests/snapshots/files__range_splitting-optimize.snap
+++ b/tests/snapshots/files__range_splitting-optimize.snap
@@ -32,7 +32,8 @@ expression: visualization.result
   br v11_ .v7_ .v21_;
 .v21_:
   v3_: int = id v6_;
-  jmp .v5_;
+  print v3_;
+  ret;
 .v14_:
   v22_: int = const 2;
   print v22_;

--- a/tests/snapshots/files__sqrt-optimize.snap
+++ b/tests/snapshots/files__sqrt-optimize.snap
@@ -9,74 +9,74 @@ expression: visualization.result
   br v3_ .v4_ .v5_;
 .v4_:
   print v2_;
-  jmp .v6_;
+  ret;
 .v5_:
-  v7_: bool = feq v0 v0;
-  v8_: bool = const true;
-  v9_: float = id v2_;
-  v10_: bool = id v8_;
-  br v7_ .v11_ .v12_;
-.v11_:
-  v13_: bool = flt v0 v2_;
-  v14_: float = id v2_;
-  br v13_ .v15_ .v16_;
-.v16_:
-  v17_: float = const 1;
-  v18_: float = const 1.0000000001;
-  v19_: float = const 0.9999999999;
-  v20_: float = const 2;
-  v21_: float = id v2_;
+  v6_: bool = feq v0 v0;
+  v7_: bool = const true;
+  v8_: float = id v2_;
+  v9_: bool = id v7_;
+  br v6_ .v10_ .v11_;
+.v10_:
+  v12_: bool = flt v0 v2_;
+  v13_: float = id v2_;
+  br v12_ .v14_ .v15_;
+.v15_:
+  v16_: float = const 1;
+  v17_: float = const 1.0000000001;
+  v18_: float = const 0.9999999999;
+  v19_: float = const 2;
+  v20_: float = id v2_;
+  v21_: float = id v16_;
   v22_: float = id v17_;
   v23_: float = id v18_;
   v24_: float = id v19_;
-  v25_: float = id v20_;
-  v26_: float = id v0;
-.v27_:
-  v28_: float = fdiv v26_ v22_;
-  v29_: float = fadd v22_ v28_;
-  v30_: float = fdiv v29_ v25_;
-  v31_: float = fdiv v30_ v22_;
-  v32_: bool = fle v31_ v23_;
-  v33_: bool = fge v31_ v24_;
-  v34_: bool = and v32_ v33_;
-  v35_: bool = const true;
-  v36_: float = id v21_;
-  v37_: float = id v30_;
-  v38_: bool = id v35_;
+  v25_: float = id v0;
+.v26_:
+  v27_: float = fdiv v25_ v21_;
+  v28_: float = fadd v21_ v27_;
+  v29_: float = fdiv v28_ v24_;
+  v30_: float = fdiv v29_ v21_;
+  v31_: bool = fle v30_ v22_;
+  v32_: bool = fge v30_ v23_;
+  v33_: bool = and v31_ v32_;
+  v34_: bool = const true;
+  v35_: float = id v20_;
+  v36_: float = id v29_;
+  v37_: bool = id v34_;
+  v38_: float = id v22_;
   v39_: float = id v23_;
   v40_: float = id v24_;
   v41_: float = id v25_;
-  v42_: float = id v26_;
-  br v34_ .v43_ .v44_;
+  br v33_ .v42_ .v43_;
+.v42_:
+  v44_: bool = const false;
+  v35_: float = id v20_;
+  v36_: float = id v29_;
+  v37_: bool = id v44_;
+  v38_: float = id v22_;
+  v39_: float = id v23_;
+  v40_: float = id v24_;
+  v41_: float = id v25_;
 .v43_:
-  v45_: bool = const false;
-  v36_: float = id v21_;
-  v37_: float = id v30_;
-  v38_: bool = id v45_;
-  v39_: float = id v23_;
-  v40_: float = id v24_;
-  v41_: float = id v25_;
-  v42_: float = id v26_;
-.v44_:
-  v46_: bool = not v34_;
-  v21_: float = id v21_;
-  v22_: float = id v30_;
+  v45_: bool = not v33_;
+  v20_: float = id v20_;
+  v21_: float = id v29_;
+  v22_: float = id v22_;
   v23_: float = id v23_;
   v24_: float = id v24_;
   v25_: float = id v25_;
-  v26_: float = id v26_;
-  br v46_ .v27_ .v47_;
+  br v45_ .v26_ .v46_;
+.v46_:
+  print v21_;
+  v13_: float = id v20_;
+.v14_:
+  v8_: float = id v13_;
+  v9_: bool = id v12_;
+.v11_:
+  br v9_ .v47_ .v48_;
 .v47_:
-  print v22_;
-  v14_: float = id v21_;
-.v15_:
-  v9_: float = id v14_;
-  v10_: bool = id v13_;
-.v12_:
-  br v10_ .v48_ .v49_;
+  v49_: float = fdiv v8_ v8_;
+  print v49_;
 .v48_:
-  v50_: float = fdiv v9_ v9_;
-  print v50_;
-.v49_:
-.v6_:
+.v50_:
 }


### PR DESCRIPTION
Discussed this a bit offline. The goal here is to generate somewhat cleaner code. The snapshot diffs have some good examples; a further refinement we might explore is to keep the jumps in place when the exit block has nontrivial logic in it (to avoid duplication). 