### PR TITLE
Using loop-inversion to optimizes translation overhead for while loops

### DIFF
--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -66,6 +66,7 @@ pub fn prologue() -> String {
         include_str!("optimizations/loop_strength_reduction.egg"),
         include_str!("utility/debug-helper.egg"),
         &rulesets(),
+        include_str!("optimizations/ivt.egg"),
     ]
     .join("\n")
 }

--- a/dag_in_context/src/optimizations/ivt.egg
+++ b/dag_in_context/src/optimizations/ivt.egg
@@ -88,45 +88,40 @@
 
     (ContextOf inpW outer-ctx)
     (ContextOf inpI if-ctx)
-    (HasType inpW argW)
+    (HasType inpI argI)
 ) (
     ;; first peeled condition
     (let new-if-cond (Subst outer-ctx inpW condI))
     ;; if contexts
-    (let new-if-true-ctx (InIf true new-if-cond inpW))
-    (let new-if-false-ctx (InIf false new-if-cond inpW))
+    (let new-if-inp (Subst outer-ctx inpW inpI))
+    (let new-if-true-ctx (InIf true new-if-cond new-if-inp))
+    (let new-if-false-ctx (InIf false new-if-cond new-if-inp))
     
     (let new-loop-context (TmpCtx))
 
     ;; body
     (let new-loop-outputs_ 
-        (TupleRemoveAt
-            (ApplyPerm perm (Subst new-loop-context inpI thn))
-            0))
-    ;; the first element of body was true but should be the condition.
-    (let new-loop-outputs
-        (Concat
-            ; (Single (Subst new-loop-context (Arg argW new-loop-context) condI))
-            (Single (Subst new-loop-context new-loop-outputs_ condI))
-            new-loop-outputs_))
+        (TupleRemoveAt (ApplyPerm perm thn) 0))
+    (let new-loop-outputs 
+        (Subst new-loop-context new-loop-outputs_ 
+            (Concat (Single condI) inpI)))
 
-    (let new-loop (DoWhile (Arg argW new-if-true-ctx) new-loop-outputs))
+    (let new-loop (DoWhile (Arg argI new-if-true-ctx) new-loop-outputs))
     (let new-if
-        (If new-if-cond inpW
+        (If new-if-cond new-if-inp
             new-loop
-            (Arg argW new-if-false-ctx)))
+            (Arg argI new-if-false-ctx)))
 
     ;; Apply the body of the false branch as an afterprocessing wrapper
     (let new-expr_
-        (Subst outer-ctx new-if 
-            (Subst if-ctx inpI els)))
+        (Subst outer-ctx new-if els))
     (let new-expr 
         (TupleRemoveAt 
             (ApplyPerm perm new-expr_) 
             0))
 
     (union new-expr loop)
-    (union new-loop-context (InLoop (Arg argW new-if-true-ctx) new-loop-outputs))
+    (union new-loop-context (InLoop (Arg argI new-if-true-ctx) new-loop-outputs))
 
     (delete (DoWhile inpW outW))
     (delete (TmpCtx))

--- a/dag_in_context/src/optimizations/ivt.egg
+++ b/dag_in_context/src/optimizations/ivt.egg
@@ -1,11 +1,4 @@
-; (= loop (Loop pred body))
-; (= pred (Project ith (If cond thn els)))
 
-; =>
-
-; (If cond 
-;     (Loop pred body)
-;     (passthrough))
 ;; A Perm is a reverse list of integers
 (datatype Perm (PermPush i64 Perm) (PNil))
 ;; expr1 is a list of expressions of the form (Get expr2 i),
@@ -49,19 +42,50 @@
 (function ApplyPerm (Perm Expr) Expr)
 
 (rewrite (ApplyPerm (PermPush ith rest) expr) 
-         (Concat (ApplyPerm rest expr) (Get expr ith)))
+         (Concat (ApplyPerm rest expr) (Single (Get expr ith)))
+    :when ((= rest (PermPush _jth _rest)))
+    :ruleset always-run)
+(rewrite (ApplyPerm (PermPush ith (PNil)) expr) (Single (Get expr ith))
+    :ruleset always-run)
 
 (ruleset loop-inversion)
 
+;; This is for unified handling of thn/els branches
+(relation ith-arg-is-bool (Expr Expr Expr i64 Expr Expr))
+
 (rule (
     (= loop (DoWhile inpW outW))
-    (= pred (Get outW 0))
     (IVTPermutationAnalysis outW conditional perm)
     (= conditional (If condI inpI thn els))
+
     (= (Get thn ith) (Const (Bool true) _unused1 _unused2))
     (= (Get els ith) (Const (Bool false) _unused3 _unused4))
+) (
+    (ith-arg-is-bool conditional condI inpI ith thn els)
+) :ruleset always-run)
+
+(rule (
+    (= loop (DoWhile inpW outW))
+    (IVTPermutationAnalysis outW conditional perm)
+    (= conditional (If condI inpI thn els))
+
+    (= (Get thn ith) (Const (Bool false) _unused1 _unused2))
+    (= (Get els ith) (Const (Bool true) _unused3 _unused4))
+) (
+    (ith-arg-is-bool conditional condI inpI ith els thn)
+) :ruleset always-run)
+
+(rule (
+    (= loop (DoWhile inpW outW))
+    (IVTPermutationAnalysis outW conditional perm)
+    ;; This generalizes the following conditions:
+    ;;   (= conditional (If condI inpI thn els))
+    ;;     (= (Get thn ith) (Const (Bool true) _unused1 _unused2))
+    ;;     (= (Get els ith) (Const (Bool false) _unused3 _unused4))
+    (ith-arg-is-bool conditional condI inpI ith thn els)
 
     (ContextOf inpW outer-ctx)
+    (ContextOf inpI if-ctx)
     (HasType inpW argW)
 ) (
     ;; first peeled condition
@@ -77,17 +101,27 @@
     ;; the first element of body was true but should be the condition.
     (let new-loop-outputs
         (Concat
-            (Single (Subst new-loop-context inpI condI))
+            (Single (Subst new-loop-context (Arg argW new-loop-context) condI))
             (TupleRemoveAt new-loop-outputs_ 0)))
 
-    (let new-loop (DoWhile inpI new-loop-outputs))
-    (let new-expr
+    (let new-loop (DoWhile (Arg argW new-if-true-ctx) new-loop-outputs))
+    (let new-if
         (If new-if-cond inpW
             new-loop
             (Arg argW new-if-false-ctx)))
 
-    (union new-loop loop)
+    ;; Apply the body of the false branch as an afterprocessing wrapper
+    (let new-expr_
+        (Subst outer-ctx new-if 
+            (Subst if-ctx inpI els)))
+    (let new-expr 
+        (TupleRemoveAt 
+            (ApplyPerm perm new-expr_) 
+            0))
 
-    (union new-loop-context (InLoop inpI new-loop-outputs))
+    (union new-expr loop)
+    (union new-loop-context (InLoop (Arg argW new-if-true-ctx) new-loop-outputs))
+
+    (delete (DoWhile inpW outW))
     (delete (TmpCtx))
 ) :ruleset loop-inversion)

--- a/dag_in_context/src/optimizations/ivt.egg
+++ b/dag_in_context/src/optimizations/ivt.egg
@@ -80,8 +80,8 @@
     (IVTPermutationAnalysis outW conditional perm)
     ;; This generalizes the following conditions:
     ;;   (= conditional (If condI inpI thn els))
-    ;;     (= (Get thn ith) (Const (Bool true) _unused1 _unused2))
-    ;;     (= (Get els ith) (Const (Bool false) _unused3 _unused4))
+    ;;   (= (Get thn ith) (Const (Bool true) _unused1 _unused2))
+    ;;   (= (Get els ith) (Const (Bool false) _unused3 _unused4))
     (ith-arg-is-bool conditional condI inpI ith thn els)
 
     (ContextOf inpW outer-ctx)
@@ -97,12 +97,16 @@
     (let new-loop-context (TmpCtx))
 
     ;; body
-    (let new-loop-outputs_ (ApplyPerm perm (Subst new-loop-context inpI thn)))
+    (let new-loop-outputs_ 
+        (TupleRemoveAt
+            (ApplyPerm perm (Subst new-loop-context inpI thn))
+            0))
     ;; the first element of body was true but should be the condition.
     (let new-loop-outputs
         (Concat
-            (Single (Subst new-loop-context (Arg argW new-loop-context) condI))
-            (TupleRemoveAt new-loop-outputs_ 0)))
+            ; (Single (Subst new-loop-context (Arg argW new-loop-context) condI))
+            (Single (Subst new-loop-context new-loop-outputs_ condI))
+            new-loop-outputs_))
 
     (let new-loop (DoWhile (Arg argW new-if-true-ctx) new-loop-outputs))
     (let new-if

--- a/dag_in_context/src/optimizations/ivt.egg
+++ b/dag_in_context/src/optimizations/ivt.egg
@@ -8,7 +8,7 @@
 ;     (passthrough))
 ;; A Perm is a reverse list of integers
 (datatype Perm (PermPush i64 Perm) (PNil))
-;; expr1 is a list of expressions of the form (Project i expr2),
+;; expr1 is a list of expressions of the form (Get expr2 i),
 ;; where all the i's form a permutation
 (relation IVTPermutationAnalysisDemand (Expr))
 ;;                                    expr1 curr  expr2
@@ -24,7 +24,7 @@
 
 (rule (
     (IVTPermutationAnalysisDemand loop-body)
-    (= loop-body (Concat (Single (Project expr ith))) rest)
+    (= loop-body (Concat (Single (Get expr ith)) rest))
 ) (
     (let perm (PermPush ith (PNil)))
     (IVTPermutationAnalysisImpl loop-body rest expr perm)
@@ -32,7 +32,7 @@
 
 (rule (
     (IVTPermutationAnalysisImpl loop-body curr expr perm)
-    (= curr (Concat (Single (Project expr ith))) rest)
+    (= curr (Concat (Single (Get expr ith)) rest))
 ) (
     (let new-perm (PermPush ith perm))
     (IVTPermutationAnalysisImpl loop-body rest expr new-perm)
@@ -40,13 +40,18 @@
 
 (rule (
     (IVTPermutationAnalysisImpl loop-body (Single last) expr perm)
-    (= last (Project expr ith))
+    (= last (Get expr ith))
 ) (
     (let new-perm (PermPush ith perm))
     (IVTPermutationAnalysis loop-body expr new-perm)
 ) :ruleset always-run)
 
 (function ApplyPerm (Perm Expr) Expr)
+
+(rewrite (ApplyPerm (PermPush ith rest) expr) 
+         (Concat (ApplyPerm rest expr) (Get expr ith)))
+
+(ruleset loop-inversion)
 
 (rule (
     (= loop (DoWhile inpW outW))
@@ -85,4 +90,4 @@
 
     (union new-loop-context (InLoop inpI new-loop-outputs))
     (delete (TmpCtx))
-))
+) :ruleset loop-inversion)

--- a/dag_in_context/src/optimizations/ivt.egg
+++ b/dag_in_context/src/optimizations/ivt.egg
@@ -1,0 +1,88 @@
+; (= loop (Loop pred body))
+; (= pred (Project ith (If cond thn els)))
+
+; =>
+
+; (If cond 
+;     (Loop pred body)
+;     (passthrough))
+;; A Perm is a reverse list of integers
+(datatype Perm (PermPush i64 Perm) (PNil))
+;; expr1 is a list of expressions of the form (Project i expr2),
+;; where all the i's form a permutation
+(relation IVTPermutationAnalysisDemand (Expr))
+;;                                    expr1 curr  expr2
+(relation IVTPermutationAnalysisImpl (Expr  Expr  Expr Perm))
+;;                                expr1 expr2
+(relation IVTPermutationAnalysis (Expr Expr Perm))
+
+(rule (
+    (DoWhile inpW outW)
+) (
+    (IVTPermutationAnalysisDemand outW)
+) :ruleset always-run)
+
+(rule (
+    (IVTPermutationAnalysisDemand loop-body)
+    (= loop-body (Concat (Single (Project expr ith))) rest)
+) (
+    (let perm (PermPush ith (PNil)))
+    (IVTPermutationAnalysisImpl loop-body rest expr perm)
+) :ruleset always-run)
+
+(rule (
+    (IVTPermutationAnalysisImpl loop-body curr expr perm)
+    (= curr (Concat (Single (Project expr ith))) rest)
+) (
+    (let new-perm (PermPush ith perm))
+    (IVTPermutationAnalysisImpl loop-body rest expr new-perm)
+) :ruleset always-run)
+
+(rule (
+    (IVTPermutationAnalysisImpl loop-body (Single last) expr perm)
+    (= last (Project expr ith))
+) (
+    (let new-perm (PermPush ith perm))
+    (IVTPermutationAnalysis loop-body expr new-perm)
+) :ruleset always-run)
+
+(function ApplyPerm (Perm Expr) Expr)
+
+(rule (
+    (= loop (DoWhile inpW outW))
+    (= pred (Get outW 0))
+    (IVTPermutationAnalysis outW conditional perm)
+    (= conditional (If condI inpI thn els))
+    (= (Get thn ith) (Const (Bool true) _unused1 _unused2))
+    (= (Get els ith) (Const (Bool false) _unused3 _unused4))
+
+    (ContextOf inpW outer-ctx)
+    (HasType inpW argW)
+) (
+    ;; first peeled condition
+    (let new-if-cond (Subst outer-ctx inpW condI))
+    ;; if contexts
+    (let new-if-true-ctx (InIf true new-if-cond inpW))
+    (let new-if-false-ctx (InIf false new-if-cond inpW))
+    
+    (let new-loop-context (TmpCtx))
+
+    ;; body
+    (let new-loop-outputs_ (ApplyPerm perm (Subst new-loop-context inpI thn)))
+    ;; the first element of body was true but should be the condition.
+    (let new-loop-outputs
+        (Concat
+            (Single (Subst new-loop-context inpI condI))
+            (TupleRemoveAt new-loop-outputs_ 0)))
+
+    (let new-loop (DoWhile inpI new-loop-outputs))
+    (let new-expr
+        (If new-if-cond inpW
+            new-loop
+            (Arg argW new-if-false-ctx)))
+
+    (union new-loop loop)
+
+    (union new-loop-context (InLoop inpI new-loop-outputs))
+    (delete (TmpCtx))
+))

--- a/dag_in_context/src/optimizations/ivt.egg
+++ b/dag_in_context/src/optimizations/ivt.egg
@@ -72,7 +72,9 @@
     (= (Get thn ith) (Const (Bool false) _unused1 _unused2))
     (= (Get els ith) (Const (Bool true) _unused3 _unused4))
 ) (
-    (ith-arg-is-bool conditional condI inpI ith els thn)
+    ;; TODO: this may introduce overhead, but is the only way to
+    ;; not have two rules
+    (ith-arg-is-bool conditional (Uop (Not) condI) inpI ith els thn)
 ) :ruleset always-run)
 
 (rule (

--- a/dag_in_context/src/optimizations/passthrough.egg
+++ b/dag_in_context/src/optimizations/passthrough.egg
@@ -23,7 +23,7 @@
        (= (Get branch1 i) (Get (Arg _ _ctx1) j))
        (= passed-through (Get inputs j))
        (HasType lhs lhs_ty)
-       (!= lhs_ty (Base (StateT))))
+       (NonStateType lhs_ty))
       ((union lhs passed-through))
       :ruleset passthrough)
 
@@ -45,7 +45,7 @@
        (= then-branch (Get (Arg arg_ty _then_ctx) j))
        (= else-branch (Get (Arg arg_ty _else_ctx) j))
        (HasType then-branch lhs_ty)
-       (!= lhs_ty (Base (StateT))))
+       (NonStateType lhs_ty))
       ((union (Get if i) (Get inputs j)))
       :ruleset passthrough)
 

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -47,6 +47,7 @@ fn optimizations() -> Vec<String> {
         "loop-inv-motion",
         "loop-strength-reduction",
         "loop-peel",
+        "loop-inversion",
     ]
     .iter()
     .map(|opt| opt.to_string())

--- a/dag_in_context/src/type_analysis.egg
+++ b/dag_in_context/src/type_analysis.egg
@@ -509,6 +509,41 @@
       :ruleset error-checking)
 
 ; =================================
+; Predicate to check if a type is not a state type
+; =================================
+
+(relation NonStateBaseType (BaseType))
+(rule ()
+     ((NonStateBaseType (IntT))
+      (NonStateBaseType (BoolT))
+      (NonStateBaseType (FloatT)))
+  :ruleset type-analysis)
+(rule ((= ptr-type (PointerT ty))
+       (NonStateBaseType ty))
+      ((NonStateBaseType ptr-type))
+  :ruleset type-analysis)
+
+(relation NonStateTypeList (TypeList))
+(rule ()
+     ((NonStateTypeList (TNil)))
+  :ruleset type-analysis)
+(rule ((NonStateTypeList tl)
+       (NonStateBaseType hd)
+       (= type-list (TCons hd tl)))
+      ((NonStateTypeList type-list))
+  :ruleset type-analysis)
+
+(relation NonStateType (Type))
+(rule ((NonStateBaseType bt)
+       (= t (Base bt)))
+      ((NonStateType t))
+  :ruleset type-analysis)
+(rule ((NonStateTypeList tl)
+       (= t (TupleT tl)))
+      ((NonStateType t))
+  :ruleset type-analysis)
+
+; =================================
 ; Functions
 ; =================================
 


### PR DESCRIPTION
Prerequisite: #620 

Before:
<img width="520" alt="image" src="https://github.com/egraphs-good/eggcc/assets/13150100/d793c033-40c0-4d22-9fdb-7efec1d66091">

After:
<img width="479" alt="image" src="https://github.com/egraphs-good/eggcc/assets/13150100/7176ddbf-9b69-44ba-9a06-2d6822a2e0dd">

There are still some issues that need to be fixed.

Updates: the tests are still blowing up