### PR TITLE
Rewrite if a </> b then a else b to min/max

### DIFF
--- a/dag_in_context/src/optimizations/switch_rewrites.egg
+++ b/dag_in_context/src/optimizations/switch_rewrites.egg
@@ -1,6 +1,34 @@
 (ruleset switch_rewrite)
 (ruleset always-switch-rewrite)
 
+(rule (
+       (= pred (Bop (LessThan) a b))
+       (= if_e (If pred inputs thn els))
+       ; a is an input to the if region
+       (= a (Get inputs i))
+       ; b is an input to the if region
+       (= b (Get inputs j))
+       ; if a < b then a else b
+       (= (Get thn k) (Get (Arg ty (InIf true pred inputs)) i))
+       (= (Get els k) (Get (Arg ty (InIf false pred inputs)) j))
+      )
+      ((union (Get if_e k) (Bop (Smin) a b)))
+      :ruleset switch_rewrite)
+
+(rule (
+       (= pred (Bop (LessThan) a b))
+       (= if_e (If pred inputs thn els))
+       ; a is an input to the if region
+       (= a (Get inputs i))
+       ; b is an input to the if region
+       (= b (Get inputs j))
+       ; if a < b then b else a
+       (= (Get thn k) (Get (Arg ty (InIf true pred inputs)) j))
+       (= (Get els k) (Get (Arg ty (InIf false pred inputs)) i))
+      )
+      ((union (Get if_e k) (Bop (Smax) a b)))
+      :ruleset switch_rewrite) 
+
 ; if (a and b) X Y ~~> if a (if b X Y) Y
 (rule ((= lhs (If (Bop (And) a b) ins X Y))
        (HasType ins (TupleT ins_ty))

--- a/tests/passing/small/max.bril
+++ b/tests/passing/small/max.bril
@@ -1,0 +1,14 @@
+# ARGS: 20 30
+@main(x: int, y: int) {
+  cmp: bool = gt x y;
+  one: int = const 1;
+  br cmp .then .else;
+  .then:
+    res: int = id x;
+    jmp .done;
+  .else:
+    res: int = id y;
+    jmp .done;
+  .done:
+    print res;
+}

--- a/tests/passing/small/min.bril
+++ b/tests/passing/small/min.bril
@@ -1,0 +1,11 @@
+# ARGS: 20 30
+@main(x: int, y: int) {
+  cmp: bool = lt x y;
+  res: int = id y;
+  br cmp .then .else;
+  .then:
+    res: int = id x;
+  .else:
+  .done:
+    print res;
+}

--- a/tests/snapshots/files__max-optimize.snap
+++ b/tests/snapshots/files__max-optimize.snap
@@ -1,0 +1,15 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+.b2_:
+  v3_: int = smax v1 v0;
+  v4_: bool = lt v1 v0;
+  v5_: int = id v1;
+  br v4_ .b6_ .b7_;
+.b6_:
+  v5_: int = id v0;
+.b7_:
+  print v3_;
+}

--- a/tests/snapshots/files__min-optimize.snap
+++ b/tests/snapshots/files__min-optimize.snap
@@ -1,0 +1,15 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+.b2_:
+  v3_: int = smin v0 v1;
+  v4_: bool = lt v0 v1;
+  v5_: int = id v1;
+  br v4_ .b6_ .b7_;
+.b6_:
+  v5_: int = id v0;
+.b7_:
+  print v3_;
+}


### PR DESCRIPTION
Doesn't result in big changes to benchmarks yet because of the branch thing that @Alex-Fischman is working on.

But I tested on the commit that Alex sent me, and `min.bril` correctly optimizes to
```
@main(v0: int, v1: int) {
.b2_:
  v3_: int = smin v0 v1;
  print v3_;
}
```