### PR TITLE
Add summary table and compile times to nightly

### DIFF
--- a/infra/generate_line_counts.py
+++ b/infra/generate_line_counts.py
@@ -79,8 +79,8 @@ def detailed_linecount_table():
 def round_fmt(v):
     return "{:.3f}".format(round(v, 3))
 
-# given a list of integers (cycles taken for each run)
-# return the mean of the cycles
+# given a list of numbers, compute the mean
+# numbers may be floating-point or integers (for cycles)
 def mean_cycles(cycles):
     return sum(cycles) / len(cycles)
 

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -62,6 +62,13 @@ function getEntry(benchmark, runMode) {
   }
 }
 
+function speedup(entry, baseline) {
+  const baseV = mean_cycles(baseline["cycles"]);
+  const expV = mean_cycles(entry["cycles"]);
+  // If you change this, also change the displayed formula in index.html
+  return baseV / expV;
+}
+
 function getValue(entry) {
   if (GLOBAL_DATA.chart.mode === "absolute") {
     return mean_cycles(entry["cycles"]);
@@ -70,10 +77,7 @@ function getValue(entry) {
     if (!baseline) {
       addWarning(`No speedup baseline for ${benchmark}`);
     }
-    const baseV = mean_cycles(baseline["cycles"]);
-    const expV = mean_cycles(entry["cycles"]);
-    // If you change this, also change the displayed formula in index.html
-    return baseV / expV;
+    return speedup(entry, baseline);
   } else {
     throw new Error(`unknown chart mode ${GLOBAL_DATA.chart.mode}`);
   }

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -16,7 +16,7 @@ const BASELINE_MODE = "llvm-O0";
 
 // Given a list of integers, compute the mean
 // number of cycles
-function mean_cycles(cycles) {
+function mean(cycles) {
   return cycles.reduce((a, b) => a + b, 0) / cycles.length;
 }
 
@@ -63,15 +63,15 @@ function getEntry(benchmark, runMode) {
 }
 
 function speedup(entry, baseline) {
-  const baseV = mean_cycles(baseline["cycles"]);
-  const expV = mean_cycles(entry["cycles"]);
+  const baseV = mean(baseline["cycles"]);
+  const expV = mean(entry["cycles"]);
   // If you change this, also change the displayed formula in index.html
   return baseV / expV;
 }
 
 function getValue(entry) {
   if (GLOBAL_DATA.chart.mode === "absolute") {
-    return mean_cycles(entry["cycles"]);
+    return mean(entry["cycles"]);
   } else if (GLOBAL_DATA.chart.mode === "speedup") {
     const baseline = getEntry(entry.benchmark, BASELINE_MODE);
     if (!baseline) {
@@ -94,8 +94,8 @@ function getError(entry) {
       addWarning(`No speedup baseline for ${benchmark}`);
     }
 
-    const baseV = mean_cycles(baseline["cycles"]);
-    const expV = mean_cycles(entry["cycles"]);
+    const baseV = mean(baseline["cycles"]);
+    const expV = mean(entry["cycles"]);
     const baseStd = stddev_cycles(baseline["cycles"]);
     const expStd = stddev_cycles(entry["cycles"]);
 

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -80,17 +80,20 @@ function getOverallStatistics() {
       }
     }
 
-    const compile_times = [];
+    const eggcc_compile_times = [];
+    const llvm_compile_times = [];
     for (const benchmark of GLOBAL_DATA.enabledBenchmarks) {
       const row = getRow(benchmark, treatment);
-      compile_times.push(row.compileTimeSecs);
+      eggcc_compile_times.push(row.eggccCompileTimeSecs);
+      llvm_compile_times.push(row.llvmCompileTimeSecs);
     }
 
     // calculate the geometric mean of the speedups
     result.push({
       runMethod: treatment,
-      geoMeanSpeedup: geometricMean(speedups),
-      averageCompileTimeSecs: compile_times.reduce((a, b) => a + b, 0) / compile_times.length,
+      geoMeanSpeedup: tryRound(geometricMean(speedups)),
+      meanEggccCompileTimeSecs: tryRound(mean(eggcc_compile_times)),
+      meanLlvmCompileTimeSecs: tryRound(mean(llvm_compile_times)),
     });
   }
   return result;
@@ -105,8 +108,8 @@ function getDataForBenchmark(benchmark) {
       const cycles = row["cycles"];
       const rowData = {
         runMethod: row.runMethod,
-        mean: { class: "", value: tryRound(mean_cycles(cycles)) },
-        meanVsBaseline: getDifference(cycles, comparisonCycles, mean_cycles),
+        mean: { class: "", value: tryRound(mean(cycles)) },
+        meanVsBaseline: getDifference(cycles, comparisonCycles, mean),
         min: { class: "", value: tryRound(min_cycles(cycles)) },
         minVsBaseline: getDifference(cycles, comparisonCycles, min_cycles),
         max: { class: "", value: tryRound(max_cycles(cycles)) },
@@ -114,7 +117,8 @@ function getDataForBenchmark(benchmark) {
         median: { class: "", value: tryRound(median_cycles(cycles)) },
         medianVsBaseline: getDifference(cycles, comparisonCycles, median_cycles),
         stddev: { class: "", value: tryRound(median_cycles(cycles)) },
-        compileTimeSecs: { class: "", value: tryRound(row.compileTimeSecs) },
+        eggccCompileTimeSecs: { class: "", value: tryRound(row.eggccCompileTimeSecs) },
+        llvmCompileTimeSecs: { class: "", value: tryRound(row.llvmCompileTimeSecs) },
         speedup: { class: "", value: tryRound(speedup(row, baseline)) }, 
       };
       if (shouldHaveLlvm(row.runMethod)) {

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -62,7 +62,10 @@ function getBrilPathForBenchmark(benchmark) {
 
 // calculates the geometric mean over a list of ratios
 function geometricMean(values) {
-  return Math.pow(values.reduce((a, b) => a * b, 1), 1 / values.length);
+  return Math.pow(
+    values.reduce((a, b) => a * b, 1),
+    1 / values.length,
+  );
 }
 
 function getOverallStatistics() {
@@ -104,7 +107,10 @@ function getDataForBenchmark(benchmark) {
     ?.filter((row) => row.benchmark === benchmark)
     .map((row) => {
       const baseline = getRow(benchmark, BASELINE_MODE);
-      const comparisonCycles = getComparison(row.benchmark, row.runMethod)?.cycles;
+      const comparisonCycles = getComparison(
+        row.benchmark,
+        row.runMethod,
+      )?.cycles;
       const cycles = row["cycles"];
       const rowData = {
         runMethod: row.runMethod,
@@ -115,11 +121,21 @@ function getDataForBenchmark(benchmark) {
         max: { class: "", value: tryRound(max_cycles(cycles)) },
         maxVsBaseline: getDifference(cycles, comparisonCycles, max_cycles),
         median: { class: "", value: tryRound(median_cycles(cycles)) },
-        medianVsBaseline: getDifference(cycles, comparisonCycles, median_cycles),
+        medianVsBaseline: getDifference(
+          cycles,
+          comparisonCycles,
+          median_cycles,
+        ),
         stddev: { class: "", value: tryRound(median_cycles(cycles)) },
-        eggccCompileTimeSecs: { class: "", value: tryRound(row.eggccCompileTimeSecs) },
-        llvmCompileTimeSecs: { class: "", value: tryRound(row.llvmCompileTimeSecs) },
-        speedup: { class: "", value: tryRound(speedup(row, baseline)) }, 
+        eggccCompileTimeSecs: {
+          class: "",
+          value: tryRound(row.eggccCompileTimeSecs),
+        },
+        llvmCompileTimeSecs: {
+          class: "",
+          value: tryRound(row.llvmCompileTimeSecs),
+        },
+        speedup: { class: "", value: tryRound(speedup(row, baseline)) },
       };
       if (shouldHaveLlvm(row.runMethod)) {
         rowData.runMethod = `<a target="_blank" rel="noopener noreferrer" href="llvm.html?benchmark=${benchmark}&runmode=${row.runMethod}">${row.runMethod}</a>`;

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -18,7 +18,6 @@
 
 <body onload="load_index()">
   <h2>Nightlies</h2>
-  <h2>Profile</h2>
 
   <div>
     <button type="button" class="collapsible" onclick="toggle(this, '\u25B6 Show Chart', '\u25BC Hide Chart')">&#x25BC; Hide Chart</button>
@@ -67,6 +66,10 @@
     </div>
   </div>
   
+  <h2>Overall Stats</h2>
+  <div id="overall-stats-table"></div>
+
+  <h2>Detailed Table</h2>
   <div id="profile"></div>
   <h2>Raw</h2>
   <p>

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -67,6 +67,7 @@
   </div>
   
   <h2>Overall Stats</h2>
+  <t>Warning: compile-time statistics are not very trustworthy in parallel mode.</t>
   <div id="overall-stats-table"></div>
 
   <h2>Detailed Table</h2>

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -48,6 +48,11 @@ function refreshView() {
 
   document.getElementById("profile").innerHTML = ConvertJsonToTable(tableData);
 
+  // fill in the overall stats table
+  const overallStats = getOverallStatistics();
+  const overallTable = document.getElementById("overall-stats-table");
+  overallTable.innerHTML = ConvertJsonToTable(overallStats);
+
   renderWarnings();
   refreshChart();
 }

--- a/infra/update-frontend.sh
+++ b/infra/update-frontend.sh
@@ -1,0 +1,17 @@
+# smalls script to test changes to the javascript or html files
+# determine physical directory of this script
+src="${BASH_SOURCE[0]}"
+while [ -L "$src" ]; do
+  dir="$(cd -P "$(dirname "$src")" && pwd)"
+  src="$(readlink "$src")"
+  [[ $src != /* ]] && src="$dir/$src"
+done
+MYDIR="$(cd -P "$(dirname "$src")" && pwd)"
+TOP_DIR="$MYDIR/.."
+RESOURCE_DIR="$MYDIR/nightly-resources"
+NIGHTLY_DIR="$TOP_DIR/nightly"
+
+echo "Copying resources to $NIGHTLY_DIR/output"
+cp "$RESOURCE_DIR"/* "$NIGHTLY_DIR/output"
+
+cd nightly/output && python3 -m http.server 8002

--- a/infra/update-frontend.sh
+++ b/infra/update-frontend.sh
@@ -1,4 +1,7 @@
 # smalls script to test changes to the javascript or html files
+# copys javascript and html files to the output directory
+
+
 # determine physical directory of this script
 src="${BASH_SOURCE[0]}"
 while [ -L "$src" ]; do

--- a/src/util.rs
+++ b/src/util.rs
@@ -276,6 +276,19 @@ pub struct ProgWithArguments {
     args: Vec<String>,
 }
 
+impl ProgWithArguments {
+    pub(crate) fn to_viz(&self) -> Visualization {
+        Visualization {
+            result: "# ARGS: ".to_string()
+                + &ListDisplay(&self.args, " ").to_string()
+                + "\n"
+                + &self.program.to_string(),
+            file_extension: ".bril".to_string(),
+            name: "".to_string(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum TestProgram {
     Prog(ProgWithArguments),
@@ -577,11 +590,7 @@ impl Run {
 
         let (visualizations, interpretable_out) = match self.test_type {
             RunMode::Parse => (
-                vec![Visualization {
-                    result: self.prog_with_args.program.to_string(),
-                    file_extension: ".bril".to_string(),
-                    name: "".to_string(),
-                }],
+                vec![self.prog_with_args.to_viz()],
                 Some(Interpretable::Bril(self.prog_with_args.program.clone())),
             ),
             RunMode::BrilToJson => {
@@ -616,12 +625,13 @@ impl Run {
                 let rvsdg = Optimizer::program_to_rvsdg(&self.prog_with_args.program)?;
                 let cfg = rvsdg.to_cfg();
                 let bril = cfg.to_bril();
+                let prog_with_args = ProgWithArguments {
+                    program: bril.clone(),
+                    name: self.prog_with_args.name.clone(),
+                    args: self.prog_with_args.args.clone(),
+                };
                 (
-                    vec![Visualization {
-                        result: bril.to_string(),
-                        file_extension: ".bril".to_string(),
-                        name: "".to_string(),
-                    }],
+                    vec![prog_with_args.to_viz()],
                     Some(Interpretable::Bril(bril)),
                 )
             }
@@ -652,12 +662,13 @@ impl Run {
                 let rvsdg2 = dag_to_rvsdg(&tree);
                 let cfg = rvsdg2.to_cfg();
                 let bril = cfg.to_bril();
+                let prog_with_args = ProgWithArguments {
+                    program: bril.clone(),
+                    name: self.prog_with_args.name.clone(),
+                    args: self.prog_with_args.args.clone(),
+                };
                 (
-                    vec![Visualization {
-                        result: bril.to_string(),
-                        file_extension: ".bril".to_string(),
-                        name: "".to_string(),
-                    }],
+                    vec![prog_with_args.to_viz()],
                     Some(Interpretable::Bril(bril)),
                 )
             }
@@ -669,12 +680,13 @@ impl Run {
             }
             RunMode::Optimize => {
                 let bril = Run::optimize_bril(&self.prog_with_args.program, &self.eggcc_config)?;
+                let new_prog_with_args = ProgWithArguments {
+                    program: bril.clone(),
+                    name: self.prog_with_args.name.clone(),
+                    args: self.prog_with_args.args.clone(),
+                };
                 (
-                    vec![Visualization {
-                        result: bril.to_string(),
-                        file_extension: ".bril".to_string(),
-                        name: "".to_string(),
-                    }],
+                    vec![new_prog_with_args.to_viz()],
                     Some(Interpretable::Bril(bril)),
                 )
             }
@@ -796,12 +808,13 @@ impl Run {
             RunMode::CfgRoundTrip => {
                 let cfg = Optimizer::program_to_cfg(&self.prog_with_args.program);
                 let bril = cfg.to_bril();
+                let prog_with_args = ProgWithArguments {
+                    program: bril.clone(),
+                    name: self.prog_with_args.name.clone(),
+                    args: self.prog_with_args.args.clone(),
+                };
                 (
-                    vec![Visualization {
-                        result: bril.to_string(),
-                        file_extension: ".bril".to_string(),
-                        name: "".to_string(),
-                    }],
+                    vec![prog_with_args.to_viz()],
                     Some(Interpretable::Bril(bril)),
                 )
             }
@@ -809,12 +822,13 @@ impl Run {
                 let cfg = Optimizer::program_to_cfg(&self.prog_with_args.program);
                 let optimized = cfg.optimize_jumps();
                 let bril = optimized.to_bril();
+                let prog_with_args = ProgWithArguments {
+                    program: bril.clone(),
+                    name: self.prog_with_args.name.clone(),
+                    args: self.prog_with_args.args.clone(),
+                };
                 (
-                    vec![Visualization {
-                        result: bril.to_string(),
-                        file_extension: ".bril".to_string(),
-                        name: "".to_string(),
-                    }],
+                    vec![prog_with_args.to_viz()],
                     Some(Interpretable::Bril(bril)),
                 )
             }

--- a/tests/snapshots/files__add-optimize-sequential.snap
+++ b/tests/snapshots/files__add-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__add-optimize.snap
+++ b/tests/snapshots/files__add-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__add_block_indirection-optimize-sequential.snap
+++ b/tests/snapshots/files__add_block_indirection-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__add_block_indirection-optimize.snap
+++ b/tests/snapshots/files__add_block_indirection-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__block-diamond-optimize-sequential.snap
+++ b/tests/snapshots/files__block-diamond-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__bool-optimize-sequential.snap
+++ b/tests/snapshots/files__bool-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: bool = const true;

--- a/tests/snapshots/files__bool-optimize.snap
+++ b/tests/snapshots/files__bool-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: bool = const true;

--- a/tests/snapshots/files__branch_duplicate_work-optimize-sequential.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 2;

--- a/tests/snapshots/files__branch_duplicate_work-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 2;

--- a/tests/snapshots/files__collatz_redundant_computation-optimize-sequential.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 8888
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__collatz_redundant_computation-optimize.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 8888
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__constant_fold_simple-optimize-sequential.snap
+++ b/tests/snapshots/files__constant_fold_simple-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__constant_fold_simple-optimize.snap
+++ b/tests/snapshots/files__constant_fold_simple-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__diamond-optimize-sequential.snap
+++ b/tests/snapshots/files__diamond-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 3
 @main(v0: int) {
 .b1_:
   v2_: bool = lt v0 v0;

--- a/tests/snapshots/files__diamond-optimize.snap
+++ b/tests/snapshots/files__diamond-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 3
 @main(v0: int) {
 .b1_:
   v2_: bool = lt v0 v0;

--- a/tests/snapshots/files__duplicate_branch-optimize-sequential.snap
+++ b/tests/snapshots/files__duplicate_branch-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 5
 @main(v0: int) {
 .b1_:
   c2_: int = const 4;

--- a/tests/snapshots/files__duplicate_branch-optimize.snap
+++ b/tests/snapshots/files__duplicate_branch-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 5
 @main(v0: int) {
 .b1_:
   c2_: int = const 4;

--- a/tests/snapshots/files__eliminate_gamma-optimize-sequential.snap
+++ b/tests/snapshots/files__eliminate_gamma-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 1;

--- a/tests/snapshots/files__eliminate_gamma-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 1;

--- a/tests/snapshots/files__eliminate_gamma_interval-optimize-sequential.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: bool = const false;

--- a/tests/snapshots/files__eliminate_gamma_interval-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: bool = const false;

--- a/tests/snapshots/files__eliminate_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__eliminate_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 1;

--- a/tests/snapshots/files__eliminate_loop-optimize.snap
+++ b/tests/snapshots/files__eliminate_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 1;

--- a/tests/snapshots/files__fib_recursive-optimize-sequential.snap
+++ b/tests/snapshots/files__fib_recursive-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @fac(v0: int): int {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @fac(v0: int): int {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__fib_shape-optimize-sequential.snap
+++ b/tests/snapshots/files__fib_shape-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 10
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__fib_shape-optimize.snap
+++ b/tests/snapshots/files__fib_shape-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 10
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__five_call_nestings-optimize-sequential.snap
+++ b/tests/snapshots/files__five_call_nestings-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @one {
 .b0_:
   call @four;

--- a/tests/snapshots/files__five_call_nestings-optimize.snap
+++ b/tests/snapshots/files__five_call_nestings-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @one {
 .b0_:
   call @four;

--- a/tests/snapshots/files__flatten_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__flatten_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 10 10
 @main(v0: int, v1: int) {
 .b2_:
   c3_: int = const 0;

--- a/tests/snapshots/files__flatten_loop-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 10 10
 @main(v0: int, v1: int) {
 .b2_:
   c3_: int = const 0;

--- a/tests/snapshots/files__four_call_nestings-optimize-sequential.snap
+++ b/tests/snapshots/files__four_call_nestings-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @one {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__four_call_nestings-optimize.snap
+++ b/tests/snapshots/files__four_call_nestings-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @one {
 .b0_:
   c1_: int = const 3;

--- a/tests/snapshots/files__gamma_condition_and-optimize-sequential.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__gamma_pull_in-optimize-sequential.snap
+++ b/tests/snapshots/files__gamma_pull_in-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 10;

--- a/tests/snapshots/files__gamma_pull_in-optimize.snap
+++ b/tests/snapshots/files__gamma_pull_in-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 10;

--- a/tests/snapshots/files__if_constant_fold-optimize-sequential.snap
+++ b/tests/snapshots/files__if_constant_fold-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 6;

--- a/tests/snapshots/files__if_constant_fold-optimize.snap
+++ b/tests/snapshots/files__if_constant_fold-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 6;

--- a/tests/snapshots/files__if_constant_fold2-optimize-sequential.snap
+++ b/tests/snapshots/files__if_constant_fold2-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 20;

--- a/tests/snapshots/files__if_constant_fold2-optimize.snap
+++ b/tests/snapshots/files__if_constant_fold2-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 20;

--- a/tests/snapshots/files__if_context-optimize-sequential.snap
+++ b/tests/snapshots/files__if_context-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: bool = const true;

--- a/tests/snapshots/files__if_context-optimize.snap
+++ b/tests/snapshots/files__if_context-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: bool = const true;

--- a/tests/snapshots/files__if_dead_code-optimize-sequential.snap
+++ b/tests/snapshots/files__if_dead_code-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__if_dead_code-optimize.snap
+++ b/tests/snapshots/files__if_dead_code-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__if_dead_code_nested-optimize-sequential.snap
+++ b/tests/snapshots/files__if_dead_code_nested-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__if_dead_code_nested-optimize.snap
+++ b/tests/snapshots/files__if_dead_code_nested-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__if_in_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__if_in_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__if_in_loop-optimize.snap
+++ b/tests/snapshots/files__if_in_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__if_interval-optimize-sequential.snap
+++ b/tests/snapshots/files__if_interval-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: bool = const true;

--- a/tests/snapshots/files__if_interval-optimize.snap
+++ b/tests/snapshots/files__if_interval-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: bool = const true;

--- a/tests/snapshots/files__implicit-return-optimize-sequential.snap
+++ b/tests/snapshots/files__implicit-return-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @pow(v0: int, v1: int) {
 .b2_:
   c3_: int = const 0;

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @pow(v0: int, v1: int) {
 .b2_:
   c3_: int = const 0;

--- a/tests/snapshots/files__impossible_if-optimize-sequential.snap
+++ b/tests/snapshots/files__impossible_if-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__impossible_if-optimize.snap
+++ b/tests/snapshots/files__impossible_if-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__jumping_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__jumping_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__jumping_loop-optimize.snap
+++ b/tests/snapshots/files__jumping_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__loop_hoist-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_hoist-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1 2 3 4
 @main(v0: int, v1: int, v2: int, v3: int) {
 .b4_:
   v5_: int = sub v2 v1;

--- a/tests/snapshots/files__loop_hoist-optimize.snap
+++ b/tests/snapshots/files__loop_hoist-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1 2 3 4
 @main(v0: int, v1: int, v2: int, v3: int) {
 .b4_:
   v5_: int = sub v2 v1;

--- a/tests/snapshots/files__loop_if-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_if-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__loop_pass_through-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 5
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__loop_pass_through-optimize.snap
+++ b/tests/snapshots/files__loop_pass_through-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 5
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__loop_with_mul_by_inv-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_with_mul_by_inv-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 4
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__loop_with_mul_by_inv-optimize.snap
+++ b/tests/snapshots/files__loop_with_mul_by_inv-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 4
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__max-optimize-sequential.snap
+++ b/tests/snapshots/files__max-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 20 30
 @main(v0: int, v1: int) {
 .b2_:
   v3_: bool = lt v1 v0;

--- a/tests/snapshots/files__max-optimize.snap
+++ b/tests/snapshots/files__max-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 20 30
 @main(v0: int, v1: int) {
 .b2_:
   v3_: int = smax v1 v0;

--- a/tests/snapshots/files__mem_loop_store_forwarding-optimize-sequential.snap
+++ b/tests/snapshots/files__mem_loop_store_forwarding-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: false
 @main(v0: bool) {
 .b1_:
   c2_: int = const 3;

--- a/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: false
 @main(v0: bool) {
 .b1_:
   c2_: int = const 3;

--- a/tests/snapshots/files__mem_simple_redundant_load-optimize-sequential.snap
+++ b/tests/snapshots/files__mem_simple_redundant_load-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: false
 @main(v0: bool) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
+++ b/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: false
 @main(v0: bool) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__mem_simple_store_forwarding-optimize-sequential.snap
+++ b/tests/snapshots/files__mem_simple_store_forwarding-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 2;

--- a/tests/snapshots/files__mem_simple_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_simple_store_forwarding-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 2;

--- a/tests/snapshots/files__min-optimize-sequential.snap
+++ b/tests/snapshots/files__min-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 20 30
 @main(v0: int, v1: int) {
 .b2_:
   v3_: bool = lt v0 v1;

--- a/tests/snapshots/files__min-optimize.snap
+++ b/tests/snapshots/files__min-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 20 30
 @main(v0: int, v1: int) {
 .b2_:
   v3_: int = smin v0 v1;

--- a/tests/snapshots/files__nested_call-optimize-sequential.snap
+++ b/tests/snapshots/files__nested_call-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int): int {
 .b1_:
   c2_: int = const 2;

--- a/tests/snapshots/files__nested_call-optimize.snap
+++ b/tests/snapshots/files__nested_call-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int): int {
 .b1_:
   c2_: int = const 2;

--- a/tests/snapshots/files__peel_twice-optimize-sequential.snap
+++ b/tests/snapshots/files__peel_twice-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__peel_twice-optimize.snap
+++ b/tests/snapshots/files__peel_twice-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 2;

--- a/tests/snapshots/files__peel_twice_precalc_pred-optimize-sequential.snap
+++ b/tests/snapshots/files__peel_twice_precalc_pred-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__peel_twice_precalc_pred-optimize.snap
+++ b/tests/snapshots/files__peel_twice_precalc_pred-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 2;

--- a/tests/snapshots/files__range_check-optimize-sequential.snap
+++ b/tests/snapshots/files__range_check-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__range_check-optimize.snap
+++ b/tests/snapshots/files__range_check-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__range_splitting-optimize-sequential.snap
+++ b/tests/snapshots/files__range_splitting-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__range_splitting-optimize.snap
+++ b/tests/snapshots/files__range_splitting-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__reassoc-optimize-sequential.snap
+++ b/tests/snapshots/files__reassoc-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 2 4
 @main(v0: int, v1: int) {
 .b2_:
   c3_: int = const 1;

--- a/tests/snapshots/files__reassoc-optimize.snap
+++ b/tests/snapshots/files__reassoc-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 2 4
 @main(v0: int, v1: int) {
 .b2_:
   c3_: int = const 1;

--- a/tests/snapshots/files__recurse_once-optimize-sequential.snap
+++ b/tests/snapshots/files__recurse_once-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @to_zero(v0: int): int {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__recurse_once-optimize.snap
+++ b/tests/snapshots/files__recurse_once-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @to_zero(v0: int): int {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__simple-call-optimize-sequential.snap
+++ b/tests/snapshots/files__simple-call-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int): int {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__simple-call-optimize.snap
+++ b/tests/snapshots/files__simple-call-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int): int {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__simple_branch-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_branch-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__simple_branch-optimize.snap
+++ b/tests/snapshots/files__simple_branch-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 1
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__simple_call-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_call-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__simple_call-optimize.snap
+++ b/tests/snapshots/files__simple_call-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int) {
 .b1_:
   c2_: int = const 1;

--- a/tests/snapshots/files__simple_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__simple_loop-optimize.snap
+++ b/tests/snapshots/files__simple_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__simple_loop_swap-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_loop_swap-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 2;

--- a/tests/snapshots/files__simple_loop_swap-optimize.snap
+++ b/tests/snapshots/files__simple_loop_swap-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 2;

--- a/tests/snapshots/files__simple_recursive-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_recursive-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int): int {
 .b1_:
   c2_: int = const 2;

--- a/tests/snapshots/files__simple_recursive-optimize.snap
+++ b/tests/snapshots/files__simple_recursive-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @inc(v0: int): int {
 .b1_:
   c2_: int = const 2;

--- a/tests/snapshots/files__simplest_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__simplest_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__simplest_loop-optimize.snap
+++ b/tests/snapshots/files__simplest_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__small-collatz-optimize-sequential.snap
+++ b/tests/snapshots/files__small-collatz-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 8888
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__small-collatz-optimize.snap
+++ b/tests/snapshots/files__small-collatz-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 8888
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__small-fib-optimize-sequential.snap
+++ b/tests/snapshots/files__small-fib-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 2
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__small-fib-optimize.snap
+++ b/tests/snapshots/files__small-fib-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 2
 @main(v0: int) {
 .b1_:
   c2_: int = const 0;

--- a/tests/snapshots/files__sqrt_small-optimize-sequential.snap
+++ b/tests/snapshots/files__sqrt_small-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 16.0
 @main(v0: float) {
 .b1_:
   c2_: float = const 0;

--- a/tests/snapshots/files__sqrt_small-optimize.snap
+++ b/tests/snapshots/files__sqrt_small-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 16.0
 @main(v0: float) {
 .b1_:
   c2_: float = const 0;

--- a/tests/snapshots/files__strong_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__strong_loop-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 3
 @main(v0: int) {
 .b1_:
   c2_: int = const 3;

--- a/tests/snapshots/files__strong_loop-optimize.snap
+++ b/tests/snapshots/files__strong_loop-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 3
 @main(v0: int) {
 .b1_:
   c2_: int = const 3;

--- a/tests/snapshots/files__two_fns-optimize-sequential.snap
+++ b/tests/snapshots/files__two_fns-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @sub: int {
 .b0_:
   c1_: int = const -1;

--- a/tests/snapshots/files__two_fns-optimize.snap
+++ b/tests/snapshots/files__two_fns-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @sub: int {
 .b0_:
   c1_: int = const -1;

--- a/tests/snapshots/files__unroll_and_constant_fold-optimize-sequential.snap
+++ b/tests/snapshots/files__unroll_and_constant_fold-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__unroll_and_constant_fold-optimize.snap
+++ b/tests/snapshots/files__unroll_and_constant_fold-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 1;

--- a/tests/snapshots/files__unroll_multiple_4-optimize-sequential.snap
+++ b/tests/snapshots/files__unroll_multiple_4-optimize-sequential.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;

--- a/tests/snapshots/files__unroll_multiple_4-optimize.snap
+++ b/tests/snapshots/files__unroll_multiple_4-optimize.snap
@@ -2,6 +2,7 @@
 source: tests/files.rs
 expression: visualization.result
 ---
+# ARGS: 
 @main {
 .b0_:
   c1_: int = const 0;


### PR DESCRIPTION
- Adding compile times ended up causing a refactor of the nightly. It's now a two step process: eggcc, then llvm. This is cleaner in hindsight than using complex run modes
- Visualizations now preserve inputs to enable the change above
- Added an aggregate table, and refactored the old table slightly to share code