### PR TITLE
Add brils for peggy comparison

### DIFF
--- a/tests/failing/peggy_comparison/infinite_loop.bril
+++ b/tests/failing/peggy_comparison/infinite_loop.bril
@@ -1,0 +1,17 @@
+@main: int {
+    five: int = const 5;
+    one: int = const 1;
+    j: int = const 0;
+    i: int = id five;
+
+.loop_test:
+    cond: bool = eq i five;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    j: int = add one j;
+    jmp .loop_test;
+
+.loop_end:
+    ret j;
+}

--- a/tests/passing/small/peggy_comparison/branch_hoisting.bril
+++ b/tests/passing/small/peggy_comparison/branch_hoisting.bril
@@ -1,0 +1,33 @@
+# ARGS: 0
+@main(n: int) {
+    zero: int = const 0;
+    x: int = id zero;
+    y: int = id zero;
+    fivehundred: int = const 500;
+
+.pred:
+    whilecond: bool = lt y fivehundred;
+    br whilecond .loopbody .end;
+
+.loopbody:
+    two: int = const 2;
+    ifcond: bool = eq n zero;
+    br ifcond .thn .els;
+
+.thn:
+    x: int = mul y two;
+    jmp .ifend;
+
+.els:
+    three: int = const 3;
+    x: int = mul y three;
+
+.ifend:
+    one: int = const 1;
+    y: int = add one y;
+
+    jmp .pred;
+
+.end:
+    print x;
+}

--- a/tests/passing/small/peggy_comparison/conditional_constant_folding.bril
+++ b/tests/passing/small/peggy_comparison/conditional_constant_folding.bril
@@ -1,0 +1,28 @@
+# ARGS: 4
+@main(x: int) {
+    five: int = const 5;
+    four: int = const 4;
+    twenty: int = const 20;
+    cond: bool = eq x five;
+    br cond .if .else_if_check;
+
+.if:
+    res: int = mul four x;
+    jmp .end;
+
+.else_if_check:
+    cond: bool = eq x four;
+    br cond .else_if .else;
+    jmp .end;
+
+.else_if:
+    res: int = mul five x;
+    jmp .end;
+    
+.else:
+    res: int = id twenty;
+    jmp .end;
+
+.end:
+    print res;
+}

--- a/tests/passing/small/peggy_comparison/dead_loop_deletion.bril
+++ b/tests/passing/small/peggy_comparison/dead_loop_deletion.bril
@@ -1,0 +1,20 @@
+@main {
+    j: int = const 3;
+    i: int = const 0;
+    forty: int = const 40;
+    one: int = const 1;
+    
+.loop_test:
+    cond: bool = lt i forty;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    j: int = add j one;
+    i: int = add i one;
+    jmp .loop_test;
+
+.loop_end:
+    j: int = const 2;
+
+    print j;
+}

--- a/tests/passing/small/peggy_comparison/if_true.bril
+++ b/tests/passing/small/peggy_comparison/if_true.bril
@@ -1,0 +1,13 @@
+# ARGS: 20
+@main(x: int) {
+    cond: bool = const true;
+    br cond .thn .els;
+
+.thn:
+    print x;
+
+.els:
+    one: int = const 1;
+    res: int = sub x one;
+    print res;
+}

--- a/tests/passing/small/peggy_comparison/loop_based_code_motion.bril
+++ b/tests/passing/small/peggy_comparison/loop_based_code_motion.bril
@@ -1,0 +1,19 @@
+@main {
+    x: int = const 0;
+    three: int = const 3;
+
+.loop_test:
+    cond: bool = lt x three;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    one: int = const 1;
+    x: int = add x one;
+    jmp .loop_test;
+    
+.loop_end:
+    five: int = const 5;
+    x: int = mul x five;
+
+    print x;
+}

--- a/tests/passing/small/peggy_comparison/loop_invariant_code_motion.bril
+++ b/tests/passing/small/peggy_comparison/loop_invariant_code_motion.bril
@@ -1,0 +1,26 @@
+# ARGS: 30 10
+@main(n: int, m: int) {
+    i: int = const 0;
+    twenty: int = const 20;
+    one: int = const 1;
+
+.loop_test:
+    cond: bool = lt i twenty;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    j: int = mul n twenty;
+    if_cond: bool = lt j m;
+    br if_cond .thn .end_if; 
+
+.thn:
+    j: int = add j one;
+
+.end_if:
+    output: int = mul i j;
+    print output;
+    i: int = add i one;
+    jmp .loop_test;
+
+.loop_end:
+}

--- a/tests/passing/small/peggy_comparison/loop_peeling.bril
+++ b/tests/passing/small/peggy_comparison/loop_peeling.bril
@@ -1,0 +1,19 @@
+# ARGS: 5
+@main(n: int) {
+    x: int = const 0;
+    i: int = const 0;
+
+.loop_test:
+    cond: bool = lt i n;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    five: int = const 5;
+    one: int = const 1;
+    x: int = add x five;
+    i: int = add i one;
+    jmp .loop_test;
+
+.loop_end:
+    print x;
+}

--- a/tests/passing/small/peggy_comparison/loop_strength_reduction.bril
+++ b/tests/passing/small/peggy_comparison/loop_strength_reduction.bril
@@ -1,0 +1,21 @@
+@main {
+    i: int = const 0;
+    d: int = const 0;
+    three_hundred: int = const 300;
+    five: int = const 5;
+    one: int = const 1;
+
+.loop_test:
+    cond: bool = lt d three_hundred;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    out: int = mul i five;
+    print out;
+
+    i: int = add i one;
+    d: int = add d one;
+    jmp .loop_test;
+
+.loop_end:
+}

--- a/tests/passing/small/peggy_comparison/loop_strength_reduction_modified.bril
+++ b/tests/passing/small/peggy_comparison/loop_strength_reduction_modified.bril
@@ -1,0 +1,31 @@
+@main {
+    i: int = const 0;
+    d: int = const 0;
+    three_hundred: int = const 300;
+    three: int = const 3;
+    five: int = const 5;
+    one: int = const 1;
+    one_hundred_fifty: int = const 150;
+
+.loop_test:
+    cond: bool = lt d three_hundred;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    out: int = mul i five;
+    print out;
+
+    i: int = add i one;
+    if_cond: bool = eq d one_hundred_fifty;
+    br if_cond .if_then .end_if;
+
+.if_then:
+    i: int = add i three;
+
+.end_if:
+    d: int = add d one;
+    
+    jmp .loop_test;
+
+.loop_end:
+}

--- a/tests/passing/small/peggy_comparison/loop_unroll.bril
+++ b/tests/passing/small/peggy_comparison/loop_unroll.bril
@@ -1,0 +1,15 @@
+@main {
+    i: int = const 0;
+    one: int = const 1;
+
+.loop_test:
+    cond: bool = lt i one;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    i: int = add one i;
+    jmp .loop_test;
+
+.loop_end:
+    print i;
+}

--- a/tests/passing/small/peggy_comparison/simple_loop_unswitch.bril
+++ b/tests/passing/small/peggy_comparison/simple_loop_unswitch.bril
@@ -1,0 +1,28 @@
+# ARGS: 40
+@main(n: int) {
+    one: int = const 1;
+    zero: int = const 0;
+    i: int = id zero;
+    j: int = id zero;
+
+.loop_test:
+    cond: bool = lt i n;
+    br cond .loop_body .loop_end;
+
+.loop_body:
+    print i;
+
+    cond: bool = lt n zero;
+    br cond .thn .ifend;
+
+.thn:
+    j: int = const 2;
+
+.ifend:
+    j: int = add one j;
+    i: int = add one i;
+    jmp .loop_test;
+
+.loop_end:
+    print j;
+}

--- a/tests/snapshots/files__branch_hoisting-optimize-sequential.snap
+++ b/tests/snapshots/files__branch_hoisting-optimize-sequential.snap
@@ -1,0 +1,64 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 0
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  c3_: int = const 500;
+  v4_: int = id c2_;
+  v5_: int = id c2_;
+  v6_: int = id v0;
+  v7_: int = id c2_;
+  v8_: int = id c3_;
+.b9_:
+  v10_: bool = lt v5_ v8_;
+  v11_: int = id v4_;
+  v12_: int = id v5_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  br v10_ .b16_ .b17_;
+.b16_:
+  v18_: bool = eq v6_ v7_;
+  c19_: int = const 2;
+  br v18_ .b20_ .b21_;
+.b20_:
+  v22_: int = mul c19_ v5_;
+  v23_: int = id v22_;
+  v24_: int = id v5_;
+  v25_: int = id v6_;
+  v26_: int = id v6_;
+  v27_: int = id v8_;
+.b28_:
+  c29_: int = const 1;
+  v30_: int = add c29_ v5_;
+  v11_: int = id v23_;
+  v12_: int = id v30_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  jmp .b9_;
+.b21_:
+  c31_: int = const 3;
+  v32_: int = mul c31_ v5_;
+  v23_: int = id v32_;
+  v24_: int = id v5_;
+  v25_: int = id v6_;
+  v26_: int = id v7_;
+  v27_: int = id v8_;
+  jmp .b28_;
+.b17_:
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  print v4_;
+}

--- a/tests/snapshots/files__branch_hoisting-optimize.snap
+++ b/tests/snapshots/files__branch_hoisting-optimize.snap
@@ -1,0 +1,64 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 0
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  c3_: int = const 500;
+  v4_: int = id c2_;
+  v5_: int = id c2_;
+  v6_: int = id v0;
+  v7_: int = id c2_;
+  v8_: int = id c3_;
+.b9_:
+  v10_: bool = lt v5_ v8_;
+  v11_: int = id v4_;
+  v12_: int = id v5_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  br v10_ .b16_ .b17_;
+.b16_:
+  v18_: bool = eq v6_ v7_;
+  c19_: int = const 2;
+  br v18_ .b20_ .b21_;
+.b20_:
+  v22_: int = mul c19_ v5_;
+  v23_: int = id v22_;
+  v24_: int = id v5_;
+  v25_: int = id v6_;
+  v26_: int = id v6_;
+  v27_: int = id v8_;
+.b28_:
+  c29_: int = const 1;
+  v30_: int = add c29_ v5_;
+  v11_: int = id v23_;
+  v12_: int = id v30_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  jmp .b9_;
+.b21_:
+  c31_: int = const 3;
+  v32_: int = mul c31_ v5_;
+  v23_: int = id v32_;
+  v24_: int = id v5_;
+  v25_: int = id v6_;
+  v26_: int = id v7_;
+  v27_: int = id v8_;
+  jmp .b28_;
+.b17_:
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  print v4_;
+}

--- a/tests/snapshots/files__conditional_constant_folding-optimize-sequential.snap
+++ b/tests/snapshots/files__conditional_constant_folding-optimize-sequential.snap
@@ -1,0 +1,10 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 4
+@main(v0: int) {
+.b1_:
+  c2_: int = const 20;
+  print c2_;
+}

--- a/tests/snapshots/files__conditional_constant_folding-optimize.snap
+++ b/tests/snapshots/files__conditional_constant_folding-optimize.snap
@@ -1,0 +1,10 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 4
+@main(v0: int) {
+.b1_:
+  c2_: int = const 20;
+  print c2_;
+}

--- a/tests/snapshots/files__dead_loop_deletion-optimize-sequential.snap
+++ b/tests/snapshots/files__dead_loop_deletion-optimize-sequential.snap
@@ -1,0 +1,42 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 2;
+  c2_: int = const 3;
+  c3_: int = const 0;
+  c4_: int = const 1;
+  c5_: int = const 40;
+  v6_: int = id c2_;
+  v7_: int = id c3_;
+  v8_: int = id c4_;
+  v9_: int = id c5_;
+.b10_:
+  v11_: bool = lt v7_ v9_;
+  v12_: int = id v6_;
+  v13_: int = id v7_;
+  v14_: int = id v8_;
+  v15_: int = id v9_;
+  br v11_ .b16_ .b17_;
+.b16_:
+  v18_: int = add v6_ v8_;
+  v19_: int = add v7_ v8_;
+  v12_: int = id v18_;
+  v13_: int = id v19_;
+  v14_: int = id v8_;
+  v15_: int = id v9_;
+  v6_: int = id v12_;
+  v7_: int = id v13_;
+  v8_: int = id v14_;
+  v9_: int = id v15_;
+  jmp .b10_;
+.b17_:
+  v6_: int = id v12_;
+  v7_: int = id v13_;
+  v8_: int = id v14_;
+  v9_: int = id v15_;
+  print c1_;
+}

--- a/tests/snapshots/files__dead_loop_deletion-optimize.snap
+++ b/tests/snapshots/files__dead_loop_deletion-optimize.snap
@@ -1,0 +1,42 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 2;
+  c2_: int = const 3;
+  c3_: int = const 0;
+  c4_: int = const 1;
+  c5_: int = const 40;
+  v6_: int = id c2_;
+  v7_: int = id c3_;
+  v8_: int = id c4_;
+  v9_: int = id c5_;
+.b10_:
+  v11_: bool = lt v7_ v9_;
+  v12_: int = id v6_;
+  v13_: int = id v7_;
+  v14_: int = id v8_;
+  v15_: int = id v9_;
+  br v11_ .b16_ .b17_;
+.b16_:
+  v18_: int = add v6_ v8_;
+  v19_: int = add v7_ v8_;
+  v12_: int = id v18_;
+  v13_: int = id v19_;
+  v14_: int = id v8_;
+  v15_: int = id v9_;
+  v6_: int = id v12_;
+  v7_: int = id v13_;
+  v8_: int = id v14_;
+  v9_: int = id v15_;
+  jmp .b10_;
+.b17_:
+  v6_: int = id v12_;
+  v7_: int = id v13_;
+  v8_: int = id v14_;
+  v9_: int = id v15_;
+  print c1_;
+}

--- a/tests/snapshots/files__if_true-optimize-sequential.snap
+++ b/tests/snapshots/files__if_true-optimize-sequential.snap
@@ -1,0 +1,12 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+.b1_:
+  c2_: int = const 1;
+  v3_: int = sub v0 c2_;
+  print v0;
+  print v3_;
+}

--- a/tests/snapshots/files__if_true-optimize.snap
+++ b/tests/snapshots/files__if_true-optimize.snap
@@ -1,0 +1,12 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+.b1_:
+  c2_: int = const 1;
+  v3_: int = sub v0 c2_;
+  print v0;
+  print v3_;
+}

--- a/tests/snapshots/files__loop_based_code_motion-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_based_code_motion-optimize-sequential.snap
@@ -1,0 +1,31 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 3;
+  v3_: int = id c1_;
+  v4_: int = id c2_;
+.b5_:
+  v6_: bool = lt v3_ v4_;
+  v7_: int = id v3_;
+  v8_: int = id v4_;
+  br v6_ .b9_ .b10_;
+.b9_:
+  c11_: int = const 1;
+  v12_: int = add c11_ v3_;
+  v7_: int = id v12_;
+  v8_: int = id v4_;
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  jmp .b5_;
+.b10_:
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  c13_: int = const 5;
+  v14_: int = mul c13_ v3_;
+  print v14_;
+}

--- a/tests/snapshots/files__loop_based_code_motion-optimize.snap
+++ b/tests/snapshots/files__loop_based_code_motion-optimize.snap
@@ -1,0 +1,31 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 3;
+  v3_: int = id c1_;
+  v4_: int = id c2_;
+.b5_:
+  v6_: bool = lt v3_ v4_;
+  v7_: int = id v3_;
+  v8_: int = id v4_;
+  br v6_ .b9_ .b10_;
+.b9_:
+  c11_: int = const 1;
+  v12_: int = add c11_ v3_;
+  v7_: int = id v12_;
+  v8_: int = id v4_;
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  jmp .b5_;
+.b10_:
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  c13_: int = const 5;
+  v14_: int = mul c13_ v3_;
+  print v14_;
+}

--- a/tests/snapshots/files__loop_invariant_code_motion-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_invariant_code_motion-optimize-sequential.snap
@@ -1,0 +1,63 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 30 10
+@main(v0: int, v1: int) {
+.b2_:
+  c3_: int = const 0;
+  c4_: int = const 1;
+  c5_: int = const 20;
+  v6_: int = id c3_;
+  v7_: int = id c4_;
+  v8_: int = id v1;
+  v9_: int = id v0;
+  v10_: int = id c5_;
+.b11_:
+  v12_: bool = lt v6_ v10_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  v17_: int = id v10_;
+  br v12_ .b18_ .b19_;
+.b18_:
+  v20_: int = mul v10_ v9_;
+  v21_: bool = lt v20_ v8_;
+  v22_: int = id v6_;
+  v23_: int = id v7_;
+  v24_: int = id v20_;
+  v25_: int = id v8_;
+  v26_: int = id v9_;
+  v27_: int = id v10_;
+  br v21_ .b28_ .b29_;
+.b28_:
+  v30_: int = add v20_ v7_;
+  v22_: int = id v6_;
+  v23_: int = id v7_;
+  v24_: int = id v30_;
+  v25_: int = id v8_;
+  v26_: int = id v9_;
+  v27_: int = id v10_;
+.b29_:
+  v31_: int = mul v24_ v6_;
+  print v31_;
+  v32_: int = add v6_ v7_;
+  v13_: int = id v32_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  v17_: int = id v10_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+  v10_: int = id v17_;
+  jmp .b11_;
+.b19_:
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+  v10_: int = id v17_;
+}

--- a/tests/snapshots/files__loop_invariant_code_motion-optimize.snap
+++ b/tests/snapshots/files__loop_invariant_code_motion-optimize.snap
@@ -1,0 +1,63 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 30 10
+@main(v0: int, v1: int) {
+.b2_:
+  c3_: int = const 0;
+  c4_: int = const 1;
+  c5_: int = const 20;
+  v6_: int = id c3_;
+  v7_: int = id c4_;
+  v8_: int = id v1;
+  v9_: int = id v0;
+  v10_: int = id c5_;
+.b11_:
+  v12_: bool = lt v6_ v10_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  v17_: int = id v10_;
+  br v12_ .b18_ .b19_;
+.b18_:
+  v20_: int = mul v10_ v9_;
+  v21_: bool = lt v20_ v8_;
+  v22_: int = id v6_;
+  v23_: int = id v7_;
+  v24_: int = id v20_;
+  v25_: int = id v8_;
+  v26_: int = id v9_;
+  v27_: int = id v10_;
+  br v21_ .b28_ .b29_;
+.b28_:
+  v30_: int = add v20_ v7_;
+  v22_: int = id v6_;
+  v23_: int = id v7_;
+  v24_: int = id v30_;
+  v25_: int = id v8_;
+  v26_: int = id v9_;
+  v27_: int = id v10_;
+.b29_:
+  v31_: int = mul v24_ v6_;
+  print v31_;
+  v32_: int = add v6_ v7_;
+  v13_: int = id v32_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  v17_: int = id v10_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+  v10_: int = id v17_;
+  jmp .b11_;
+.b19_:
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+  v10_: int = id v17_;
+}

--- a/tests/snapshots/files__loop_peeling-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_peeling-optimize-sequential.snap
@@ -1,0 +1,35 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 5
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  v3_: int = id c2_;
+  v4_: int = id c2_;
+  v5_: int = id v0;
+.b6_:
+  v7_: bool = lt v4_ v5_;
+  v8_: int = id v3_;
+  v9_: int = id v4_;
+  v10_: int = id v5_;
+  br v7_ .b11_ .b12_;
+.b11_:
+  c13_: int = const 5;
+  v14_: int = add c13_ v3_;
+  c15_: int = const 1;
+  v16_: int = add c15_ v4_;
+  v8_: int = id v14_;
+  v9_: int = id v16_;
+  v10_: int = id v5_;
+  v3_: int = id v8_;
+  v4_: int = id v9_;
+  v5_: int = id v10_;
+  jmp .b6_;
+.b12_:
+  v3_: int = id v8_;
+  v4_: int = id v9_;
+  v5_: int = id v10_;
+  print v3_;
+}

--- a/tests/snapshots/files__loop_peeling-optimize.snap
+++ b/tests/snapshots/files__loop_peeling-optimize.snap
@@ -1,0 +1,35 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 5
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  v3_: int = id c2_;
+  v4_: int = id c2_;
+  v5_: int = id v0;
+.b6_:
+  v7_: bool = lt v4_ v5_;
+  v8_: int = id v3_;
+  v9_: int = id v4_;
+  v10_: int = id v5_;
+  br v7_ .b11_ .b12_;
+.b11_:
+  c13_: int = const 5;
+  v14_: int = add c13_ v3_;
+  c15_: int = const 1;
+  v16_: int = add c15_ v4_;
+  v8_: int = id v14_;
+  v9_: int = id v16_;
+  v10_: int = id v5_;
+  v3_: int = id v8_;
+  v4_: int = id v9_;
+  v5_: int = id v10_;
+  jmp .b6_;
+.b12_:
+  v3_: int = id v8_;
+  v4_: int = id v9_;
+  v5_: int = id v10_;
+  print v3_;
+}

--- a/tests/snapshots/files__loop_strength_reduction-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_strength_reduction-optimize-sequential.snap
@@ -1,0 +1,47 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 1;
+  c3_: int = const 5;
+  c4_: int = const 300;
+  v5_: int = id c1_;
+  v6_: int = id c2_;
+  v7_: int = id c1_;
+  v8_: int = id c3_;
+  v9_: int = id c4_;
+.b10_:
+  v11_: bool = lt v5_ v9_;
+  v12_: int = id v5_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  br v11_ .b17_ .b18_;
+.b17_:
+  v19_: int = mul v7_ v8_;
+  print v19_;
+  v20_: int = add v5_ v6_;
+  v21_: int = add v6_ v7_;
+  v12_: int = id v20_;
+  v13_: int = id v6_;
+  v14_: int = id v21_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+  jmp .b10_;
+.b18_:
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+}

--- a/tests/snapshots/files__loop_strength_reduction-optimize.snap
+++ b/tests/snapshots/files__loop_strength_reduction-optimize.snap
@@ -1,0 +1,47 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 1;
+  c3_: int = const 5;
+  c4_: int = const 300;
+  v5_: int = id c1_;
+  v6_: int = id c2_;
+  v7_: int = id c1_;
+  v8_: int = id c3_;
+  v9_: int = id c4_;
+.b10_:
+  v11_: bool = lt v5_ v9_;
+  v12_: int = id v5_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  br v11_ .b17_ .b18_;
+.b17_:
+  v19_: int = mul v7_ v8_;
+  print v19_;
+  v20_: int = add v5_ v6_;
+  v21_: int = add v6_ v7_;
+  v12_: int = id v20_;
+  v13_: int = id v6_;
+  v14_: int = id v21_;
+  v15_: int = id v8_;
+  v16_: int = id v9_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+  jmp .b10_;
+.b18_:
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  v9_: int = id v16_;
+}

--- a/tests/snapshots/files__loop_strength_reduction_modified-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_strength_reduction_modified-optimize-sequential.snap
@@ -1,0 +1,94 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 1;
+  c3_: int = const 3;
+  c4_: int = const 150;
+  c5_: int = const 5;
+  c6_: int = const 300;
+  v7_: int = id c1_;
+  v8_: int = id c2_;
+  v9_: int = id c1_;
+  v10_: int = id c3_;
+  v11_: int = id c4_;
+  v12_: int = id c5_;
+  v13_: int = id c6_;
+.b14_:
+  v15_: bool = lt v7_ v13_;
+  v16_: int = id v7_;
+  v17_: int = id v8_;
+  v18_: int = id v9_;
+  v19_: int = id v10_;
+  v20_: int = id v11_;
+  v21_: int = id v12_;
+  v22_: int = id v13_;
+  br v15_ .b23_ .b24_;
+.b23_:
+  v25_: int = mul v12_ v9_;
+  print v25_;
+  v26_: int = add v7_ v8_;
+  v27_: bool = eq v11_ v7_;
+  v28_: int = add v8_ v9_;
+  v29_: int = id v7_;
+  v30_: int = id v8_;
+  v31_: int = id v28_;
+  v32_: int = id v10_;
+  v33_: int = id v11_;
+  v34_: int = id v12_;
+  v35_: int = id v13_;
+  br v27_ .b36_ .b37_;
+.b36_:
+  v38_: int = add v10_ v28_;
+  v29_: int = id v7_;
+  v30_: int = id v8_;
+  v31_: int = id v38_;
+  v32_: int = id v10_;
+  v33_: int = id v7_;
+  v34_: int = id v12_;
+  v35_: int = id v13_;
+  v16_: int = id v26_;
+  v17_: int = id v8_;
+  v18_: int = id v31_;
+  v19_: int = id v10_;
+  v20_: int = id v11_;
+  v21_: int = id v12_;
+  v22_: int = id v13_;
+  v7_: int = id v16_;
+  v8_: int = id v17_;
+  v9_: int = id v18_;
+  v10_: int = id v19_;
+  v11_: int = id v20_;
+  v12_: int = id v21_;
+  v13_: int = id v22_;
+  br v15_ .b14_ .b39_;
+.b37_:
+  v16_: int = id v26_;
+  v17_: int = id v8_;
+  v18_: int = id v31_;
+  v19_: int = id v10_;
+  v20_: int = id v11_;
+  v21_: int = id v12_;
+  v22_: int = id v13_;
+  v7_: int = id v16_;
+  v8_: int = id v17_;
+  v9_: int = id v18_;
+  v10_: int = id v19_;
+  v11_: int = id v20_;
+  v12_: int = id v21_;
+  v13_: int = id v22_;
+  jmp .b14_;
+.b24_:
+  v7_: int = id v16_;
+  v8_: int = id v17_;
+  v9_: int = id v18_;
+  v10_: int = id v19_;
+  v11_: int = id v20_;
+  v12_: int = id v21_;
+  v13_: int = id v22_;
+.b39_:
+}

--- a/tests/snapshots/files__loop_strength_reduction_modified-optimize.snap
+++ b/tests/snapshots/files__loop_strength_reduction_modified-optimize.snap
@@ -1,0 +1,94 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 1;
+  c3_: int = const 3;
+  c4_: int = const 150;
+  c5_: int = const 5;
+  c6_: int = const 300;
+  v7_: int = id c1_;
+  v8_: int = id c2_;
+  v9_: int = id c1_;
+  v10_: int = id c3_;
+  v11_: int = id c4_;
+  v12_: int = id c5_;
+  v13_: int = id c6_;
+.b14_:
+  v15_: bool = lt v7_ v13_;
+  v16_: int = id v7_;
+  v17_: int = id v8_;
+  v18_: int = id v9_;
+  v19_: int = id v10_;
+  v20_: int = id v11_;
+  v21_: int = id v12_;
+  v22_: int = id v13_;
+  br v15_ .b23_ .b24_;
+.b23_:
+  v25_: int = mul v12_ v9_;
+  print v25_;
+  v26_: int = add v7_ v8_;
+  v27_: bool = eq v11_ v7_;
+  v28_: int = add v8_ v9_;
+  v29_: int = id v7_;
+  v30_: int = id v8_;
+  v31_: int = id v28_;
+  v32_: int = id v10_;
+  v33_: int = id v11_;
+  v34_: int = id v12_;
+  v35_: int = id v13_;
+  br v27_ .b36_ .b37_;
+.b36_:
+  v38_: int = add v10_ v28_;
+  v29_: int = id v7_;
+  v30_: int = id v8_;
+  v31_: int = id v38_;
+  v32_: int = id v10_;
+  v33_: int = id v7_;
+  v34_: int = id v12_;
+  v35_: int = id v13_;
+  v16_: int = id v26_;
+  v17_: int = id v8_;
+  v18_: int = id v31_;
+  v19_: int = id v10_;
+  v20_: int = id v11_;
+  v21_: int = id v12_;
+  v22_: int = id v13_;
+  v7_: int = id v16_;
+  v8_: int = id v17_;
+  v9_: int = id v18_;
+  v10_: int = id v19_;
+  v11_: int = id v20_;
+  v12_: int = id v21_;
+  v13_: int = id v22_;
+  br v15_ .b14_ .b39_;
+.b37_:
+  v16_: int = id v26_;
+  v17_: int = id v8_;
+  v18_: int = id v31_;
+  v19_: int = id v10_;
+  v20_: int = id v11_;
+  v21_: int = id v12_;
+  v22_: int = id v13_;
+  v7_: int = id v16_;
+  v8_: int = id v17_;
+  v9_: int = id v18_;
+  v10_: int = id v19_;
+  v11_: int = id v20_;
+  v12_: int = id v21_;
+  v13_: int = id v22_;
+  jmp .b14_;
+.b24_:
+  v7_: int = id v16_;
+  v8_: int = id v17_;
+  v9_: int = id v18_;
+  v10_: int = id v19_;
+  v11_: int = id v20_;
+  v12_: int = id v21_;
+  v13_: int = id v22_;
+.b39_:
+}

--- a/tests/snapshots/files__loop_unroll-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_unroll-optimize-sequential.snap
@@ -1,0 +1,28 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 1;
+  v3_: int = id c1_;
+  v4_: int = id c2_;
+.b5_:
+  v6_: bool = lt v3_ v4_;
+  v7_: int = id v3_;
+  v8_: int = id v4_;
+  br v6_ .b9_ .b10_;
+.b9_:
+  v11_: int = add v3_ v4_;
+  v7_: int = id v11_;
+  v8_: int = id v4_;
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  jmp .b5_;
+.b10_:
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  print v3_;
+}

--- a/tests/snapshots/files__loop_unroll-optimize.snap
+++ b/tests/snapshots/files__loop_unroll-optimize.snap
@@ -1,0 +1,28 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@main {
+.b0_:
+  c1_: int = const 0;
+  c2_: int = const 1;
+  v3_: int = id c1_;
+  v4_: int = id c2_;
+.b5_:
+  v6_: bool = lt v3_ v4_;
+  v7_: int = id v3_;
+  v8_: int = id v4_;
+  br v6_ .b9_ .b10_;
+.b9_:
+  v11_: int = add v3_ v4_;
+  v7_: int = id v11_;
+  v8_: int = id v4_;
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  jmp .b5_;
+.b10_:
+  v3_: int = id v7_;
+  v4_: int = id v8_;
+  print v3_;
+}

--- a/tests/snapshots/files__simple_loop_unswitch-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_loop_unswitch-optimize-sequential.snap
@@ -1,0 +1,60 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 40
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  c3_: int = const 1;
+  v4_: int = id c2_;
+  v5_: int = id c2_;
+  v6_: int = id c3_;
+  v7_: int = id v0;
+  v8_: int = id c2_;
+.b9_:
+  v10_: bool = lt v5_ v7_;
+  v11_: int = id v4_;
+  v12_: int = id v5_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  br v10_ .b16_ .b17_;
+.b16_:
+  print v5_;
+  v18_: bool = lt v7_ v8_;
+  v19_: int = id v4_;
+  v20_: int = id v5_;
+  v21_: int = id v6_;
+  v22_: int = id v7_;
+  v23_: int = id v8_;
+  br v18_ .b24_ .b25_;
+.b24_:
+  c26_: int = const 2;
+  v19_: int = id c26_;
+  v20_: int = id v5_;
+  v21_: int = id v6_;
+  v22_: int = id v7_;
+  v23_: int = id v8_;
+.b25_:
+  v27_: int = add v19_ v6_;
+  v28_: int = add v5_ v6_;
+  v11_: int = id v27_;
+  v12_: int = id v28_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  jmp .b9_;
+.b17_:
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  print v4_;
+}

--- a/tests/snapshots/files__simple_loop_unswitch-optimize.snap
+++ b/tests/snapshots/files__simple_loop_unswitch-optimize.snap
@@ -1,0 +1,60 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 40
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  c3_: int = const 1;
+  v4_: int = id c2_;
+  v5_: int = id c2_;
+  v6_: int = id c3_;
+  v7_: int = id v0;
+  v8_: int = id c2_;
+.b9_:
+  v10_: bool = lt v5_ v7_;
+  v11_: int = id v4_;
+  v12_: int = id v5_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  br v10_ .b16_ .b17_;
+.b16_:
+  print v5_;
+  v18_: bool = lt v7_ v8_;
+  v19_: int = id v4_;
+  v20_: int = id v5_;
+  v21_: int = id v6_;
+  v22_: int = id v7_;
+  v23_: int = id v8_;
+  br v18_ .b24_ .b25_;
+.b24_:
+  c26_: int = const 2;
+  v19_: int = id c26_;
+  v20_: int = id v5_;
+  v21_: int = id v6_;
+  v22_: int = id v7_;
+  v23_: int = id v8_;
+.b25_:
+  v27_: int = add v19_ v6_;
+  v28_: int = add v5_ v6_;
+  v11_: int = id v27_;
+  v12_: int = id v28_;
+  v13_: int = id v6_;
+  v14_: int = id v7_;
+  v15_: int = id v8_;
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  jmp .b9_;
+.b17_:
+  v4_: int = id v11_;
+  v5_: int = id v12_;
+  v6_: int = id v13_;
+  v7_: int = id v14_;
+  v8_: int = id v15_;
+  print v4_;
+}


### PR DESCRIPTION
Each of these files corresponds to an equivalent Java file for the peggy comparison.
`infinite_loop.bril` is in `failing` because we shouldn't execute an infinite loop, but the optimized result is correct.