### PR TITLE
Better select rule

### DIFF
--- a/dag_in_context/src/optimizations/switch_rewrites.egg
+++ b/dag_in_context/src/optimizations/switch_rewrites.egg
@@ -31,76 +31,24 @@
       ((union (Get if_e k) (Bop (Smax) a b)))
       :ruleset switch_rewrite) 
 
-; if pred then a else b ~~> (select pred a b)
-; where a and b are inputs to the region
-(rule (
-       (= if_e (If pred inputs thn els))
-       (= a (Get inputs i))
-       (= b (Get inputs j))
+(rule
+       (
+        (= if_e (If pred inputs thn els))
+        (ContextOf if_e ctx)
 
-       ; if pred then a else b
-       (= (Get thn k) (Get (Arg ty (InIf true pred inputs)) i))
-       (= (Get els k) (Get (Arg ty (InIf false pred inputs)) j))
-
-       ; If i = j, then the arg is just passed through the if, and we
-       ; don't need a select. This will get handled by the passthrough rules.
-       (!= i j)
+        (= thn_out (Get thn i))
+        (= els_out (Get els i))
+        (ExprIsPure thn_out)
+        (ExprIsPure els_out)
+        
+        (> 10 (Expr-size thn_out)) ; TODO: Tune these size limits
+        (> 10 (Expr-size els_out))
        )
        (
-       (union (Get if_e k) (Top (Select) pred a b))
-       )
-       :ruleset switch_rewrite)
-
-(rule (
-       (= if_e (If pred inputs thn els))
-       (ContextOf if_e ctx)
-       (HasArgType if_e ty)
-       (= (Get thn i) (Const x _ty (InIf true pred inputs)))
-       (= (Get els i) (Const y _ty (InIf false pred inputs)))
-      )
-      ((union (Get if_e i) (Top (Select) pred (Const x ty ctx) (Const y ty ctx))))
-      :ruleset switch_rewrite)
-
-; if pred then A else Const -> select pred A Const
-; where A is an input to the region
-(rule (
-       (= if_e (If pred inputs thn els))
-       (ContextOf if_e ctx)
-       (HasArgType if_e ty)
-
-       ; input to the if
-       (= a (Get inputs i))
-       (= (Get thn k) (Get (Arg _ty (InIf true pred inputs)) i))
-
-       (= els_out (Get els k))
-       (= (IntB y) (lo-bound els_out))
-       (= (IntB y) (hi-bound els_out))
-       )
-       (
-       (union (Get if_e k) (Top (Select) pred a (Const (Int y) ty ctx)))
+        (union (Get if_e i)
+               (Top (Select) pred (Subst ctx inputs thn_out) (Subst ctx inputs els_out)))
        )
        :ruleset switch_rewrite
-)
-
-; if pred then Const else B -> select pred Const B
-; where B is an input to the region
-(rule (
-       (= if_e (If pred inputs thn els))
-       (ContextOf if_e ctx)
-       (HasArgType if_e ty)
-
-       (= thn_out (Get thn k))
-       (= (IntB y) (lo-bound thn_out))
-       (= (IntB y) (hi-bound thn_out))
-
-       ; input to the if
-       (= b (Get inputs i))
-       (= (Get els k) (Get (Arg _ty (InIf false pred inputs)) i))
-      )
-      (
-       (union (Get if_e k) (Top (Select) pred (Const (Int y) ty ctx) b))
-      )
-      :ruleset switch_rewrite
 )
 
 ; if (a and b) X Y ~~> if a (if b X Y) Y

--- a/tests/passing/small/select_simple.rs
+++ b/tests/passing/small/select_simple.rs
@@ -1,10 +1,33 @@
 // ARGS: 20 30
 fn main(x: i64, y: i64) {
     let res: i64 = 0;
+    // if P then A else B where A and B are inputs to the region
     if (x * y < 20) {
         res = x;
     } else {
         res = y;
+    }
+    println!("{}", res);
+
+    // if P then C1 else C2
+    if (x * y > 10) {
+        res = 4;
+    } else {
+        res = 5;
+    }
+    println!("{}", res);
+
+    // if P then C1 (and implicitly, the else is a passthrough)
+    if (x * y > 20) {
+        res = 10;
+    }
+    println!("{}", res);
+
+    // if P then X else Y where X and Y are small, pure expressions
+    if (x * y == 40) {
+        res = x * 2;
+    } else {
+        res = x + 5;
     }
     println!("{}", res);
 }

--- a/tests/snapshots/files__block-diamond-optimize-sequential.snap
+++ b/tests/snapshots/files__block-diamond-optimize-sequential.snap
@@ -8,31 +8,11 @@ expression: visualization.result
   c2_: int = const 1;
   c3_: int = const 2;
   v4_: bool = lt v0 c3_;
-  c5_: int = const 0;
-  c6_: int = const 5;
-  v7_: int = id c2_;
-  v8_: int = id c2_;
-  v9_: int = id c3_;
-  br v4_ .b10_ .b11_;
-.b10_:
-  c12_: int = const 4;
-  v7_: int = id c12_;
-  v8_: int = id c2_;
-  v9_: int = id c3_;
-  v13_: int = id v7_;
-  v14_: int = id v8_;
-  v15_: int = add c2_ v13_;
-  print v15_;
+  c5_: int = const 4;
+  v6_: int = select v4_ c5_ c2_;
+  v7_: int = add c3_ v6_;
+  v8_: int = select v4_ v6_ v7_;
+  v9_: int = add c2_ v8_;
+  print v9_;
   ret;
-  jmp .b16_;
-.b11_:
-  v13_: int = id v7_;
-  v14_: int = id v8_;
-  v17_: int = add v7_ v9_;
-  v13_: int = id v17_;
-  v14_: int = id v8_;
-  v15_: int = add c2_ v13_;
-  print v15_;
-  ret;
-.b16_:
 }

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -5,25 +5,14 @@ expression: visualization.result
 # ARGS: 1
 @main(v0: int) {
 .b1_:
-  c2_: int = const 1;
-  c3_: int = const 2;
-  v4_: bool = lt v0 c3_;
-  c5_: int = const 4;
-  v6_: int = select v4_ c5_ c2_;
-  v7_: int = id v6_;
-  v8_: int = id c2_;
-  br v4_ .b9_ .b10_;
-.b9_:
-  v11_: int = add c2_ v7_;
-  print v11_;
+  c2_: int = const 2;
+  v3_: bool = lt v0 c2_;
+  c4_: int = const 4;
+  c5_: int = const 1;
+  v6_: int = select v3_ c4_ c5_;
+  v7_: int = add c2_ v6_;
+  v8_: int = select v3_ v6_ v7_;
+  v9_: int = add c5_ v8_;
+  print v9_;
   ret;
-  jmp .b12_;
-.b10_:
-  v13_: int = add c3_ v6_;
-  v7_: int = id v13_;
-  v8_: int = id c2_;
-  v11_: int = add c2_ v7_;
-  print v11_;
-  ret;
-.b12_:
 }

--- a/tests/snapshots/files__branch_duplicate_work-optimize-sequential.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize-sequential.snap
@@ -7,18 +7,9 @@ expression: visualization.result
 .b1_:
   c2_: int = const 2;
   v3_: bool = lt v0 c2_;
-  br v3_ .b4_ .b5_;
-.b4_:
-  v6_: int = add v0 v0;
-  v7_: int = id v6_;
-  print v7_;
+  v4_: int = add v0 v0;
+  v5_: int = mul c2_ v4_;
+  v6_: int = select v3_ v4_ v5_;
+  print v6_;
   ret;
-  jmp .b8_;
-.b5_:
-  v9_: int = add v0 v0;
-  v10_: int = mul c2_ v9_;
-  v7_: int = id v10_;
-  print v7_;
-  ret;
-.b8_:
 }

--- a/tests/snapshots/files__branch_duplicate_work-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-optimize.snap
@@ -7,18 +7,9 @@ expression: visualization.result
 .b1_:
   c2_: int = const 2;
   v3_: bool = lt v0 c2_;
-  br v3_ .b4_ .b5_;
-.b4_:
-  v6_: int = add v0 v0;
-  v7_: int = id v6_;
-  print v7_;
+  v4_: int = add v0 v0;
+  v5_: int = mul c2_ v4_;
+  v6_: int = select v3_ v4_ v5_;
+  print v6_;
   ret;
-  jmp .b8_;
-.b5_:
-  v9_: int = add v0 v0;
-  v10_: int = mul c2_ v9_;
-  v7_: int = id v10_;
-  print v7_;
-  ret;
-.b8_:
 }

--- a/tests/snapshots/files__branch_hoisting-optimize-sequential.snap
+++ b/tests/snapshots/files__branch_hoisting-optimize-sequential.snap
@@ -23,19 +23,14 @@ expression: visualization.result
 .b16_:
   v18_: bool = eq v6_ v7_;
   c19_: int = const 2;
-  br v18_ .b20_ .b21_;
-.b20_:
-  v22_: int = mul c19_ v5_;
-  v23_: int = id v22_;
-  v24_: int = id v5_;
-  v25_: int = id v6_;
-  v26_: int = id v6_;
-  v27_: int = id v8_;
-.b28_:
-  c29_: int = const 1;
-  v30_: int = add c29_ v5_;
+  v20_: int = mul c19_ v5_;
+  c21_: int = const 3;
+  v22_: int = mul c21_ v5_;
+  v23_: int = select v18_ v20_ v22_;
+  c24_: int = const 1;
+  v25_: int = add c24_ v5_;
   v11_: int = id v23_;
-  v12_: int = id v30_;
+  v12_: int = id v25_;
   v13_: int = id v6_;
   v14_: int = id v7_;
   v15_: int = id v8_;
@@ -45,15 +40,6 @@ expression: visualization.result
   v7_: int = id v14_;
   v8_: int = id v15_;
   jmp .b9_;
-.b21_:
-  c31_: int = const 3;
-  v32_: int = mul c31_ v5_;
-  v23_: int = id v32_;
-  v24_: int = id v5_;
-  v25_: int = id v6_;
-  v26_: int = id v7_;
-  v27_: int = id v8_;
-  jmp .b28_;
 .b17_:
   v4_: int = id v11_;
   v5_: int = id v12_;
@@ -61,4 +47,5 @@ expression: visualization.result
   v7_: int = id v14_;
   v8_: int = id v15_;
   print v4_;
+  ret;
 }

--- a/tests/snapshots/files__collatz_redundant_computation-optimize-sequential.snap
+++ b/tests/snapshots/files__collatz_redundant_computation-optimize-sequential.snap
@@ -32,48 +32,23 @@ expression: visualization.result
   v25_: bool = eq v11_ v24_;
   v26_: int = mul v7_ v9_;
   v27_: int = add v26_ v8_;
-  c28_: bool = const true;
-  v29_: int = id v6_;
-  v30_: bool = id c28_;
-  v31_: int = id v27_;
-  v32_: int = id v8_;
-  v33_: int = id v9_;
-  v34_: int = id v10_;
-  v35_: int = id v11_;
-  br v25_ .b36_ .b37_;
-.b36_:
-  c38_: bool = const true;
-  v29_: int = id v6_;
-  v30_: bool = id c38_;
-  v31_: int = id v22_;
-  v32_: int = id v8_;
-  v33_: int = id v9_;
-  v34_: int = id v10_;
-  v35_: int = id v11_;
+  v28_: int = select v25_ v22_ v27_;
   v14_: int = id v6_;
-  v15_: int = id v31_;
+  v15_: int = id v28_;
   v16_: int = id v8_;
   v17_: int = id v9_;
   v18_: int = id v10_;
   v19_: int = id v11_;
 .b20_:
-  v39_: bool = not v13_;
+  v29_: bool = not v13_;
   v6_: int = id v14_;
   v7_: int = id v15_;
   v8_: int = id v16_;
   v9_: int = id v17_;
   v10_: int = id v18_;
   v11_: int = id v19_;
-  br v39_ .b12_ .b40_;
-.b37_:
-  v14_: int = id v6_;
-  v15_: int = id v31_;
-  v16_: int = id v8_;
-  v17_: int = id v9_;
-  v18_: int = id v10_;
-  v19_: int = id v11_;
-  jmp .b20_;
-.b40_:
+  br v29_ .b12_ .b30_;
+.b30_:
   print v0;
   ret;
 }

--- a/tests/snapshots/files__conditional_constant_folding-optimize-sequential.snap
+++ b/tests/snapshots/files__conditional_constant_folding-optimize-sequential.snap
@@ -7,4 +7,5 @@ expression: visualization.result
 .b1_:
   c2_: int = const 20;
   print c2_;
+  ret;
 }

--- a/tests/snapshots/files__conditional_constant_folding-optimize.snap
+++ b/tests/snapshots/files__conditional_constant_folding-optimize.snap
@@ -7,4 +7,5 @@ expression: visualization.result
 .b1_:
   c2_: int = const 20;
   print c2_;
+  ret;
 }

--- a/tests/snapshots/files__dead_loop_deletion-optimize-sequential.snap
+++ b/tests/snapshots/files__dead_loop_deletion-optimize-sequential.snap
@@ -39,4 +39,5 @@ expression: visualization.result
   v8_: int = id v14_;
   v9_: int = id v15_;
   print c1_;
+  ret;
 }

--- a/tests/snapshots/files__dead_loop_deletion-optimize.snap
+++ b/tests/snapshots/files__dead_loop_deletion-optimize.snap
@@ -16,27 +16,16 @@ expression: visualization.result
   v9_: int = id c5_;
 .b10_:
   v11_: bool = lt v7_ v9_;
-  v12_: int = id v6_;
-  v13_: int = id v7_;
-  v14_: int = id v8_;
-  v15_: int = id v9_;
-  br v11_ .b16_ .b17_;
+  v12_: int = add v6_ v8_;
+  v13_: int = select v11_ v12_ v6_;
+  v14_: int = add v7_ v8_;
+  v15_: int = select v11_ v14_ v7_;
+  v6_: int = id v13_;
+  v7_: int = id v15_;
+  v8_: int = id v8_;
+  v9_: int = id v9_;
+  br v11_ .b10_ .b16_;
 .b16_:
-  v18_: int = add v6_ v8_;
-  v19_: int = add v7_ v8_;
-  v12_: int = id v18_;
-  v13_: int = id v19_;
-  v14_: int = id v8_;
-  v15_: int = id v9_;
-  v6_: int = id v12_;
-  v7_: int = id v13_;
-  v8_: int = id v14_;
-  v9_: int = id v15_;
-  jmp .b10_;
-.b17_:
-  v6_: int = id v12_;
-  v7_: int = id v13_;
-  v8_: int = id v14_;
-  v9_: int = id v15_;
   print c1_;
+  ret;
 }

--- a/tests/snapshots/files__fib_shape-optimize.snap
+++ b/tests/snapshots/files__fib_shape-optimize.snap
@@ -12,23 +12,13 @@ expression: visualization.result
   v6_: int = id v0;
 .b7_:
   v8_: bool = lt v4_ v6_;
-  v9_: int = id v4_;
-  v10_: int = id v5_;
-  v11_: int = id v6_;
-  br v8_ .b12_ .b13_;
-.b12_:
-  v14_: int = add v4_ v5_;
-  v9_: int = id v14_;
-  v10_: int = id v5_;
-  v11_: int = id v6_;
-  v4_: int = id v9_;
-  v5_: int = id v10_;
-  v6_: int = id v11_;
-  jmp .b7_;
-.b13_:
-  v4_: int = id v9_;
-  v5_: int = id v10_;
-  v6_: int = id v11_;
+  v9_: int = add v4_ v5_;
+  v10_: int = select v8_ v9_ v4_;
+  v4_: int = id v10_;
+  v5_: int = id v5_;
+  v6_: int = id v6_;
+  br v8_ .b7_ .b11_;
+.b11_:
   print v4_;
   ret;
 }

--- a/tests/snapshots/files__gamma_condition_and-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-optimize.snap
@@ -10,25 +10,8 @@ expression: visualization.result
   v4_: bool = lt c2_ v0;
   c5_: int = const 1;
   c6_: int = const 3;
-  v7_: int = id c6_;
-  br v3_ .b8_ .b9_;
-.b8_:
-  c10_: int = const 3;
-  v11_: int = id c10_;
-  br v4_ .b12_ .b13_;
-.b12_:
-  v11_: int = id c5_;
-  v7_: int = id v11_;
-  print v7_;
+  v7_: int = select v4_ c5_ c6_;
+  v8_: int = select v3_ v7_ c6_;
+  print v8_;
   ret;
-  jmp .b14_;
-.b13_:
-  v7_: int = id v11_;
-  print v7_;
-  ret;
-  jmp .b14_;
-.b9_:
-  print v7_;
-  ret;
-.b14_:
 }

--- a/tests/snapshots/files__gamma_pull_in-optimize-sequential.snap
+++ b/tests/snapshots/files__gamma_pull_in-optimize-sequential.snap
@@ -7,19 +7,10 @@ expression: visualization.result
 .b1_:
   c2_: int = const 10;
   v3_: bool = lt v0 c2_;
-  c4_: int = const 3;
-  v5_: int = id c4_;
-  br v3_ .b6_ .b7_;
-.b6_:
-  c8_: int = const 2;
-  v5_: int = id c8_;
-  v9_: int = add v5_ v5_;
-  print v9_;
+  c4_: int = const 2;
+  c5_: int = const 3;
+  v6_: int = select v3_ c4_ c5_;
+  v7_: int = add v6_ v6_;
+  print v7_;
   ret;
-  jmp .b10_;
-.b7_:
-  v9_: int = add v5_ v5_;
-  print v9_;
-  ret;
-.b10_:
 }

--- a/tests/snapshots/files__if_dead_code-optimize-sequential.snap
+++ b/tests/snapshots/files__if_dead_code-optimize-sequential.snap
@@ -7,19 +7,9 @@ expression: visualization.result
 .b1_:
   c2_: int = const 0;
   v3_: bool = lt v0 c2_;
-  c4_: int = const 0;
-  v5_: int = id c4_;
-  br v3_ .b6_ .b7_;
-.b6_:
-  c8_: int = const 1;
-  v5_: int = id c8_;
+  c4_: int = const 1;
+  v5_: int = select v3_ c4_ c2_;
   print v5_;
   print v3_;
   ret;
-  jmp .b9_;
-.b7_:
-  print v5_;
-  print v3_;
-  ret;
-.b9_:
 }

--- a/tests/snapshots/files__if_dead_code_nested-optimize-sequential.snap
+++ b/tests/snapshots/files__if_dead_code_nested-optimize-sequential.snap
@@ -13,79 +13,67 @@ expression: visualization.result
   br v3_ .b7_ .b8_;
 .b7_:
   v9_: bool = lt v0 c4_;
-  c10_: bool = const true;
-  c11_: int = const 1;
-  c12_: int = const 2;
-  v13_: int = id c12_;
-  v14_: bool = id c10_;
-  v15_: int = id c11_;
-  br v9_ .b16_ .b17_;
-.b16_:
-  v13_: int = id c11_;
-  v14_: bool = id c10_;
-  v15_: int = id c11_;
-  v18_: int = id v13_;
-  v19_: int = id c11_;
-  print v19_;
+  c10_: int = const 1;
+  c11_: int = const 2;
+  v12_: int = select v9_ c10_ c11_;
+  v13_: int = id v12_;
+  v14_: int = id c10_;
+  v15_: int = select v3_ c2_ c4_;
+  print v15_;
   print v3_;
-  print v18_;
+  print v13_;
   ret;
-  jmp .b20_;
-.b17_:
-  v18_: int = id v13_;
-  v19_: int = id c11_;
-  print v19_;
-  print v3_;
-  print v18_;
-  ret;
-  jmp .b20_;
+  jmp .b16_;
 .b8_:
-  v21_: bool = gt v0 c6_;
-  c22_: bool = const false;
-  c23_: int = const 2;
-  v24_: int = id c23_;
-  v25_: bool = id c22_;
-  v26_: int = id c4_;
-  br v21_ .b27_ .b28_;
-.b27_:
-  v29_: bool = gt v0 c5_;
-  c30_: int = const 4;
-  v31_: int = id c30_;
-  v32_: bool = id c22_;
-  v33_: int = id c4_;
-  br v29_ .b34_ .b35_;
-.b34_:
-  c36_: int = const 3;
-  v31_: int = id c36_;
-  v32_: bool = id c22_;
-  v33_: int = id c4_;
-  v24_: int = id v31_;
-  v25_: bool = id v32_;
-  v26_: int = id v33_;
-  v18_: int = id v24_;
-  v19_: int = id c4_;
-  print v19_;
+  v17_: bool = gt v0 c6_;
+  c18_: bool = const false;
+  c19_: int = const 2;
+  v20_: int = id c19_;
+  v21_: bool = id c18_;
+  v22_: int = id c4_;
+  br v17_ .b23_ .b24_;
+.b23_:
+  v25_: bool = gt v0 c5_;
+  c26_: int = const 4;
+  v27_: int = id c26_;
+  v28_: bool = id c18_;
+  v29_: int = id c4_;
+  br v25_ .b30_ .b31_;
+.b30_:
+  c32_: int = const 3;
+  v27_: int = id c32_;
+  v28_: bool = id c18_;
+  v29_: int = id c4_;
+  v20_: int = id v27_;
+  v21_: bool = id v28_;
+  v22_: int = id v29_;
+  v13_: int = id v20_;
+  v14_: int = id c4_;
+  v15_: int = select v3_ c2_ c4_;
+  print v15_;
   print v3_;
-  print v18_;
+  print v13_;
   ret;
-  jmp .b20_;
-.b35_:
-  v24_: int = id v31_;
-  v25_: bool = id v32_;
-  v26_: int = id v33_;
-  v18_: int = id v24_;
-  v19_: int = id c4_;
-  print v19_;
+  jmp .b16_;
+.b31_:
+  v20_: int = id v27_;
+  v21_: bool = id v28_;
+  v22_: int = id v29_;
+  v13_: int = id v20_;
+  v14_: int = id c4_;
+  v15_: int = select v3_ c2_ c4_;
+  print v15_;
   print v3_;
-  print v18_;
+  print v13_;
   ret;
-  jmp .b20_;
-.b28_:
-  v18_: int = id v24_;
-  v19_: int = id c4_;
-  print v19_;
+  jmp .b16_;
+.b24_:
+  v13_: int = id v20_;
+  v14_: int = id c4_;
+  v15_: int = select v3_ c2_ c4_;
+  print v15_;
   print v3_;
-  print v18_;
+  print v13_;
   ret;
-.b20_:
+.b16_:
 }

--- a/tests/snapshots/files__if_dead_code_nested-optimize.snap
+++ b/tests/snapshots/files__if_dead_code_nested-optimize.snap
@@ -5,96 +5,36 @@ expression: visualization.result
 # ARGS: 1
 @main(v0: int) {
 .b1_:
-  c2_: int = const 0;
-  v3_: bool = le v0 c2_;
-  c4_: int = const 3;
-  c5_: int = const 2;
-  br v3_ .b6_ .b7_;
-.b6_:
-  v8_: bool = lt v0 c2_;
-  c9_: bool = const true;
-  c10_: int = const 1;
-  c11_: int = const 2;
-  v12_: int = id c11_;
-  v13_: bool = id c9_;
-  v14_: int = id c10_;
-  br v8_ .b15_ .b16_;
-.b15_:
-  v12_: int = id c10_;
-  v13_: bool = id c9_;
-  v14_: int = id c10_;
-  v17_: int = id v12_;
-  v18_: int = id c10_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
-  print v3_;
-  print v17_;
-  ret;
-  jmp .b21_;
-.b16_:
-  v17_: int = id v12_;
-  v18_: int = id c10_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
-  print v3_;
-  print v17_;
-  ret;
-  jmp .b21_;
+  c2_: int = const 1;
+  v3_: bool = lt v0 c2_;
+  c4_: int = const 0;
+  c5_: int = const 3;
+  c6_: int = const 2;
+  br v3_ .b7_ .b8_;
 .b7_:
-  v22_: bool = gt v0 c5_;
-  c23_: bool = const false;
-  c24_: int = const 2;
-  v25_: int = id c24_;
-  v26_: bool = id c23_;
-  v27_: int = id c2_;
-  br v22_ .b28_ .b29_;
-.b28_:
-  v30_: bool = gt v0 c4_;
-  c31_: int = const 4;
-  v32_: int = id c31_;
-  v33_: bool = id c23_;
-  v34_: int = id c2_;
-  br v30_ .b35_ .b36_;
-.b35_:
-  c37_: int = const 3;
-  v32_: int = id c37_;
-  v33_: bool = id c23_;
-  v34_: int = id c2_;
-  v25_: int = id v32_;
-  v26_: bool = id v33_;
-  v27_: int = id v34_;
-  v17_: int = id v25_;
-  v18_: int = id c2_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
+  v9_: bool = lt v0 c4_;
+  c10_: int = const 1;
+  v11_: int = select v9_ c10_ c6_;
+  v12_: int = id v11_;
+  v13_: int = id c10_;
+  v14_: int = select v3_ c2_ c4_;
+  print v14_;
   print v3_;
-  print v17_;
+  print v12_;
   ret;
-  jmp .b21_;
-.b36_:
-  v25_: int = id v32_;
-  v26_: bool = id v33_;
-  v27_: int = id v34_;
-  v17_: int = id v25_;
-  v18_: int = id c2_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
+  jmp .b15_;
+.b8_:
+  v16_: bool = gt v0 c6_;
+  v17_: bool = gt v0 c5_;
+  c18_: int = const 4;
+  v19_: int = select v17_ c5_ c18_;
+  v20_: int = select v16_ v19_ c6_;
+  v12_: int = id v20_;
+  v13_: int = id c4_;
+  v14_: int = select v3_ c2_ c4_;
+  print v14_;
   print v3_;
-  print v17_;
+  print v12_;
   ret;
-  jmp .b21_;
-.b29_:
-  v17_: int = id v25_;
-  v18_: int = id c2_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
-  print v3_;
-  print v17_;
-  ret;
-.b21_:
+.b15_:
 }

--- a/tests/snapshots/files__if_in_loop-optimize-sequential.snap
+++ b/tests/snapshots/files__if_in_loop-optimize-sequential.snap
@@ -16,34 +16,18 @@ expression: visualization.result
   v10_: int = id c4_;
   v11_: bool = id v5_;
 .b12_:
-  v13_: bool = lt v6_ v10_;
-  v14_: bool = id v13_;
-  v15_: int = id v6_;
-  v16_: int = id v7_;
-  v17_: int = id v9_;
-  v18_: int = id v8_;
-  v19_: int = id v9_;
-  v20_: int = id v10_;
-  br v11_ .b21_ .b22_;
-.b21_:
-  v14_: bool = id v13_;
-  v15_: int = id v6_;
-  v16_: int = id v7_;
-  v17_: int = id v7_;
-  v18_: int = id v8_;
-  v19_: int = id v9_;
-  v20_: int = id v10_;
-.b22_:
-  print v17_;
+  v13_: int = select v11_ v7_ v9_;
+  print v13_;
   print v11_;
-  v23_: int = add v6_ v7_;
-  v6_: int = id v23_;
+  v14_: int = add v6_ v7_;
+  v15_: bool = lt v6_ v10_;
+  v6_: int = id v14_;
   v7_: int = id v7_;
   v8_: int = id v8_;
   v9_: int = id v9_;
   v10_: int = id v10_;
   v11_: bool = id v11_;
-  br v13_ .b12_ .b24_;
-.b24_:
+  br v15_ .b12_ .b16_;
+.b16_:
   ret;
 }

--- a/tests/snapshots/files__if_true-optimize-sequential.snap
+++ b/tests/snapshots/files__if_true-optimize-sequential.snap
@@ -9,4 +9,5 @@ expression: visualization.result
   v3_: int = sub v0 c2_;
   print v0;
   print v3_;
+  ret;
 }

--- a/tests/snapshots/files__if_true-optimize.snap
+++ b/tests/snapshots/files__if_true-optimize.snap
@@ -9,4 +9,5 @@ expression: visualization.result
   v3_: int = sub v0 c2_;
   print v0;
   print v3_;
+  ret;
 }

--- a/tests/snapshots/files__implicit-return-optimize.snap
+++ b/tests/snapshots/files__implicit-return-optimize.snap
@@ -15,31 +15,18 @@ expression: visualization.result
   v10_: int = id v5_;
 .b11_:
   v12_: bool = lt v7_ v10_;
-  v13_: int = id v6_;
-  v14_: int = id v7_;
-  v15_: int = id v8_;
-  v16_: int = id v9_;
-  br v12_ .b17_ .b18_;
-.b17_:
-  v19_: int = mul v6_ v8_;
-  c20_: int = const 1;
-  v21_: int = add c20_ v7_;
-  v13_: int = id v19_;
-  v14_: int = id v21_;
-  v15_: int = id v8_;
-  v16_: int = id v9_;
-  v6_: int = id v13_;
-  v7_: int = id v14_;
-  v8_: int = id v15_;
-  v9_: int = id v16_;
+  v13_: int = mul v6_ v8_;
+  v14_: int = select v12_ v13_ v6_;
+  c15_: int = const 1;
+  v16_: int = add c15_ v7_;
+  v17_: int = select v12_ v16_ v7_;
+  v6_: int = id v14_;
+  v7_: int = id v17_;
+  v8_: int = id v8_;
+  v9_: int = id v9_;
   v10_: int = id v10_;
-  jmp .b11_;
+  br v12_ .b11_ .b18_;
 .b18_:
-  v6_: int = id v13_;
-  v7_: int = id v14_;
-  v8_: int = id v15_;
-  v9_: int = id v16_;
-  v10_: int = id v10_;
   print v6_;
   ret;
 }
@@ -55,29 +42,17 @@ expression: visualization.result
 .b8_:
   c9_: int = const 14;
   v10_: bool = lt v5_ c9_;
-  v11_: int = id v4_;
-  v12_: int = id v5_;
-  v13_: int = id v6_;
-  v14_: int = id v7_;
-  br v10_ .b15_ .b16_;
-.b15_:
-  v17_: int = mul v4_ v6_;
-  c18_: int = const 1;
-  v19_: int = add c18_ v5_;
-  v11_: int = id v17_;
-  v12_: int = id v19_;
-  v13_: int = id v6_;
-  v14_: int = id v7_;
-  v4_: int = id v11_;
-  v5_: int = id v12_;
-  v6_: int = id v13_;
-  v7_: int = id v14_;
-  jmp .b8_;
+  v11_: int = mul v4_ v6_;
+  v12_: int = select v10_ v11_ v4_;
+  c13_: int = const 1;
+  v14_: int = add c13_ v5_;
+  v15_: int = select v10_ v14_ v5_;
+  v4_: int = id v12_;
+  v5_: int = id v15_;
+  v6_: int = id v6_;
+  v7_: int = id v7_;
+  br v10_ .b8_ .b16_;
 .b16_:
-  v4_: int = id v11_;
-  v5_: int = id v12_;
-  v6_: int = id v13_;
-  v7_: int = id v14_;
   print v4_;
   ret;
 }

--- a/tests/snapshots/files__impossible_if-optimize.snap
+++ b/tests/snapshots/files__impossible_if-optimize.snap
@@ -6,19 +6,7 @@ expression: visualization.result
 @main(v0: int) {
 .b1_:
   c2_: int = const 1;
-  c3_: int = const 2;
-  v4_: bool = lt v0 c3_;
-  br v4_ .b5_ .b6_;
-.b5_:
   print c2_;
-  v7_: int = id c2_;
   print c2_;
   ret;
-  jmp .b8_;
-.b6_:
-  print c2_;
-  v7_: int = id c2_;
-  print c2_;
-  ret;
-.b8_:
 }

--- a/tests/snapshots/files__loop_based_code_motion-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_based_code_motion-optimize-sequential.snap
@@ -28,4 +28,5 @@ expression: visualization.result
   c13_: int = const 5;
   v14_: int = mul c13_ v3_;
   print v14_;
+  ret;
 }

--- a/tests/snapshots/files__loop_based_code_motion-optimize.snap
+++ b/tests/snapshots/files__loop_based_code_motion-optimize.snap
@@ -11,21 +11,15 @@ expression: visualization.result
   v4_: int = id c2_;
 .b5_:
   v6_: bool = lt v3_ v4_;
-  v7_: int = id v3_;
-  v8_: int = id v4_;
-  br v6_ .b9_ .b10_;
-.b9_:
-  c11_: int = const 1;
-  v12_: int = add c11_ v3_;
-  v7_: int = id v12_;
-  v8_: int = id v4_;
-  v3_: int = id v7_;
-  v4_: int = id v8_;
-  jmp .b5_;
+  c7_: int = const 1;
+  v8_: int = add c7_ v3_;
+  v9_: int = select v6_ v8_ v3_;
+  v3_: int = id v9_;
+  v4_: int = id v4_;
+  br v6_ .b5_ .b10_;
 .b10_:
-  v3_: int = id v7_;
-  v4_: int = id v8_;
-  c13_: int = const 5;
-  v14_: int = mul c13_ v3_;
-  print v14_;
+  c11_: int = const 5;
+  v12_: int = mul c11_ v3_;
+  print v12_;
+  ret;
 }

--- a/tests/snapshots/files__loop_if-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_if-optimize-sequential.snap
@@ -10,23 +10,16 @@ expression: visualization.result
   v3_: int = id c1_;
 .b4_:
   v5_: bool = eq v2_ v3_;
-  v6_: int = id v2_;
-  v7_: bool = id v5_;
-  v8_: int = id v3_;
-  br v5_ .b9_ .b10_;
-.b10_:
-  c11_: int = const 1;
-  v12_: int = add c11_ v2_;
-  v13_: int = add c11_ v3_;
-  v6_: int = id v12_;
-  v7_: bool = id v5_;
-  v8_: int = id v13_;
-.b9_:
-  v14_: bool = not v5_;
-  v2_: int = id v6_;
-  v3_: int = id v8_;
-  br v14_ .b4_ .b15_;
-.b15_:
+  c6_: int = const 1;
+  v7_: int = add c6_ v2_;
+  v8_: int = select v5_ v2_ v7_;
+  v9_: int = add c6_ v3_;
+  v10_: int = select v5_ v3_ v9_;
+  v11_: bool = not v5_;
+  v2_: int = id v8_;
+  v3_: int = id v10_;
+  br v11_ .b4_ .b12_;
+.b12_:
   print v2_;
   ret;
 }

--- a/tests/snapshots/files__loop_if-optimize.snap
+++ b/tests/snapshots/files__loop_if-optimize.snap
@@ -10,23 +10,16 @@ expression: visualization.result
   v3_: int = id c1_;
 .b4_:
   v5_: bool = eq v2_ v3_;
-  v6_: int = id v2_;
-  v7_: bool = id v5_;
-  v8_: int = id v3_;
-  br v5_ .b9_ .b10_;
-.b10_:
-  c11_: int = const 1;
-  v12_: int = add c11_ v2_;
-  v13_: int = add c11_ v3_;
-  v6_: int = id v12_;
-  v7_: bool = id v5_;
-  v8_: int = id v13_;
-.b9_:
-  v14_: bool = not v5_;
-  v2_: int = id v6_;
-  v3_: int = id v8_;
-  br v14_ .b4_ .b15_;
-.b15_:
+  c6_: int = const 1;
+  v7_: int = add c6_ v2_;
+  v8_: int = select v5_ v2_ v7_;
+  v9_: int = add c6_ v3_;
+  v10_: int = select v5_ v3_ v9_;
+  v11_: bool = not v5_;
+  v2_: int = id v8_;
+  v3_: int = id v10_;
+  br v11_ .b4_ .b12_;
+.b12_:
   print v2_;
   ret;
 }

--- a/tests/snapshots/files__loop_invariant_code_motion-optimize-sequential.snap
+++ b/tests/snapshots/files__loop_invariant_code_motion-optimize-sequential.snap
@@ -24,26 +24,12 @@ expression: visualization.result
 .b18_:
   v20_: int = mul v10_ v9_;
   v21_: bool = lt v20_ v8_;
-  v22_: int = id v6_;
-  v23_: int = id v7_;
-  v24_: int = id v20_;
-  v25_: int = id v8_;
-  v26_: int = id v9_;
-  v27_: int = id v10_;
-  br v21_ .b28_ .b29_;
-.b28_:
-  v30_: int = add v20_ v7_;
-  v22_: int = id v6_;
-  v23_: int = id v7_;
-  v24_: int = id v30_;
-  v25_: int = id v8_;
-  v26_: int = id v9_;
-  v27_: int = id v10_;
-.b29_:
-  v31_: int = mul v24_ v6_;
-  print v31_;
-  v32_: int = add v6_ v7_;
-  v13_: int = id v32_;
+  v22_: int = add v20_ v7_;
+  v23_: int = select v21_ v22_ v20_;
+  v24_: int = mul v23_ v6_;
+  print v24_;
+  v25_: int = add v6_ v7_;
+  v13_: int = id v25_;
   v14_: int = id v7_;
   v15_: int = id v8_;
   v16_: int = id v9_;
@@ -60,4 +46,5 @@ expression: visualization.result
   v8_: int = id v15_;
   v9_: int = id v16_;
   v10_: int = id v17_;
+  ret;
 }

--- a/tests/snapshots/files__max-optimize-sequential.snap
+++ b/tests/snapshots/files__max-optimize-sequential.snap
@@ -6,15 +6,7 @@ expression: visualization.result
 @main(v0: int, v1: int) {
 .b2_:
   v3_: bool = lt v1 v0;
-  v4_: int = id v1;
-  br v3_ .b5_ .b6_;
-.b5_:
-  v4_: int = id v0;
+  v4_: int = select v3_ v0 v1;
   print v4_;
   ret;
-  jmp .b7_;
-.b6_:
-  print v4_;
-  ret;
-.b7_:
 }

--- a/tests/snapshots/files__min-optimize-sequential.snap
+++ b/tests/snapshots/files__min-optimize-sequential.snap
@@ -6,15 +6,7 @@ expression: visualization.result
 @main(v0: int, v1: int) {
 .b2_:
   v3_: bool = lt v0 v1;
-  v4_: int = id v1;
-  br v3_ .b5_ .b6_;
-.b5_:
-  v4_: int = id v0;
+  v4_: int = select v3_ v0 v1;
   print v4_;
   ret;
-  jmp .b7_;
-.b6_:
-  print v4_;
-  ret;
-.b7_:
 }


### PR DESCRIPTION
Subsumes the old rules.
`select_simple.rs` before optimization
![image](https://github.com/user-attachments/assets/c6b0d7de-d7cd-4ae3-9d68-3142a8afde88)

after optimization
![image](https://github.com/user-attachments/assets/8f3bf50f-b148-4820-ad05-ca242e1d7211)

also `gcd.bril` is now just a big loop with selects, no ifs:
![image](https://github.com/user-attachments/assets/8f9c045d-ea74-4c19-8b3b-257902cc2cf5)
