### PR TITLE
Separate llvm compilation into optimization and lowering

### DIFF
--- a/benchmarks/passing/bril/long/function_call.bril
+++ b/benchmarks/passing/bril/long/function_call.bril
@@ -1,8 +1,5 @@
 # ARGS: 25
 
-# failing due to brillvm bug:
-# https://github.com/sampsyo/bril/issues/339
-
 @main(starting_m: int) {
   res: int = call @myrec starting_m;
   print res;

--- a/infra/generate_cfgs.py
+++ b/infra/generate_cfgs.py
@@ -3,6 +3,7 @@ import glob
 import os
 
 import concurrent.futures
+import subprocess
 
 def make_cfgs(bench, data_dir):
   cwd = os.getcwd()
@@ -15,7 +16,9 @@ def make_cfgs(bench, data_dir):
     # otherwise use opt
     # On Linux, sometimes it's called opt-18, while on mac it seems to be just opt
     # Also, on some machines, just running `opt-18` hangs, so we pass the version flag
-    if os.system("opt-18 --version") == 0:
+    # Catch the output using shell
+    opt18_res = subprocess.run("opt-18", shell=True, capture_output=True, text=True)
+    if opt18_res.returncode == 0:
       opt = "opt-18"
     else:
       opt = "opt"

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -1,15 +1,16 @@
 const COLORS = {
   "rvsdg-round-trip-to-executable": "red",
-  "llvm-O0": "purple",
-  "llvm-O1": "green",
-  "llvm-O2": "orange",
-  "llvm-O3": "gray",
-  "llvm-O0-eggcc": "pink",
-  "llvm-O0-eggcc-sequential": "blue",
-  "llvm-O3-eggcc": "brown",
+  "llvm-O0-O0": "purple",
+  "llvm-O1-O0": "green",
+  "llvm-O2-O0": "orange",
+  "llvm-O3-O0": "gray",
+  "llvm-O3Lower": "yellow",
+  "llvm-eggcc-O0-O0": "pink",
+  "llvm-eggcc-sequential-O0-O0": "blue",
+  "llvm-eggcc-O3-O0": "brown",
 };
 
-const BASELINE_MODE = "llvm-O0";
+const BASELINE_MODE = "llvm-O0-O0";
 
 // TODO these functions (mean, median, ect) are duplicated in generate_line_counts.py
 // we could move the computation of the latex table to js to solve this problem

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -40,13 +40,14 @@ function getComparison(benchmark, runMethod) {
 function shouldHaveLlvm(runMethod) {
   return [
     "rvsdg-round-trip-to-executable",
-    "llvm-O0",
-    "llvm-O1",
-    "llvm-O2",
-    "llvm-O0-eggcc",
-    "llvm-O0-eggcc-sequential",
-    "llvm-O3",
-    "llvm-O3-eggcc",
+    "llvm-O0-O0",
+    "llvm-O1-O0",
+    "llvm-O2-O0",
+    "llvm-eggcc-O0-O0",
+    "llvm-eggcc-sequential-O0-O0",
+    "llvm-O3-O0",
+    "llvm-O3-O0",
+    "llvm-eggcc-O3-O0",
   ].includes(runMethod);
 }
 

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -46,7 +46,7 @@ function shouldHaveLlvm(runMethod) {
     "llvm-eggcc-O0-O0",
     "llvm-eggcc-sequential-O0-O0",
     "llvm-O3-O0",
-    "llvm-O3-O0",
+    "llvm-O3-O3",
     "llvm-eggcc-O3-O0",
   ].includes(runMethod);
 }

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -1,13 +1,14 @@
 // copied from profile.py
 const treatments = [
   "rvsdg-round-trip-to-executable",
-  "llvm-O0",
-  "llvm-O1",
-  "llvm-O2",
-  "llvm-O0-eggcc",
-  "llvm-O0-eggcc-sequential",
-  "llvm-O3",
-  "llvm-O3-eggcc",
+  "llvm-O0-O0",
+  "llvm-O1-O0",
+  "llvm-O2-O0",
+  "llvm-eggcc-O0-O0",
+  "llvm-eggcc-sequential-O0-O0",
+  "llvm-O3-O0",
+  "llvm-O3-O3",
+  "llvm-eggcc-O3-O0",
 ];
 
 const GLOBAL_DATA = {

--- a/infra/nightly-resources/llvm.js
+++ b/infra/nightly-resources/llvm.js
@@ -1,6 +1,6 @@
 async function showIR(benchmark, runMode) {
   const llvm = await fetchText(
-    `./data/llvm/${benchmark}/${runMode}/${benchmark}-${runMode}.ll`,
+    `./data/llvm/${benchmark}/${runMode}/optimized.ll`,
   );
   document.getElementById("llvm-ir").innerText = llvm;
 }

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -12,13 +12,14 @@ import concurrent.futures
 treatments = [
   "rvsdg-round-trip-to-executable",
   #"cranelift-O3", currently disabled since it doesn't support measuring cycles yet
-  "llvm-O0",
-  "llvm-O1",
-  "llvm-O2",
-  "llvm-O0-eggcc",
-  "llvm-O0-eggcc-sequential",
-  "llvm-O3",
-  "llvm-O3-eggcc",
+  "llvm-O0-O0",
+  "llvm-O1-O0",
+  "llvm-O2-O0",
+  "llvm-eggcc-O0-O0",
+  "llvm-eggcc-sequential-O0-O0",
+  "llvm-O3-O0",
+  "llvm-O3-O3",
+  "llvm-eggcc-O3-O0",
 ]
 
 # Where to output files that are needed for nightly report
@@ -36,21 +37,23 @@ EGGCC_BINARY = "target/release/eggcc"
 def get_eggcc_options(benchmark):
   match benchmark.treatment:
     case "rvsdg-round-trip-to-executable":
-      return (f'rvsdg-round-trip',  f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0')
-    case "llvm-O0":
-      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0')
-    case "llvm-O1":
-      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O1')
-    case "llvm-O2":
-      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O2')
-    case "llvm-O3":
-      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3')
-    case "llvm-O0-eggcc-sequential":
-      return (f'optimize --eggcc-schedule sequential', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0')
-    case "llvm-O0-eggcc":
-      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0')
-    case "llvm-O3-eggcc":
-      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3')
+      return (f'rvsdg-round-trip',  f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
+    case "llvm-O0-O0":
+      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
+    case "llvm-O1-O0":
+      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O1_O0')
+    case "llvm-O2-O0":
+      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O2_O0')
+    case "llvm-O3-O0":
+      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O0')
+    case "llvm-O3-O3":
+      return (f'parse', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O3')
+    case "llvm-eggcc-sequential-O0-O0":
+      return (f'optimize --eggcc-schedule sequential', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
+    case "llvm-eggcc-O0-O0":
+      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
+    case "llvm-eggcc-O3-O0":
+      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O0')
     case _:
       raise Exception("Unexpected run mode: " + benchmark.treatment)
     
@@ -149,13 +152,14 @@ def bench(benchmark):
 def should_have_llvm_ir(runMethod):
   return runMethod in [
     "rvsdg-round-trip-to-executable",
-    "llvm-O0",
-    "llvm-O1",
-    "llvm-O2",
-    "llvm-O0-eggcc",
-    "llvm-O0-eggcc-sequential",
-    "llvm-O3",
-    "llvm-O3-eggcc",
+    "llvm-O0-O0",
+    "llvm-O1-O0",
+    "llvm-O2-O0",
+    "llvm-eggcc-O0-O0",
+    "llvm-eggcc-sequential-O0-O0",
+    "llvm-O3-O0",
+    "llvm-O3-O3",
+    "llvm-eggcc-O3-O0",
   ]
 
 # aggregate all profile info into a single json array.
@@ -195,7 +199,11 @@ if __name__ == '__main__':
 
   # build eggcc
   print("Building eggcc")
-  os.system("cargo build --release")
+  buildres = os.system("cargo build --release")
+  if buildres != 0:
+    print("Failed to build eggcc")
+    exit(1)
+
 
 
   bril_dir, DATA_DIR = os.sys.argv[1:]

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -87,10 +87,12 @@ def optimize(benchmark):
 
   # get the commands we need to run
   (eggcc_run_mode, llvm_args) = get_eggcc_options(benchmark)
-  llvm_out_dir = f"{DATA_DIR}/llvm/{benchmark.name}/{benchmark.treatment}"
+  # make the llvm output directory
+  os.makedirs(f"{DATA_DIR}/llvm/{benchmark.name}/{benchmark.treatment}", exist_ok=True)
+  llvm_out_file = f"{DATA_DIR}/llvm/{benchmark.name}/{benchmark.treatment}/optimized.ll"
 
   cmd1 = f'{EGGCC_BINARY} {benchmark.path} --run-mode {eggcc_run_mode}'
-  cmd2 = f'{EGGCC_BINARY} {optimized_bril_file} --add-timing {llvm_args} -o {profile_dir}/{benchmark.treatment} --llvm-output-dir {llvm_out_dir}'
+  cmd2 = f'{EGGCC_BINARY} {optimized_bril_file} --add-timing {llvm_args} -o {profile_dir}/{benchmark.treatment} --llvm-output-dir {llvm_out_file}'
 
   print(f'Running c1: {cmd1}', flush=True)
   start_eggcc = time.time()

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,9 @@ struct Args {
     /// Where to put the executable (only for the brillift and llvm modes)
     #[clap(short)]
     output_path: Option<String>,
-    /// Where to put intermediary files (only for OptimizeBrilLLVM mode)
+    /// Where to put the optimized llvm file (for the llvm mode)
     #[clap(long)]
-    llvm_output_dir: Option<String>,
+    llvm_output_dir: Option<PathBuf>,
     /// For the LLVM run mode, choose whether to first run eggcc
     /// to optimize the bril program before going to LLVM.
     #[clap(long)]
@@ -98,7 +98,7 @@ fn main() {
         },
         profile_out: args.profile_out,
         output_path: args.output_path,
-        llvm_output_dir: args.llvm_output_dir,
+        optimized_llvm_out: args.llvm_output_dir,
         optimize_egglog: args.optimize_egglog,
         optimize_brilift: args.optimize_brilift,
         optimize_bril_llvm: args.optimize_bril_llvm,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1106,7 +1106,6 @@ impl Run {
                 .arg("-fno-vectorize")
                 .arg("-fno-slp-vectorize")
                 .arg("-emit-llvm")
-                .arg("-disable-O0-optnone")
                 .arg("-S")
                 .arg("-o")
                 .arg(optimized.clone()),
@@ -1130,7 +1129,6 @@ impl Run {
                 .arg("-regalloc=greedy")
                 .arg("-mllvm")
                 .arg("-optimize-regalloc")
-                .arg("-disable-O0-optnone")
                 .arg("-o")
                 .arg(executable.clone()),
             "failed to compile llvm ir",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1080,6 +1080,7 @@ impl Run {
         expect_command_success(
             Command::new("clang-18")
                 .arg(processed.clone())
+                .arg("-g0")
                 .arg(format!("-{}", llvm_level))
                 .arg("-fno-vectorize")
                 .arg("-fno-slp-vectorize")
@@ -1096,6 +1097,7 @@ impl Run {
                 Command::new("clang-18")
                     .current_dir(output_dir)
                     .arg(processed)
+                    .arg("-g0")
                     .arg(format!("-{}", llvm_level))
                     .arg("-fno-vectorize")
                     .arg("-fno-slp-vectorize")

--- a/src/util.rs
+++ b/src/util.rs
@@ -1106,6 +1106,7 @@ impl Run {
                 .arg("-fno-vectorize")
                 .arg("-fno-slp-vectorize")
                 .arg("-emit-llvm")
+                .arg("-disable-O0-optnone")
                 .arg("-S")
                 .arg("-o")
                 .arg(optimized.clone()),
@@ -1129,6 +1130,7 @@ impl Run {
                 .arg("-regalloc=greedy")
                 .arg("-mllvm")
                 .arg("-optimize-regalloc")
+                .arg("-disable-O0-optnone")
                 .arg("-o")
                 .arg(executable.clone()),
             "failed to compile llvm ir",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1083,6 +1083,10 @@ impl Run {
                 .arg(format!("-{}", llvm_level))
                 .arg("-fno-vectorize")
                 .arg("-fno-slp-vectorize")
+                .arg("-mllvm")
+                .arg("-regalloc=greedy")
+                .arg("-mllvm")
+                .arg("-optimize-regalloc")
                 .arg("-o")
                 .arg(executable.clone()),
             "failed to compile llvm ir",
@@ -1095,6 +1099,10 @@ impl Run {
                     .arg(format!("-{}", llvm_level))
                     .arg("-fno-vectorize")
                     .arg("-fno-slp-vectorize")
+                    .arg("-mllvm")
+                    .arg("-regalloc=greedy")
+                    .arg("-mllvm")
+                    .arg("-optimize-regalloc")
                     .arg("-emit-llvm")
                     .arg("-S")
                     .arg("-o")


### PR DESCRIPTION
This PR allows eggcc to run LLVM with separate optimization levels for the middle-end and lowering to a binary. The idea is to give us a more fair comparison in the nightly because LLVM won't be doing platform-specific optimization, so we compare more directly to the llvm middle-end optimizer. 

It leaves in the normal O3 run as `llvm-O3-O3`.