### PR TITLE
Go back to batching all fns from the program together

### DIFF
--- a/tests/snapshots/files__fib_recursive-optimize-sequential.snap
+++ b/tests/snapshots/files__fib_recursive-optimize-sequential.snap
@@ -119,7 +119,7 @@ expression: visualization.result
   br v57_ .b58_ .b59_;
 .b58_:
   v60_: int = call @fac c2_;
-  v61_: int = id v0;
+  v61_: int = id c37_;
   v39_: int = id v61_;
   v42_: int = id v0;
   jmp .b43_;
@@ -281,7 +281,7 @@ expression: visualization.result
   br v137_ .b138_ .b139_;
 .b138_:
   v140_: int = call @fac c2_;
-  v141_: int = id v67_;
+  v141_: int = id c2_;
   v133_: int = id v141_;
   v136_: int = id v67_;
   v71_: int = id v136_;
@@ -337,7 +337,7 @@ expression: visualization.result
   br v169_ .b170_ .b171_;
 .b170_:
   v172_: int = call @fac c2_;
-  v173_: int = id c4_;
+  v173_: int = id v147_;
   v151_: int = id v173_;
   v154_: int = id c4_;
   jmp .b155_;
@@ -383,7 +383,7 @@ expression: visualization.result
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: int = call @fac c2_;
-  v21_: int = id c1_;
+  v21_: int = id c2_;
   v13_: int = id v21_;
   v16_: int = id c1_;
   v5_: int = id v16_;
@@ -424,7 +424,7 @@ expression: visualization.result
   br v37_ .b38_ .b39_;
 .b38_:
   v40_: int = call @fac c2_;
-  v41_: int = id c2_;
+  v41_: int = id c4_;
   v32_: int = id v41_;
   v36_: int = add v29_ v32_;
   v16_: int = id v36_;

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -119,7 +119,7 @@ expression: visualization.result
   br v57_ .b58_ .b59_;
 .b58_:
   v60_: int = call @fac c2_;
-  v61_: int = id v0;
+  v61_: int = id c37_;
   v39_: int = id v61_;
   v42_: int = id v0;
   jmp .b43_;
@@ -281,7 +281,7 @@ expression: visualization.result
   br v137_ .b138_ .b139_;
 .b138_:
   v140_: int = call @fac c2_;
-  v141_: int = id v67_;
+  v141_: int = id c2_;
   v133_: int = id v141_;
   v136_: int = id v67_;
   v71_: int = id v136_;
@@ -337,7 +337,7 @@ expression: visualization.result
   br v169_ .b170_ .b171_;
 .b170_:
   v172_: int = call @fac c2_;
-  v173_: int = id c4_;
+  v173_: int = id v147_;
   v151_: int = id v173_;
   v154_: int = id c4_;
   jmp .b155_;
@@ -383,7 +383,7 @@ expression: visualization.result
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: int = call @fac c2_;
-  v21_: int = id c1_;
+  v21_: int = id c2_;
   v13_: int = id v21_;
   v16_: int = id c1_;
   v5_: int = id v16_;
@@ -424,7 +424,7 @@ expression: visualization.result
   br v37_ .b38_ .b39_;
 .b38_:
   v40_: int = call @fac c2_;
-  v41_: int = id c2_;
+  v41_: int = id c4_;
   v32_: int = id v41_;
   v36_: int = add v29_ v32_;
   v16_: int = id v36_;

--- a/tests/snapshots/files__implicit-return-optimize-sequential.snap
+++ b/tests/snapshots/files__implicit-return-optimize-sequential.snap
@@ -6,41 +6,38 @@ expression: visualization.result
 @pow(v0: int, v1: int) {
 .b2_:
   c3_: int = const 0;
-  c4_: int = const 1;
-  v5_: int = sub v1 c4_;
+  v4_: int = id v0;
+  v5_: int = id c3_;
   v6_: int = id v0;
-  v7_: int = id c3_;
-  v8_: int = id v0;
-  v9_: int = id v1;
-  v10_: int = id v5_;
-.b11_:
-  v12_: bool = lt v7_ v10_;
-  v13_: int = id v6_;
-  v14_: int = id v7_;
-  v15_: int = id v8_;
-  v16_: int = id v9_;
-  br v12_ .b17_ .b18_;
+  v7_: int = id v1;
+.b8_:
+  c9_: int = const 1;
+  v10_: int = sub v7_ c9_;
+  v11_: bool = lt v5_ v10_;
+  v12_: int = id v4_;
+  v13_: int = id v5_;
+  v14_: int = id v6_;
+  v15_: int = id v7_;
+  br v11_ .b16_ .b17_;
+.b16_:
+  v18_: int = mul v4_ v6_;
+  c19_: int = const 1;
+  v20_: int = add c19_ v5_;
+  v12_: int = id v18_;
+  v13_: int = id v20_;
+  v14_: int = id v6_;
+  v15_: int = id v7_;
+  v4_: int = id v12_;
+  v5_: int = id v13_;
+  v6_: int = id v14_;
+  v7_: int = id v15_;
+  jmp .b8_;
 .b17_:
-  v19_: int = mul v6_ v8_;
-  c20_: int = const 1;
-  v21_: int = add c20_ v7_;
-  v13_: int = id v19_;
-  v14_: int = id v21_;
-  v15_: int = id v8_;
-  v16_: int = id v9_;
-  v6_: int = id v13_;
-  v7_: int = id v14_;
-  v8_: int = id v15_;
-  v9_: int = id v16_;
-  v10_: int = id v10_;
-  jmp .b11_;
-.b18_:
-  v6_: int = id v13_;
-  v7_: int = id v14_;
-  v8_: int = id v15_;
-  v9_: int = id v16_;
-  v10_: int = id v10_;
-  print v6_;
+  v4_: int = id v12_;
+  v5_: int = id v13_;
+  v6_: int = id v14_;
+  v7_: int = id v15_;
+  print v4_;
   ret;
 }
 @main {


### PR DESCRIPTION
Pr #660 separated the egraph's optimization of different functions. Turns out this makes everything a lot slower, perhaps due to sharing of types and other subexpressions.
This PR changes it back to batching all the functions together, but keeps extraction as per-function. This allows the extractor in the future to be function-aware, making recursive calls expensive.

It also optimizes extraction to find reachable regions instead of extracting everything in the egraph. 