### PR TITLE
Simplify schedule by separating out the saturating combined ruleset

### DIFF
--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -148,12 +148,7 @@ impl<'a> EgraphInfo<'a> {
         let mut num_not_expr = 0;
         // find all the (root, child) pairs that are important
         let mut relavent_eclasses: Vec<(ClassId, ClassId)> = vec![];
-        for (i, root) in region_roots.iter().enumerate() {
-            log::info!(
-                "Finding reachable classes for region {} of {}",
-                i,
-                region_roots.len()
-            );
+        for root in region_roots.iter() {
             let reachable = find_reachable(egraph, root.clone(), cm, true, false);
             for eclass in reachable {
                 // if type is not expr add to count

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -1,35 +1,34 @@
 pub(crate) fn helpers() -> String {
     "
 (saturate
-    (saturate type-helpers)
-    (saturate error-checking)
-
     (saturate
-        (saturate type-helpers)
-        (saturate error-checking)
-        saturating
+        (saturate
+          type-analysis
+          (saturate type-helpers))
+        error-checking
+        always-run
+        canon
+        context
+        interval-analysis
+        always-switch-rewrite
+        loop-iters-analysis
+        ; memory-helpers TODO run memory helpers for memory optimizations
     )
 
     (saturate drop)
     apply-drop-unions
     cleanup-drop
 
-    (saturate
-        (saturate type-helpers)
-        (saturate error-checking)
-        saturating
-    )
-
     (saturate subst)
     apply-subst-unions
     cleanup-subst
-
-    (saturate boundary-analysis)
 )
 
 ;; be careful to finish dropping and substituting before subsuming things!
 ;; otherwise substitution or dropat may not finish, violating the weak linearity invariant
 subsume-after-helpers
+
+(saturate boundary-analysis)
 "
     .to_string()
 }
@@ -55,32 +54,11 @@ fn optimizations() -> Vec<String> {
     .collect()
 }
 
-fn saturating_rulesets() -> Vec<String> {
-    [
-        "always-run",
-        "canon",
-        "type-analysis",
-        "context",
-        "interval-analysis",
-        "memory-helpers",
-        "always-switch-rewrite",
-        "loop-iters-analysis",
-    ]
-    .iter()
-    .map(|opt| opt.to_string())
-    .collect()
-}
-
 pub fn rulesets() -> String {
     let all_optimizations = optimizations().join("\n");
-    let saturating_combined = saturating_rulesets().join("\n");
     let cheap_optimizations = cheap_optimizations().join("\n");
     format!(
         "
-(unstable-combined-ruleset saturating
-    {saturating_combined}
-)
-
 (unstable-combined-ruleset cheap-optimizations
     {cheap_optimizations}
 )

--- a/tests/snapshots/files__block-diamond-optimize-sequential.snap
+++ b/tests/snapshots/files__block-diamond-optimize-sequential.snap
@@ -5,23 +5,23 @@ expression: visualization.result
 # ARGS: 1
 @main(v0: int) {
 .b1_:
-  c2_: int = const 1;
-  c3_: int = const 2;
-  v4_: bool = lt v0 c3_;
-  c5_: int = const 0;
+  c2_: int = const 2;
+  v3_: bool = lt v0 c2_;
+  c4_: int = const 0;
+  c5_: int = const 1;
   c6_: int = const 5;
-  v7_: int = id c2_;
-  v8_: int = id c2_;
-  v9_: int = id c3_;
-  br v4_ .b10_ .b11_;
+  v7_: int = id c5_;
+  v8_: int = id c5_;
+  v9_: int = id c2_;
+  br v3_ .b10_ .b11_;
 .b10_:
   c12_: int = const 4;
   v7_: int = id c12_;
-  v8_: int = id c2_;
-  v9_: int = id c3_;
+  v8_: int = id c5_;
+  v9_: int = id c2_;
   v13_: int = id v7_;
   v14_: int = id v8_;
-  v15_: int = add c2_ v13_;
+  v15_: int = add c5_ v13_;
   print v15_;
   ret;
   jmp .b16_;
@@ -31,7 +31,7 @@ expression: visualization.result
   v17_: int = add v7_ v9_;
   v13_: int = id v17_;
   v14_: int = id v8_;
-  v15_: int = add c2_ v13_;
+  v15_: int = add c5_ v13_;
   print v15_;
   ret;
 .b16_:

--- a/tests/snapshots/files__block-diamond-optimize.snap
+++ b/tests/snapshots/files__block-diamond-optimize.snap
@@ -5,24 +5,24 @@ expression: visualization.result
 # ARGS: 1
 @main(v0: int) {
 .b1_:
-  c2_: int = const 1;
-  c3_: int = const 2;
-  v4_: bool = lt v0 c3_;
-  c5_: int = const 4;
-  v6_: int = select v4_ c5_ c2_;
+  c2_: int = const 2;
+  v3_: bool = lt v0 c2_;
+  c4_: int = const 4;
+  c5_: int = const 1;
+  v6_: int = select v3_ c4_ c5_;
   v7_: int = id v6_;
-  v8_: int = id c2_;
-  br v4_ .b9_ .b10_;
+  v8_: int = id c5_;
+  br v3_ .b9_ .b10_;
 .b9_:
-  v11_: int = add c2_ v7_;
+  v11_: int = add c5_ v7_;
   print v11_;
   ret;
   jmp .b12_;
 .b10_:
-  v13_: int = add c3_ v6_;
+  v13_: int = add c2_ v6_;
   v7_: int = id v13_;
-  v8_: int = id c2_;
-  v11_: int = add c2_ v7_;
+  v8_: int = id c5_;
+  v11_: int = add c5_ v7_;
   print v11_;
   ret;
 .b12_:

--- a/tests/snapshots/files__fib_recursive-optimize-sequential.snap
+++ b/tests/snapshots/files__fib_recursive-optimize-sequential.snap
@@ -18,51 +18,51 @@ expression: visualization.result
   br v9_ .b10_ .b11_;
 .b10_:
   v12_: bool = eq c2_ c2_;
-  v13_: int = id v0;
+  v13_: int = id c4_;
   br v12_ .b14_ .b15_;
 .b14_:
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b15_:
-  v17_: bool = eq c2_ v0;
+  v17_: bool = eq c2_ c4_;
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: bool = eq c2_ c2_;
-  v21_: int = id c2_;
+  v21_: int = id c4_;
   br v20_ .b22_ .b23_;
 .b22_:
-  v24_: int = id c2_;
+  v24_: int = id c4_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b23_:
-  v25_: bool = eq c2_ c2_;
+  v25_: bool = eq c2_ c4_;
   br v25_ .b26_ .b27_;
 .b26_:
   v28_: int = call @fac c2_;
-  v29_: int = id c2_;
+  v29_: int = id c4_;
   v21_: int = id v29_;
-  v24_: int = id c2_;
+  v24_: int = id c4_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b27_:
-  c30_: int = const -1;
-  v31_: int = sub c30_ c2_;
-  v32_: int = call @fac c30_;
-  v33_: int = call @fac v31_;
+  c30_: int = const -2;
+  c31_: int = const -1;
+  v32_: int = call @fac c31_;
+  v33_: int = call @fac c30_;
   v34_: int = add v32_ v33_;
   v29_: int = id v34_;
   v21_: int = id v29_;
-  v24_: int = id c2_;
+  v24_: int = id c4_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -71,31 +71,31 @@ expression: visualization.result
   v36_: bool = eq c2_ c35_;
   c37_: int = const -1;
   v38_: bool = eq c2_ c37_;
-  v39_: int = id v0;
+  v39_: int = id c4_;
   br v38_ .b40_ .b41_;
 .b40_:
-  v42_: int = id v0;
+  v42_: int = id c4_;
 .b43_:
   br v36_ .b44_ .b45_;
 .b44_:
   v46_: int = add v39_ v42_;
   v24_: int = id v46_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b45_:
-  v47_: bool = eq c35_ v0;
+  v47_: bool = eq c35_ c4_;
   br v47_ .b48_ .b49_;
 .b48_:
   v50_: int = call @fac c2_;
-  v51_: int = id v0;
+  v51_: int = id c4_;
   v42_: int = id v51_;
   v46_: int = add v39_ v42_;
   v24_: int = id v46_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -110,18 +110,18 @@ expression: visualization.result
   v46_: int = add v39_ v42_;
   v24_: int = id v46_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b41_:
-  v57_: bool = eq c37_ v0;
+  v57_: bool = eq c37_ c4_;
   br v57_ .b58_ .b59_;
 .b58_:
   v60_: int = call @fac c2_;
-  v61_: int = id c37_;
+  v61_: int = id c4_;
   v39_: int = id v61_;
-  v42_: int = id v0;
+  v42_: int = id c4_;
   jmp .b43_;
 .b59_:
   c62_: int = const -3;
@@ -131,7 +131,7 @@ expression: visualization.result
   v66_: int = add v64_ v65_;
   v61_: int = id v66_;
   v39_: int = id v61_;
-  v42_: int = id v0;
+  v42_: int = id c4_;
   jmp .b43_;
 .b11_:
   v67_: int = sub v0 c4_;
@@ -269,21 +269,21 @@ expression: visualization.result
   br v129_ .b130_ .b131_;
 .b130_:
   v132_: bool = eq c2_ c2_;
-  v133_: int = id v67_;
+  v133_: int = id c4_;
   br v132_ .b134_ .b135_;
 .b134_:
-  v136_: int = id v67_;
+  v136_: int = id c4_;
   v71_: int = id v136_;
   v74_: int = id c4_;
   jmp .b75_;
 .b135_:
-  v137_: bool = eq c2_ v67_;
+  v137_: bool = eq c2_ c4_;
   br v137_ .b138_ .b139_;
 .b138_:
   v140_: int = call @fac c2_;
-  v141_: int = id c2_;
+  v141_: int = id c4_;
   v133_: int = id v141_;
-  v136_: int = id v67_;
+  v136_: int = id c4_;
   v71_: int = id v136_;
   v74_: int = id c4_;
   jmp .b75_;
@@ -295,7 +295,7 @@ expression: visualization.result
   v146_: int = add v144_ v145_;
   v141_: int = id v146_;
   v133_: int = id v141_;
-  v136_: int = id v67_;
+  v136_: int = id c4_;
   v71_: int = id v136_;
   v74_: int = id c4_;
   jmp .b75_;
@@ -337,7 +337,7 @@ expression: visualization.result
   br v169_ .b170_ .b171_;
 .b170_:
   v172_: int = call @fac c2_;
-  v173_: int = id v147_;
+  v173_: int = id c4_;
   v151_: int = id v173_;
   v154_: int = id c4_;
   jmp .b155_;
@@ -370,35 +370,35 @@ expression: visualization.result
   br v9_ .b10_ .b11_;
 .b10_:
   v12_: bool = eq c2_ c2_;
-  v13_: int = id c1_;
+  v13_: int = id c4_;
   br v12_ .b14_ .b15_;
 .b14_:
-  v16_: int = id c1_;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   print v5_;
   ret;
   jmp .b8_;
 .b15_:
-  v17_: bool = eq c1_ c2_;
+  v17_: bool = eq c2_ c4_;
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: int = call @fac c2_;
-  v21_: int = id c2_;
+  v21_: int = id c4_;
   v13_: int = id v21_;
-  v16_: int = id c1_;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   print v5_;
   ret;
   jmp .b8_;
 .b19_:
   c22_: int = const -1;
-  v23_: int = sub c22_ c1_;
+  v23_: int = sub c22_ c4_;
   v24_: int = call @fac c22_;
   v25_: int = call @fac v23_;
   v26_: int = add v24_ v25_;
   v21_: int = id v26_;
   v13_: int = id v21_;
-  v16_: int = id c1_;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   print v5_;
   ret;

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -18,51 +18,51 @@ expression: visualization.result
   br v9_ .b10_ .b11_;
 .b10_:
   v12_: bool = eq c2_ c2_;
-  v13_: int = id v0;
+  v13_: int = id c4_;
   br v12_ .b14_ .b15_;
 .b14_:
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b15_:
-  v17_: bool = eq c2_ v0;
+  v17_: bool = eq c2_ c4_;
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: bool = eq c2_ c2_;
-  v21_: int = id c2_;
+  v21_: int = id c4_;
   br v20_ .b22_ .b23_;
 .b22_:
-  v24_: int = id c2_;
+  v24_: int = id c4_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b23_:
-  v25_: bool = eq c2_ c2_;
+  v25_: bool = eq c2_ c4_;
   br v25_ .b26_ .b27_;
 .b26_:
   v28_: int = call @fac c2_;
-  v29_: int = id c2_;
+  v29_: int = id c4_;
   v21_: int = id v29_;
-  v24_: int = id c2_;
+  v24_: int = id c4_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b27_:
-  c30_: int = const -1;
-  v31_: int = sub c30_ c2_;
-  v32_: int = call @fac c30_;
-  v33_: int = call @fac v31_;
+  c30_: int = const -2;
+  c31_: int = const -1;
+  v32_: int = call @fac c31_;
+  v33_: int = call @fac c30_;
   v34_: int = add v32_ v33_;
   v29_: int = id v34_;
   v21_: int = id v29_;
-  v24_: int = id c2_;
+  v24_: int = id c4_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -71,31 +71,31 @@ expression: visualization.result
   v36_: bool = eq c2_ c35_;
   c37_: int = const -1;
   v38_: bool = eq c2_ c37_;
-  v39_: int = id v0;
+  v39_: int = id c4_;
   br v38_ .b40_ .b41_;
 .b40_:
-  v42_: int = id v0;
+  v42_: int = id c4_;
 .b43_:
   br v36_ .b44_ .b45_;
 .b44_:
   v46_: int = add v39_ v42_;
   v24_: int = id v46_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b45_:
-  v47_: bool = eq c35_ v0;
+  v47_: bool = eq c35_ c4_;
   br v47_ .b48_ .b49_;
 .b48_:
   v50_: int = call @fac c2_;
-  v51_: int = id v0;
+  v51_: int = id c4_;
   v42_: int = id v51_;
   v46_: int = add v39_ v42_;
   v24_: int = id v46_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -110,18 +110,18 @@ expression: visualization.result
   v46_: int = add v39_ v42_;
   v24_: int = id v46_;
   v13_: int = id v24_;
-  v16_: int = id v0;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b41_:
-  v57_: bool = eq c37_ v0;
+  v57_: bool = eq c37_ c4_;
   br v57_ .b58_ .b59_;
 .b58_:
   v60_: int = call @fac c2_;
-  v61_: int = id c37_;
+  v61_: int = id c4_;
   v39_: int = id v61_;
-  v42_: int = id v0;
+  v42_: int = id c4_;
   jmp .b43_;
 .b59_:
   c62_: int = const -3;
@@ -131,7 +131,7 @@ expression: visualization.result
   v66_: int = add v64_ v65_;
   v61_: int = id v66_;
   v39_: int = id v61_;
-  v42_: int = id v0;
+  v42_: int = id c4_;
   jmp .b43_;
 .b11_:
   v67_: int = sub v0 c4_;
@@ -269,21 +269,21 @@ expression: visualization.result
   br v129_ .b130_ .b131_;
 .b130_:
   v132_: bool = eq c2_ c2_;
-  v133_: int = id v67_;
+  v133_: int = id c4_;
   br v132_ .b134_ .b135_;
 .b134_:
-  v136_: int = id v67_;
+  v136_: int = id c4_;
   v71_: int = id v136_;
   v74_: int = id c4_;
   jmp .b75_;
 .b135_:
-  v137_: bool = eq c2_ v67_;
+  v137_: bool = eq c2_ c4_;
   br v137_ .b138_ .b139_;
 .b138_:
   v140_: int = call @fac c2_;
-  v141_: int = id c2_;
+  v141_: int = id c4_;
   v133_: int = id v141_;
-  v136_: int = id v67_;
+  v136_: int = id c4_;
   v71_: int = id v136_;
   v74_: int = id c4_;
   jmp .b75_;
@@ -295,7 +295,7 @@ expression: visualization.result
   v146_: int = add v144_ v145_;
   v141_: int = id v146_;
   v133_: int = id v141_;
-  v136_: int = id v67_;
+  v136_: int = id c4_;
   v71_: int = id v136_;
   v74_: int = id c4_;
   jmp .b75_;
@@ -337,7 +337,7 @@ expression: visualization.result
   br v169_ .b170_ .b171_;
 .b170_:
   v172_: int = call @fac c2_;
-  v173_: int = id v147_;
+  v173_: int = id c4_;
   v151_: int = id v173_;
   v154_: int = id c4_;
   jmp .b155_;
@@ -370,35 +370,35 @@ expression: visualization.result
   br v9_ .b10_ .b11_;
 .b10_:
   v12_: bool = eq c2_ c2_;
-  v13_: int = id c1_;
+  v13_: int = id c4_;
   br v12_ .b14_ .b15_;
 .b14_:
-  v16_: int = id c1_;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   print v5_;
   ret;
   jmp .b8_;
 .b15_:
-  v17_: bool = eq c1_ c2_;
+  v17_: bool = eq c2_ c4_;
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: int = call @fac c2_;
-  v21_: int = id c2_;
+  v21_: int = id c4_;
   v13_: int = id v21_;
-  v16_: int = id c1_;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   print v5_;
   ret;
   jmp .b8_;
 .b19_:
   c22_: int = const -1;
-  v23_: int = sub c22_ c1_;
+  v23_: int = sub c22_ c4_;
   v24_: int = call @fac c22_;
   v25_: int = call @fac v23_;
   v26_: int = add v24_ v25_;
   v21_: int = id v26_;
   v13_: int = id v21_;
-  v16_: int = id c1_;
+  v16_: int = id c4_;
   v5_: int = id v16_;
   print v5_;
   ret;

--- a/tests/snapshots/files__if_dead_code_nested-optimize.snap
+++ b/tests/snapshots/files__if_dead_code_nested-optimize.snap
@@ -5,96 +5,92 @@ expression: visualization.result
 # ARGS: 1
 @main(v0: int) {
 .b1_:
-  c2_: int = const 0;
-  v3_: bool = le v0 c2_;
-  c4_: int = const 3;
-  c5_: int = const 2;
-  br v3_ .b6_ .b7_;
-.b6_:
-  v8_: bool = lt v0 c2_;
-  c9_: bool = const true;
-  c10_: int = const 1;
-  c11_: int = const 2;
-  v12_: int = id c11_;
-  v13_: bool = id c9_;
-  v14_: int = id c10_;
-  br v8_ .b15_ .b16_;
-.b15_:
-  v12_: int = id c10_;
-  v13_: bool = id c9_;
-  v14_: int = id c10_;
-  v17_: int = id v12_;
-  v18_: int = id c10_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
-  print v3_;
-  print v17_;
-  ret;
-  jmp .b21_;
-.b16_:
-  v17_: int = id v12_;
-  v18_: int = id c10_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
-  print v20_;
-  print v3_;
-  print v17_;
-  ret;
-  jmp .b21_;
+  c2_: int = const 1;
+  v3_: bool = lt v0 c2_;
+  c4_: int = const 0;
+  c5_: int = const 3;
+  c6_: int = const 2;
+  br v3_ .b7_ .b8_;
 .b7_:
-  v22_: bool = gt v0 c5_;
+  v9_: bool = lt v0 c4_;
+  c10_: bool = const true;
+  c11_: int = const 1;
+  c12_: int = const 2;
+  v13_: int = id c12_;
+  v14_: bool = id c10_;
+  v15_: int = id c11_;
+  br v9_ .b16_ .b17_;
+.b16_:
+  v13_: int = id c11_;
+  v14_: bool = id c10_;
+  v15_: int = id c11_;
+  v18_: int = id v13_;
+  v19_: int = id c11_;
+  v20_: int = select v3_ c2_ c4_;
+  print v20_;
+  print v3_;
+  print v18_;
+  ret;
+  jmp .b21_;
+.b17_:
+  v18_: int = id v13_;
+  v19_: int = id c11_;
+  v20_: int = select v3_ c2_ c4_;
+  print v20_;
+  print v3_;
+  print v18_;
+  ret;
+  jmp .b21_;
+.b8_:
+  v22_: bool = gt v0 c6_;
   c23_: bool = const false;
   c24_: int = const 2;
   v25_: int = id c24_;
   v26_: bool = id c23_;
-  v27_: int = id c2_;
+  v27_: int = id c4_;
   br v22_ .b28_ .b29_;
 .b28_:
-  v30_: bool = gt v0 c4_;
+  v30_: bool = gt v0 c5_;
   c31_: int = const 4;
   v32_: int = id c31_;
   v33_: bool = id c23_;
-  v34_: int = id c2_;
+  v34_: int = id c4_;
   br v30_ .b35_ .b36_;
 .b35_:
   c37_: int = const 3;
   v32_: int = id c37_;
   v33_: bool = id c23_;
-  v34_: int = id c2_;
+  v34_: int = id c4_;
   v25_: int = id v32_;
   v26_: bool = id v33_;
   v27_: int = id v34_;
-  v17_: int = id v25_;
-  v18_: int = id c2_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
+  v18_: int = id v25_;
+  v19_: int = id c4_;
+  v20_: int = select v3_ c2_ c4_;
   print v20_;
   print v3_;
-  print v17_;
+  print v18_;
   ret;
   jmp .b21_;
 .b36_:
   v25_: int = id v32_;
   v26_: bool = id v33_;
   v27_: int = id v34_;
-  v17_: int = id v25_;
-  v18_: int = id c2_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
+  v18_: int = id v25_;
+  v19_: int = id c4_;
+  v20_: int = select v3_ c2_ c4_;
   print v20_;
   print v3_;
-  print v17_;
+  print v18_;
   ret;
   jmp .b21_;
 .b29_:
-  v17_: int = id v25_;
-  v18_: int = id c2_;
-  c19_: int = const 1;
-  v20_: int = select v3_ c19_ c2_;
+  v18_: int = id v25_;
+  v19_: int = id c4_;
+  v20_: int = select v3_ c2_ c4_;
   print v20_;
   print v3_;
-  print v17_;
+  print v18_;
   ret;
 .b21_:
 }

--- a/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_loop_store_forwarding-optimize.snap
@@ -28,12 +28,12 @@ expression: visualization.result
   v11_: bool = id v11_;
   jmp .b12_;
 .b14_:
-  c15_: int = const 10;
-  c16_: int = const 20;
-  store v9_ c15_;
-  store v10_ c16_;
+  c15_: int = const 20;
+  c16_: int = const 10;
+  store v9_ c16_;
+  store v10_ c15_;
   v17_: int = load v9_;
-  print c15_;
+  print v17_;
   free v8_;
   ret;
 }

--- a/tests/snapshots/files__mem_simple_redundant_load-optimize-sequential.snap
+++ b/tests/snapshots/files__mem_simple_redundant_load-optimize-sequential.snap
@@ -14,7 +14,7 @@ expression: visualization.result
   v7_: ptr<int> = id v3_;
   v8_: int = load v3_;
   v9_: int = load v3_;
-  print v8_;
+  print v9_;
   free v3_;
   ret;
   jmp .b10_;
@@ -24,7 +24,7 @@ expression: visualization.result
   v7_: ptr<int> = id v3_;
   v8_: int = load v3_;
   v9_: int = load v3_;
-  print v8_;
+  print v9_;
   free v3_;
   ret;
 .b10_:

--- a/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
+++ b/tests/snapshots/files__mem_simple_redundant_load-optimize.snap
@@ -14,7 +14,7 @@ expression: visualization.result
   v7_: ptr<int> = id v3_;
   v8_: int = load v3_;
   v9_: int = load v3_;
-  print v8_;
+  print v9_;
   free v3_;
   ret;
   jmp .b10_;
@@ -24,7 +24,7 @@ expression: visualization.result
   v7_: ptr<int> = id v3_;
   v8_: int = load v3_;
   v9_: int = load v3_;
-  print v8_;
+  print v9_;
   free v3_;
   ret;
 .b10_:

--- a/tests/snapshots/files__mem_simple_store_forwarding-optimize-sequential.snap
+++ b/tests/snapshots/files__mem_simple_store_forwarding-optimize-sequential.snap
@@ -7,14 +7,14 @@ expression: visualization.result
 .b0_:
   c1_: int = const 2;
   v2_: ptr<int> = alloc c1_;
-  c3_: int = const 10;
-  c4_: int = const 1;
-  v5_: ptr<int> = ptradd v2_ c4_;
-  c6_: int = const 20;
-  store v2_ c3_;
-  store v5_ c6_;
+  c3_: int = const 1;
+  v4_: ptr<int> = ptradd v2_ c3_;
+  c5_: int = const 20;
+  c6_: int = const 10;
+  store v2_ c6_;
+  store v4_ c5_;
   v7_: int = load v2_;
-  print c3_;
+  print v7_;
   free v2_;
   ret;
 }

--- a/tests/snapshots/files__mem_simple_store_forwarding-optimize.snap
+++ b/tests/snapshots/files__mem_simple_store_forwarding-optimize.snap
@@ -7,14 +7,14 @@ expression: visualization.result
 .b0_:
   c1_: int = const 2;
   v2_: ptr<int> = alloc c1_;
-  c3_: int = const 10;
-  c4_: int = const 1;
-  v5_: ptr<int> = ptradd v2_ c4_;
-  c6_: int = const 20;
-  store v2_ c3_;
-  store v5_ c6_;
+  c3_: int = const 1;
+  v4_: ptr<int> = ptradd v2_ c3_;
+  c5_: int = const 20;
+  c6_: int = const 10;
+  store v2_ c6_;
+  store v4_ c5_;
   v7_: int = load v2_;
-  print c3_;
+  print v7_;
   free v2_;
   ret;
 }

--- a/tests/snapshots/files__reassoc-optimize-sequential.snap
+++ b/tests/snapshots/files__reassoc-optimize-sequential.snap
@@ -5,13 +5,13 @@ expression: visualization.result
 # ARGS: 2 4
 @main(v0: int, v1: int) {
 .b2_:
-  c3_: int = const 1;
-  c4_: int = const 3;
-  v5_: int = add c4_ v0;
-  c6_: int = const 4;
-  v7_: int = add c6_ v1;
-  v8_: int = add v5_ v7_;
-  v9_: int = add c3_ v8_;
+  c3_: int = const 4;
+  v4_: int = add c3_ v1;
+  c5_: int = const 3;
+  v6_: int = add c5_ v0;
+  v7_: int = add v4_ v6_;
+  c8_: int = const 1;
+  v9_: int = add c8_ v7_;
   print v9_;
   ret;
 }

--- a/tests/snapshots/files__reassoc-optimize.snap
+++ b/tests/snapshots/files__reassoc-optimize.snap
@@ -5,13 +5,13 @@ expression: visualization.result
 # ARGS: 2 4
 @main(v0: int, v1: int) {
 .b2_:
-  c3_: int = const 1;
-  c4_: int = const 3;
-  v5_: int = add c4_ v0;
-  c6_: int = const 4;
-  v7_: int = add c6_ v1;
-  v8_: int = add v5_ v7_;
-  v9_: int = add c3_ v8_;
+  c3_: int = const 4;
+  v4_: int = add c3_ v1;
+  c5_: int = const 3;
+  v6_: int = add c5_ v0;
+  v7_: int = add v4_ v6_;
+  c8_: int = const 1;
+  v9_: int = add c8_ v7_;
   print v9_;
   ret;
 }

--- a/tests/snapshots/files__simple_loop_swap-optimize-sequential.snap
+++ b/tests/snapshots/files__simple_loop_swap-optimize-sequential.snap
@@ -7,14 +7,14 @@ expression: visualization.result
 .b0_:
   c1_: int = const 2;
   v2_: ptr<int> = alloc c1_;
-  c3_: int = const 10;
-  c4_: int = const 1;
-  v5_: ptr<int> = ptradd v2_ c4_;
-  c6_: int = const 20;
-  store v2_ c3_;
-  store v5_ c6_;
+  c3_: int = const 1;
+  v4_: ptr<int> = ptradd v2_ c3_;
+  c5_: int = const 20;
+  c6_: int = const 10;
+  store v2_ c6_;
+  store v4_ c5_;
   v7_: int = load v2_;
-  print c3_;
+  print v7_;
   free v2_;
   ret;
 }

--- a/tests/snapshots/files__simple_loop_swap-optimize.snap
+++ b/tests/snapshots/files__simple_loop_swap-optimize.snap
@@ -7,14 +7,14 @@ expression: visualization.result
 .b0_:
   c1_: int = const 2;
   v2_: ptr<int> = alloc c1_;
-  c3_: int = const 10;
-  c4_: int = const 1;
-  v5_: ptr<int> = ptradd v2_ c4_;
-  c6_: int = const 20;
-  store v2_ c3_;
-  store v5_ c6_;
+  c3_: int = const 1;
+  v4_: ptr<int> = ptradd v2_ c3_;
+  c5_: int = const 20;
+  c6_: int = const 10;
+  store v2_ c6_;
+  store v4_ c5_;
   v7_: int = load v2_;
-  print c3_;
+  print v7_;
   free v2_;
   ret;
 }

--- a/tests/snapshots/files__sqrt_small-optimize.snap
+++ b/tests/snapshots/files__sqrt_small-optimize.snap
@@ -38,8 +38,8 @@ expression: visualization.result
   v29_: float = fadd v22_ v28_;
   v30_: float = fdiv v29_ v25_;
   v31_: float = fdiv v30_ v22_;
-  v32_: bool = fge v31_ v24_;
-  v33_: bool = fle v31_ v23_;
+  v32_: bool = fle v31_ v23_;
+  v33_: bool = fge v31_ v24_;
   v34_: bool = and v32_ v33_;
   v35_: bool = not v34_;
   v21_: float = id v21_;


### PR DESCRIPTION
This PR is a stepping stone for making our schedule faster. It simplifies things by listing out the rulesets explicitly, and is a good intermediate point for #663 