### PR TITLE
Use normalized times instead of speedup in nightly

### DIFF
--- a/infra/jitter.py
+++ b/infra/jitter.py
@@ -154,5 +154,3 @@ if __name__ == '__main__':
         profile = json.load(f)
 
     make_plot(profile, 4, f'{output_folder}/jitter_plot_max_4.png')
-    #make_plot(profile, 2000, f'{output_folder}/jitter_plot_2k_cycles.png')
-    #make_plot(profile, 100000, f'{output_folder}/jitter_plot_100k_cycles.png')

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -48,7 +48,6 @@ function variance(cycles) {
   return res;
 }
 
-
 function stddev(cycles) {
   return Math.sqrt(variance(cycles));
 }

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -102,7 +102,7 @@ function getValue(entry) {
 
 function getError(entry) {
   if (GLOBAL_DATA.chart.mode === "absolute") {
-    return confidence_interval_98percent(entry["cycles"]);
+    return stddev(entry["cycles"]);
   } else {
     const baseline = getEntry(entry.benchmark, BASELINE_MODE);
     if (!baseline) {
@@ -112,7 +112,7 @@ function getError(entry) {
     const normalized = entry["cycles"].map((c) => c / baseline_mean);
 
     // TODO what is n here? This is almost certainly not right
-    return confidence_interval_98percent(normalized);
+    return stddev(normalized);
   }
 }
 

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -53,17 +53,6 @@ function stddev(cycles) {
   return Math.sqrt(variance(cycles));
 }
 
-function variance_to_confidence_interval(variance, n) {
-  const std = Math.sqrt(variance);
-  const z_val = 2.326;
-  const error = (z_val * std) / Math.sqrt(n);
-  return error;
-}
-
-function confidence_interval_98percent(cycles) {
-  return variance_to_confidence_interval(variance(cycles), cycles.length);
-}
-
 function getEntry(benchmark, runMode) {
   const entries = GLOBAL_DATA.currentRun.filter(
     (entry) => entry.benchmark === benchmark && entry.runMethod === runMode,

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -89,10 +89,12 @@ function getValue(entry) {
   }
 }
 
+// get error bars for the bar chart
 function getError(entry) {
   if (GLOBAL_DATA.chart.mode === "absolute") {
     return stddev(entry["cycles"]);
   } else {
+    // when normalized, normalize the values then take the stddev
     const baseline = getEntry(entry.benchmark, BASELINE_MODE);
     if (!baseline) {
       addWarning(`No normalized baseline for ${benchmark}`);
@@ -100,7 +102,6 @@ function getError(entry) {
     const baseline_mean = mean(baseline["cycles"]);
     const normalized = entry["cycles"].map((c) => c / baseline_mean);
 
-    // TODO what is n here? This is almost certainly not right
     return stddev(normalized);
   }
 }

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -74,13 +74,13 @@ function getOverallStatistics() {
   const result = [];
   for (const treatment of treatments) {
     // calculate geometric mean of normalizeds
-    const normalizeds = [];
+    const normalized_cycles = [];
     // for each benchmark, calculate the normalized
     for (const benchmark of GLOBAL_DATA.enabledBenchmarks) {
       const row = getRow(benchmark, treatment);
       const baseline = getRow(benchmark, BASELINE_MODE);
       if (row && baseline) {
-        normalizeds.push(normalized(row, baseline));
+        normalized_cycles.push(normalized(row, baseline));
       }
     }
 
@@ -95,7 +95,7 @@ function getOverallStatistics() {
     // calculate the geometric mean of the normalizeds
     result.push({
       runMethod: treatment,
-      geoMeannormalized: tryRound(geometricMean(normalizeds)),
+      geoMeanNormalized: tryRound(geometricMean(normalized_cycles)),
       meanEggccCompileTimeSecs: tryRound(mean(eggcc_compile_times)),
       meanLlvmCompileTimeSecs: tryRound(mean(llvm_compile_times)),
     });

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -73,9 +73,8 @@ function getOverallStatistics() {
   // generate one row per treatment...
   const result = [];
   for (const treatment of treatments) {
-    // calculate geometric mean of normalizeds
     const normalized_cycles = [];
-    // for each benchmark, calculate the normalized
+    // for each benchmark, calculate the normalized cycles
     for (const benchmark of GLOBAL_DATA.enabledBenchmarks) {
       const row = getRow(benchmark, treatment);
       const baseline = getRow(benchmark, BASELINE_MODE);
@@ -92,7 +91,6 @@ function getOverallStatistics() {
       llvm_compile_times.push(row.llvmCompileTimeSecs);
     }
 
-    // calculate the geometric mean of the normalizeds
     result.push({
       runMethod: treatment,
       geoMeanNormalized: tryRound(geometricMean(normalized_cycles)),

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -73,14 +73,14 @@ function getOverallStatistics() {
   // generate one row per treatment...
   const result = [];
   for (const treatment of treatments) {
-    // calculate geometric mean of speedups
-    const speedups = [];
-    // for each benchmark, calculate the speedup
+    // calculate geometric mean of normalizeds
+    const normalizeds = [];
+    // for each benchmark, calculate the normalized
     for (const benchmark of GLOBAL_DATA.enabledBenchmarks) {
       const row = getRow(benchmark, treatment);
       const baseline = getRow(benchmark, BASELINE_MODE);
       if (row && baseline) {
-        speedups.push(speedup(row, baseline));
+        normalizeds.push(normalized(row, baseline));
       }
     }
 
@@ -92,10 +92,10 @@ function getOverallStatistics() {
       llvm_compile_times.push(row.llvmCompileTimeSecs);
     }
 
-    // calculate the geometric mean of the speedups
+    // calculate the geometric mean of the normalizeds
     result.push({
       runMethod: treatment,
-      geoMeanSpeedup: tryRound(geometricMean(speedups)),
+      geoMeannormalized: tryRound(geometricMean(normalizeds)),
       meanEggccCompileTimeSecs: tryRound(mean(eggcc_compile_times)),
       meanLlvmCompileTimeSecs: tryRound(mean(llvm_compile_times)),
     });
@@ -136,7 +136,7 @@ function getDataForBenchmark(benchmark) {
           class: "",
           value: tryRound(row.llvmCompileTimeSecs),
         },
-        speedup: { class: "", value: tryRound(speedup(row, baseline)) },
+        normalized: { class: "", value: tryRound(normalized(row, baseline)) },
       };
       if (shouldHaveLlvm(row.runMethod)) {
         rowData.runMethod = `<a target="_blank" rel="noopener noreferrer" href="llvm.html?benchmark=${benchmark}&runmode=${row.runMethod}">${row.runMethod}</a>`;

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -127,7 +127,7 @@ function getDataForBenchmark(benchmark) {
           comparisonCycles,
           median_cycles,
         ),
-        stddev: { class: "", value: tryRound(median_cycles(cycles)) },
+        stddev: { class: "", value: tryRound(stddev(cycles)) },
         eggccCompileTimeSecs: {
           class: "",
           value: tryRound(row.eggccCompileTimeSecs),

--- a/infra/nightly-resources/handlers.js
+++ b/infra/nightly-resources/handlers.js
@@ -141,8 +141,8 @@ async function loadBaseline(url) {
 
 function onRadioClick(value) {
   GLOBAL_DATA.chart.mode = value;
-  document.getElementById("speedup-formula").style.visibility =
-    value === "speedup" ? "visible" : "hidden";
+  document.getElementById("normalized-formula").style.visibility =
+    value === "normalized" ? "visible" : "hidden";
   refreshChart();
 }
 

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -24,9 +24,9 @@
     <div class="expanded">
       <input onclick="onRadioClick('absolute');" checked type="radio" id="absolute" name="chart-type" value="absolute">
       <label for="absolute">Absolute</label>
-      <input onclick="onRadioClick('speedup');" type="radio" id="speedup" name="chart-type" value="speedup">
-      <label for="speedup">Speedup</label><br>
-      <p id="speedup-formula">Speedup = (LLVM-O0 TIME / RUN MODE TIME)</p>
+      <input onclick="onRadioClick('normalized');" type="radio" id="normalized" name="chart-type" value="normalized">
+      <label for="normalized">Normalized</label><br>
+      <p id="normalized-formula">Normalized = (RUN MODE MEAN / LLVM-O0-O0 MEAN)</p>
       <canvas class="content" id="chart"></canvas>
     </div>
   </div>

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -27,7 +27,7 @@
       <input onclick="onRadioClick('normalized');" type="radio" id="normalized" name="chart-type" value="normalized">
       <label for="normalized">Normalized</label><br>
       <p id="normalized-formula">Normalized = (RUN MODE MEAN / LLVM-O0-O0 MEAN)</p>
-      <p id="error-formula">Error bars show 98th percentile confidence intervals</p>
+      <p id="error-formula">Error bars show standard deviation</p>
       <canvas class="content" id="chart"></canvas>
     </div>
   </div>
@@ -73,9 +73,7 @@
     &#9654; Show
   </button>
   <div class="content collapsed" id="jitters">
-    <image id="jitter-plot" src="jitter_plot_full_range.png" />
-    <image id="jitter-plot" src="jitter_plot_100k_cycles.png" />
-    <image id="jitter-plot" src="jitter_plot_2k_cycles.png" />
+    <image id="jitter-plot" src="jitter_plot_max_4.png"/>
   </div>
 
   <h2>Overall Stats</h2>

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -27,6 +27,7 @@
       <input onclick="onRadioClick('normalized');" type="radio" id="normalized" name="chart-type" value="normalized">
       <label for="normalized">Normalized</label><br>
       <p id="normalized-formula">Normalized = (RUN MODE MEAN / LLVM-O0-O0 MEAN)</p>
+      <p id="error-formula">Error bars show 98th percentile confidence intervals</p>
       <canvas class="content" id="chart"></canvas>
     </div>
   </div>

--- a/infra/nightly-resources/stylesheet.css
+++ b/infra/nightly-resources/stylesheet.css
@@ -54,7 +54,7 @@ body {
   overflow: scroll;
 }
 
-#speedup-formula {
+#normalized-formula {
   visibility: hidden;
 }
 


### PR DESCRIPTION
This PR changes nightly to use "normalized times" instead of speedup. This allows us to make meaningful std dev error bars

It also changes the jitter plot to use normalized times.

![image](https://github.com/user-attachments/assets/93ff73ff-53d0-47a1-a487-e0aeb5e988c0)
