### PR TITLE
Add `abs` and make Oliver's example work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
 dependencies = [
  "serde",
  "serde_json",
@@ -235,9 +235,9 @@ dependencies = [
 [[package]]
 name = "bril2json"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
  "clap",
  "lalrpop",
  "lalrpop-util",
@@ -247,10 +247,10 @@ dependencies = [
 [[package]]
 name = "brilift"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
 dependencies = [
  "argh",
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -264,9 +264,9 @@ dependencies = [
 [[package]]
 name = "brilirs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
  "bril2json",
  "clap",
  "fxhash",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "brillvm"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
 dependencies = [
  "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?branch=main)",
  "clap",
@@ -634,7 +634,7 @@ checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
 name = "eggcc"
 version = "0.1.0"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
  "bril2json",
  "brilift",
  "brilirs",
@@ -1649,9 +1649,9 @@ dependencies = [
 [[package]]
 name = "rs2bril"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
  "clap",
  "proc-macro2",
  "syn 2.0.66",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
+source = "git+https://github.com/uwplse/bril?branch=main#4287f7f207b0a04ddd5f7c09c9545d16518cebcb"
 dependencies = [
  "serde",
  "serde_json",
@@ -215,7 +215,17 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril#a48c5e18575aa738e8d08ff483ee23d6c2735107"
+source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "bril-rs"
+version = "0.1.0"
+source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
 dependencies = [
  "serde",
  "serde_json",
@@ -225,9 +235,9 @@ dependencies = [
 [[package]]
 name = "bril2json"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
+source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
  "clap",
  "lalrpop",
  "lalrpop-util",
@@ -237,10 +247,10 @@ dependencies = [
 [[package]]
 name = "brilift"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
+source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
 dependencies = [
  "argh",
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -254,9 +264,9 @@ dependencies = [
 [[package]]
 name = "brilirs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
+source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
  "bril2json",
  "clap",
  "fxhash",
@@ -268,9 +278,9 @@ dependencies = [
 [[package]]
 name = "brillvm"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
+source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?branch=main)",
  "clap",
  "inkwell",
 ]
@@ -624,7 +634,7 @@ checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
 name = "eggcc"
 version = "0.1.0"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
  "bril2json",
  "brilift",
  "brilirs",
@@ -1639,9 +1649,9 @@ dependencies = [
 [[package]]
 name = "rs2bril"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5#f303a7d384f21a891d0215dc47e5ea947f014cf5"
+source = "git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8#53b855bb847a459616b02f830b7d9b8848612dd8"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=f303a7d384f21a891d0215dc47e5ea947f014cf5)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=53b855bb847a459616b02f830b7d9b8848612dd8)",
  "clap",
  "proc-macro2",
  "syn 2.0.66",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
+source = "git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5#bdd8732b219a1f0521977927b4c84cd0ab1bcfc5"
 dependencies = [
  "serde",
  "serde_json",
@@ -235,9 +235,9 @@ dependencies = [
 [[package]]
 name = "bril2json"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
+source = "git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5#bdd8732b219a1f0521977927b4c84cd0ab1bcfc5"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5)",
  "clap",
  "lalrpop",
  "lalrpop-util",
@@ -247,10 +247,10 @@ dependencies = [
 [[package]]
 name = "brilift"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
+source = "git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5#bdd8732b219a1f0521977927b4c84cd0ab1bcfc5"
 dependencies = [
  "argh",
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5)",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -264,9 +264,9 @@ dependencies = [
 [[package]]
 name = "brilirs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
+source = "git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5#bdd8732b219a1f0521977927b4c84cd0ab1bcfc5"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5)",
  "bril2json",
  "clap",
  "fxhash",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "brillvm"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
+source = "git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5#bdd8732b219a1f0521977927b4c84cd0ab1bcfc5"
 dependencies = [
  "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?branch=main)",
  "clap",
@@ -634,7 +634,7 @@ checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
 name = "eggcc"
 version = "0.1.0"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5)",
  "bril2json",
  "brilift",
  "brilirs",
@@ -1649,9 +1649,9 @@ dependencies = [
 [[package]]
 name = "rs2bril"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
+source = "git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5#bdd8732b219a1f0521977927b4c84cd0ab1bcfc5"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=bdd8732b219a1f0521977927b4c84cd0ab1bcfc5)",
  "clap",
  "proc-macro2",
  "syn 2.0.66",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "bril-rs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
+source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
 dependencies = [
  "serde",
  "serde_json",
@@ -235,9 +235,9 @@ dependencies = [
 [[package]]
 name = "bril2json"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
+source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
  "clap",
  "lalrpop",
  "lalrpop-util",
@@ -247,10 +247,10 @@ dependencies = [
 [[package]]
 name = "brilift"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
+source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
 dependencies = [
  "argh",
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -264,9 +264,9 @@ dependencies = [
 [[package]]
 name = "brilirs"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
+source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
  "bril2json",
  "clap",
  "fxhash",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "brillvm"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
+source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
 dependencies = [
  "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?branch=main)",
  "clap",
@@ -634,7 +634,7 @@ checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
 name = "eggcc"
 version = "0.1.0"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
  "bril2json",
  "brilift",
  "brilirs",
@@ -1649,9 +1649,9 @@ dependencies = [
 [[package]]
 name = "rs2bril"
 version = "0.1.0"
-source = "git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6#d6aa8a3e85d5a013ec930565b939e8b7f31829d6"
+source = "git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426#1f12195d043dccee1815cf6a1d88bf91b686d426"
 dependencies = [
- "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=d6aa8a3e85d5a013ec930565b939e8b7f31829d6)",
+ "bril-rs 0.1.0 (git+https://github.com/uwplse/bril?rev=1f12195d043dccee1815cf6a1d88bf91b686d426)",
  "clap",
  "proc-macro2",
  "syn 2.0.66",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ rpds = "1.1.0"
 
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 # currently using the uwplse/bril fork of bril, on eggcc-main
-bril2json = { git = "https://github.com/uwplse/bril", rev = "f303a7d384f21a891d0215dc47e5ea947f014cf5" }
-brilirs = { git = "https://github.com/uwplse/bril", rev = "f303a7d384f21a891d0215dc47e5ea947f014cf5" }
-bril-rs = { git = "https://github.com/uwplse/bril", rev = "f303a7d384f21a891d0215dc47e5ea947f014cf5" }
-brilift = { git = "https://github.com/uwplse/bril", rev = "f303a7d384f21a891d0215dc47e5ea947f014cf5" }
-rs2bril = { git = "https://github.com/uwplse/bril", rev = "f303a7d384f21a891d0215dc47e5ea947f014cf5" ,features = [
+bril2json = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
+brilirs = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
+bril-rs = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
+brilift = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
+rs2bril = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" ,features = [
   "import",
 ] }
-brillvm = { git = "https://github.com/uwplse/bril", rev = "f303a7d384f21a891d0215dc47e5ea947f014cf5" }
+brillvm = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
 
 ordered-float = "3.7.0"
 serde_json = "1.0.103"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ rpds = "1.1.0"
 
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 # currently using the uwplse/bril fork of bril, on eggcc-main
-bril2json = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
-brilirs = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
-bril-rs = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
-brilift = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
-rs2bril = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" ,features = [
+bril2json = { git = "https://github.com/uwplse/bril", rev = "bdd8732b219a1f0521977927b4c84cd0ab1bcfc5" }
+brilirs = { git = "https://github.com/uwplse/bril", rev = "bdd8732b219a1f0521977927b4c84cd0ab1bcfc5" }
+bril-rs = { git = "https://github.com/uwplse/bril", rev = "bdd8732b219a1f0521977927b4c84cd0ab1bcfc5" }
+brilift = { git = "https://github.com/uwplse/bril", rev = "bdd8732b219a1f0521977927b4c84cd0ab1bcfc5" }
+rs2bril = { git = "https://github.com/uwplse/bril", rev = "bdd8732b219a1f0521977927b4c84cd0ab1bcfc5" ,features = [
   "import",
 ] }
-brillvm = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
+brillvm = { git = "https://github.com/uwplse/bril", rev = "bdd8732b219a1f0521977927b4c84cd0ab1bcfc5" }
 
 ordered-float = "3.7.0"
 serde_json = "1.0.103"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ rpds = "1.1.0"
 
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 # currently using the uwplse/bril fork of bril, on eggcc-main
-bril2json = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
-brilirs = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
-bril-rs = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
-brilift = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
-rs2bril = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" ,features = [
+bril2json = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
+brilirs = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
+bril-rs = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
+brilift = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
+rs2bril = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" ,features = [
   "import",
 ] }
-brillvm = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
+brillvm = { git = "https://github.com/uwplse/bril", rev = "1f12195d043dccee1815cf6a1d88bf91b686d426" }
 
 ordered-float = "3.7.0"
 serde_json = "1.0.103"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ rpds = "1.1.0"
 
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 # currently using the uwplse/bril fork of bril, on eggcc-main
-bril2json = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
-brilirs = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
-bril-rs = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
-brilift = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
-rs2bril = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" ,features = [
+bril2json = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
+brilirs = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
+bril-rs = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
+brilift = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
+rs2bril = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" ,features = [
   "import",
 ] }
-brillvm = { git = "https://github.com/uwplse/bril", rev = "53b855bb847a459616b02f830b7d9b8848612dd8" }
+brillvm = { git = "https://github.com/uwplse/bril", rev = "d6aa8a3e85d5a013ec930565b939e8b7f31829d6" }
 
 ordered-float = "3.7.0"
 serde_json = "1.0.103"

--- a/benchmarks/passing/raytrace.rs
+++ b/benchmarks/passing/raytrace.rs
@@ -107,7 +107,7 @@ fn main(xpos: f64, ypos: f64, zpos: f64, width: f64, height: f64) {
 
                 let brightness: f64 = 1.0 / (light_dist * light_dist);
                 let light_dot: f64 = dot(point_to_light_norm, res_ray[1]);
-                let abs_light_dot: f64 = abs(light_dot);
+                let abs_light_dot: f64 = fabs(light_dot);
 
                 output[row2 as usize][col2 as usize] = brightness * abs_light_dot;
                 drop(point_to_light);
@@ -198,7 +198,7 @@ fn vec_scale(a: [f64; 3], s: f64) -> [f64; 3] {
     return [a[0] * s, a[1] * s, a[2] * s];
 }
 
-fn abs(x: f64) -> f64 {
+fn fabs(x: f64) -> f64 {
     let mut res: f64 = x;
     if x < 0.0 {
         res = -res;
@@ -211,7 +211,7 @@ fn sqrt(x: f64) -> f64 {
     let tolerance: f64 = 1e-2; // Set precision level
     let mut num_iters: i64 = 100;
 
-    while (num_iters > 0 && abs(guess * guess - x) > tolerance) {
+    while (num_iters > 0 && fabs(guess * guess - x) > tolerance) {
         guess = (guess + x / guess) / 2.0;
         num_iters = num_iters - 1;
     }
@@ -422,7 +422,7 @@ fn partition_cost(
     return cost;
 }
 
-fn min(a: f64, b: f64) -> f64 {
+fn fmin(a: f64, b: f64) -> f64 {
     let mut res: f64 = a;
     if b < a {
         res = b;
@@ -430,7 +430,7 @@ fn min(a: f64, b: f64) -> f64 {
     return res;
 }
 
-fn max(a: f64, b: f64) -> f64 {
+fn fmax(a: f64, b: f64) -> f64 {
     let mut res: f64 = a;
     if b > a {
         res = b;
@@ -439,11 +439,11 @@ fn max(a: f64, b: f64) -> f64 {
 }
 
 fn point_max(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    return [max(a[0], b[0]), max(a[1], b[1]), max(a[2], b[2])];
+    return [fmax(a[0], b[0]), fmax(a[1], b[1]), fmax(a[2], b[2])];
 }
 
 fn point_min(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    return [min(a[0], b[0]), min(a[1], b[1]), min(a[2], b[2])];
+    return [fmin(a[0], b[0]), fmin(a[1], b[1]), fmin(a[2], b[2])];
 }
 
 fn triangle_min(tri: [[f64; 3]; 3]) -> [f64; 3] {
@@ -731,21 +731,21 @@ fn bbox_ray_intersect(bbox: [[f64; 3]; 2], ray: &[[f64; 3]; 2]) -> bool {
     let epsilon: f64 = 0.0000001;
     let t1: f64 = (bbox[0][0] - ray[0][0]) / ray[1][0];
     let t2: f64 = (bbox[1][0] - ray[0][0]) / ray[1][0];
-    let tmin: f64 = min(t1, t2);
-    let tmax: f64 = max(t1, t2);
+    let tmin: f64 = fmin(t1, t2);
+    let tmax: f64 = fmax(t1, t2);
 
     let t3: f64 = (bbox[0][1] - ray[0][1]) / ray[1][1];
     let t4: f64 = (bbox[1][1] - ray[0][1]) / ray[1][1];
-    let tmin2: f64 = min(t3, t4);
-    let tmax2: f64 = max(t3, t4);
+    let tmin2: f64 = fmin(t3, t4);
+    let tmax2: f64 = fmax(t3, t4);
 
     let t5: f64 = (bbox[0][2] - ray[0][2]) / ray[1][2];
     let t6: f64 = (bbox[1][2] - ray[0][2]) / ray[1][2];
-    let tmin3: f64 = min(t5, t6);
-    let tmax3: f64 = max(t5, t6);
+    let tmin3: f64 = fmin(t5, t6);
+    let tmax3: f64 = fmax(t5, t6);
 
-    let tmin_final: f64 = max(tmin, max(tmin2, tmin3));
-    let tmax_final: f64 = min(tmax, min(tmax2, tmax3));
+    let tmin_final: f64 = fmax(tmin, fmax(tmin2, tmin3));
+    let tmax_final: f64 = fmin(tmax, fmin(tmax2, tmax3));
 
     return tmax_final >= tmin_final && tmax_final > epsilon;
 }

--- a/dag_in_context/src/ast.rs
+++ b/dag_in_context/src/ast.rs
@@ -86,6 +86,10 @@ macro_rules! tuplev {
 }
 pub use tuplev;
 
+pub fn abs(l: RcExpr) -> RcExpr {
+    RcExpr::new(Expr::Uop(UnaryOp::Abs, l))
+}
+
 pub fn add(l: RcExpr, r: RcExpr) -> RcExpr {
     RcExpr::new(Expr::Bop(BinaryOp::Add, l, r))
 }

--- a/dag_in_context/src/from_egglog.rs
+++ b/dag_in_context/src/from_egglog.rs
@@ -200,6 +200,7 @@ impl<'a> FromEgglog<'a> {
     fn uop_from_egglog(&mut self, uop: Term) -> UnaryOp {
         match_term_app!(uop.clone();
         {
+          ("Abs", []) => UnaryOp::Abs,
           ("Not", []) => UnaryOp::Not,
           _ => panic!("Invalid unary op: {:?}", uop),
         })

--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -996,7 +996,7 @@ impl CostModel for DefaultCostModel {
             "Base" | "TupleT" | "TNil" | "TCons" => 0.,
             "Int" | "Bool" | "Float" => 0.,
             // Algebra
-            "Add" | "PtrAdd" | "Sub" | "And" | "Or" | "Not" | "Shl" | "Shr" => 10.,
+            "Abs" | "Add" | "PtrAdd" | "Sub" | "And" | "Or" | "Not" | "Shl" | "Shr" => 10.,
             "FAdd" | "FSub" | "Fmax" | "Fmin" => 50.,
             "Mul" => 30.,
             "FMul" => 150.,

--- a/dag_in_context/src/interpreter.rs
+++ b/dag_in_context/src/interpreter.rs
@@ -334,8 +334,10 @@ impl<'a> VirtualMachine<'a> {
     }
 
     fn interpret_uop(&mut self, uop: &UnaryOp, e: &RcExpr, arg: &Value) -> Value {
+        let get_int = |e: &RcExpr, vm: &mut Self| vm.interp_int_expr(e, arg);
         match uop {
             UnaryOp::Not => Const(Constant::Bool(!self.interp_bool_expr(e, arg))),
+            UnaryOp::Abs => Const(Constant::Int(get_int(e, self).abs())),
         }
     }
 

--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -168,10 +168,10 @@
         (= lhs (Bop (Mul) x y))
         (= (IntB hi-x) (hi-bound x))
         (= (IntB hi-y) (hi-bound y))
-        (<= hi-x 0)
-        (<= hi-y 0) 
+        (< hi-x 0)
+        (< hi-y 0) 
       )
-      ((set (lo-bound lhs) (IntB 0)))
+      ((set (lo-bound lhs) (IntB 1)))
       :ruleset interval-analysis)
 
 ; negative * positive is negative
@@ -179,13 +179,46 @@
         (= lhs (Bop (Mul) x y))
         (= (IntB hi-x) (hi-bound x))
         (= (IntB lo-y) (lo-bound y))
-        (<= hi-x 0) ; x <= 0 (x is negative)
-        (>= lo-y 0) ; y >= 0 (y is positive)
+        (< hi-x 0) ; x < 0 (x is negative)
+        (> lo-y 0) ; y > 0 (y is positive)
+      )
+      ((set (hi-bound lhs) (IntB -1)))
+      :ruleset interval-analysis)
+
+; positive * positive is positive
+(rule (
+        (= lhs (Bop (Mul) x y))
+        (= (IntB lo-x) (lo-bound x))
+        (= (IntB lo-y) (lo-bound y))
+        (> lo-x 0)
+        (> lo-y 0)
+      )
+      ((set (lo-bound lhs) (IntB 1)))
+      :ruleset interval-analysis)
+
+; non-positive * non-positive is non-negative
+(rule (
+        (= lhs (Bop (Mul) x y))
+        (= (IntB hi-x) (hi-bound x))
+        (= (IntB hi-y) (hi-bound y))
+        (<= hi-x 0)
+        (<= hi-y 0) 
+      )
+      ((set (lo-bound lhs) (IntB 0)))
+      :ruleset interval-analysis)
+
+; non-positive * non-negative is non-positive
+(rule (
+        (= lhs (Bop (Mul) x y))
+        (= (IntB hi-x) (hi-bound x))
+        (= (IntB lo-y) (lo-bound y))
+        (<= hi-x 0) ; x <= 0 (x is non-positive)
+        (>= lo-y 0) ; y >= 0 (y is non-negative)
       )
       ((set (hi-bound lhs) (IntB 0)))
       :ruleset interval-analysis)
 
-; positive * positive is positive
+; non-negative * non-negative is non-negative
 (rule (
         (= lhs (Bop (Mul) x y))
         (= (IntB lo-x) (lo-bound x))

--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -1,6 +1,8 @@
 (ruleset interval-analysis)
 (ruleset interval-rewrite)
 
+(relation Debug (String Expr))
+
 (datatype Bound
   (IntB i64)
   (BoolB bool)
@@ -245,6 +247,41 @@
        (= (IntB hb) (hi-bound b))
       )
       ((set (hi-bound lhs) (BoolB (bool-< la hb))))
+      :ruleset interval-analysis)
+
+; Abs
+
+; absolute value is non-negative
+(rule (
+        (= lhs (Uop (Abs) x))
+      )
+      (
+            (Debug "rule1" lhs)
+            (set (lo-bound lhs) (IntB 0)))
+      :ruleset interval-analysis)
+
+; abs(x) = x if x >= 0
+(rule (
+        (= lhs (Uop (Abs) x))
+        (= (IntB lx) (lo-bound x))
+        (>= lx 0)
+      )
+      (
+            (Debug "rule2" lhs)
+            (union lhs x))
+      :ruleset interval-analysis)
+
+; abs(x) = -x if x <= 0
+(rule (
+        (= lhs (Uop (Abs) x))
+        (= (IntB hx) (hi-bound x))
+        (<= hx 0)
+        (HasArgType lhs ty)
+        (ContextOf lhs ctx)
+      )
+      (
+            (Debug "rule3" lhs)
+            (union lhs (Bop (Sub) (Const (Int 0) ty ctx) x)))
       :ruleset interval-analysis)
 
 ; =================================

--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -1,8 +1,6 @@
 (ruleset interval-analysis)
 (ruleset interval-rewrite)
 
-(relation Debug (String Expr))
-
 (datatype Bound
   (IntB i64)
   (BoolB bool)
@@ -255,9 +253,7 @@
 (rule (
         (= lhs (Uop (Abs) x))
       )
-      (
-            (Debug "rule1" lhs)
-            (set (lo-bound lhs) (IntB 0)))
+      ((set (lo-bound lhs) (IntB 0)))
       :ruleset interval-analysis)
 
 ; abs(x) = x if x >= 0
@@ -266,9 +262,7 @@
         (= (IntB lx) (lo-bound x))
         (>= lx 0)
       )
-      (
-            (Debug "rule2" lhs)
-            (union lhs x))
+      ((union lhs x))
       :ruleset interval-analysis)
 
 ; abs(x) = -x if x <= 0
@@ -279,9 +273,7 @@
         (HasArgType lhs ty)
         (ContextOf lhs ctx)
       )
-      (
-            (Debug "rule3" lhs)
-            (union lhs (Bop (Sub) (Const (Int 0) ty ctx) x)))
+      ((union lhs (Bop (Sub) (Const (Int 0) ty ctx) x)))
       :ruleset interval-analysis)
 
 ; =================================
@@ -352,7 +344,7 @@
         (HasType inputs ty)
       )
       ; expr < value was true, so we know expr is at most (hi-bound value) - 1
-      ((set (hi-bound (Get ctx i)) (IntB (- v 1)))) 
+      ((set (hi-bound (Get ctx i)) (IntB (- v 1))))
       :ruleset interval-analysis)
 (rule (
         ; expr < value

--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -248,14 +248,6 @@
       :ruleset interval-analysis)
 
 ; Abs
-
-; absolute value is non-negative
-(rule (
-        (= lhs (Uop (Abs) x))
-      )
-      ((set (lo-bound lhs) (IntB 0)))
-      :ruleset interval-analysis)
-
 ; abs(x) = x if x >= 0
 (rule (
         (= lhs (Uop (Abs) x))

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -20,3 +20,27 @@
 (rewrite (Bop (Or) e (Const (Bool false) ty ctx)) e :ruleset peepholes)
 (rewrite (Bop (Or) (Const (Bool true) ty ctx) e) (Const (Bool true) ty ctx) :ruleset peepholes)
 (rewrite (Bop (Or) e (Const (Bool true) ty ctx)) (Const (Bool true) ty ctx) :ruleset peepholes)
+
+(rule (
+        (= expr (Bop (Sub) x x))
+        (HasArgType expr ty)
+        (ContextOf expr ctx)
+      )
+      (
+        (Debug "x-x=0" expr)
+        (union expr (Const (Int 0) ty ctx)))
+      :ruleset peepholes)
+
+; (x - y) + z => x + (z - y)
+; (rewrite (Bop (Add) (Bop (Sub) x y) z) (Bop (Add) x (Bop (Sub) z y)) :ruleset peepholes)
+(rule (
+        (= lhs (Bop (Add) (Bop (Sub) x y) z))
+      )
+      (
+        (Debug "reassoc" lhs)
+        (union lhs (Bop (Add) x (Bop (Sub) y z)))
+      )
+      :ruleset peepholes)
+
+; (a + b) - c => a + (b - c)
+(rewrite (Bop (Sub) (Bop (Add) a b) c) (Bop (Add) a (Bop (Sub) b c)) :ruleset peepholes)

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -26,21 +26,11 @@
         (HasArgType expr ty)
         (ContextOf expr ctx)
       )
-      (
-        (Debug "x-x=0" expr)
-        (union expr (Const (Int 0) ty ctx)))
+      ((union expr (Const (Int 0) ty ctx)))
       :ruleset peepholes)
 
 ; (x - y) + z => x + (z - y)
-; (rewrite (Bop (Add) (Bop (Sub) x y) z) (Bop (Add) x (Bop (Sub) z y)) :ruleset peepholes)
-(rule (
-        (= lhs (Bop (Add) (Bop (Sub) x y) z))
-      )
-      (
-        (Debug "reassoc" lhs)
-        (union lhs (Bop (Add) x (Bop (Sub) y z)))
-      )
-      :ruleset peepholes)
+(rewrite (Bop (Add) (Bop (Sub) x y) z) (Bop (Add) x (Bop (Sub) z y)) :ruleset peepholes)
 
 ; (a + b) - c => a + (b - c)
 (rewrite (Bop (Sub) (Bop (Add) a b) c) (Bop (Add) a (Bop (Sub) b c)) :ruleset peepholes)

--- a/dag_in_context/src/optimizations/purity_analysis.egg
+++ b/dag_in_context/src/optimizations/purity_analysis.egg
@@ -32,6 +32,7 @@
 (BinaryOpIsPure (Or))
 (BinaryOpIsPure (PtrAdd))
 (UnaryOpIsPure (Not))
+(UnaryOpIsPure (Abs))
 
 (rule ((Function _name _tyin _tyout _out) (ExprIsPure _out))
         ((ExprIsPure (Function _name _tyin _tyout _out)))

--- a/dag_in_context/src/pretty_print.rs
+++ b/dag_in_context/src/pretty_print.rs
@@ -662,8 +662,9 @@ impl TernaryOp {
 
 impl UnaryOp {
     pub fn to_ast(&self) -> String {
-        use schema::UnaryOp::Not;
+        use schema::UnaryOp::{Abs, Not};
         match self {
+            Abs => "abs".into(),
             Not => "not".into(),
         }
     }

--- a/dag_in_context/src/schema.egg
+++ b/dag_in_context/src/schema.egg
@@ -130,6 +130,7 @@
   ; given a pointer and state edge, frees the whole memory region at the pointer
   (Free))
 (datatype UnaryOp
+  (Abs)
   (Not))
 
 ; Operators

--- a/dag_in_context/src/schema.rs
+++ b/dag_in_context/src/schema.rs
@@ -73,6 +73,7 @@ pub enum BinaryOp {
 
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, PartialOrd, Ord)]
 pub enum UnaryOp {
+    Abs,
     Not,
 }
 

--- a/dag_in_context/src/schema_helpers.rs
+++ b/dag_in_context/src/schema_helpers.rs
@@ -100,6 +100,7 @@ impl UnaryOp {
     pub(crate) fn name(&self) -> &'static str {
         use UnaryOp::*;
         match self {
+            Abs => "Abs",
             Not => "Not",
         }
     }
@@ -861,6 +862,7 @@ impl BinaryOp {
 impl UnaryOp {
     pub(crate) fn types(&self) -> Option<(Type, Type)> {
         match self {
+            UnaryOp::Abs => Some((base(intt()), base(intt()))),
             UnaryOp::Not => Some((base(boolt()), base(boolt()))),
         }
     }

--- a/dag_in_context/src/type_analysis.egg
+++ b/dag_in_context/src/type_analysis.egg
@@ -186,6 +186,16 @@
       ((ExpectType e (Base (BoolT)) "(Not)"))
       :ruleset type-analysis)
 
+(rule (
+        (= lhs (Uop (Abs) e))
+        (HasType e (Base (IntT)))
+      )
+      ((HasType lhs (Base (IntT))))
+      :ruleset type-analysis)
+(rule ((= lhs (Uop (Abs) e)))
+      ((ExpectType e (Base (IntT)) "(Abs)"))
+      :ruleset type-analysis)
+
 
 (rule (
         (= lhs (Bop (Print) e state))

--- a/src/rvsdg/from_dag.rs
+++ b/src/rvsdg/from_dag.rs
@@ -194,12 +194,14 @@ fn effect_op_from_binary_op(bop: BinaryOp) -> Option<EffectOps> {
 
 fn value_op_from_unary_op(uop: UnaryOp) -> Option<ValueOps> {
     match uop {
+        UnaryOp::Abs => Some(ValueOps::Abs),
         UnaryOp::Not => Some(ValueOps::Not),
     }
 }
 
 fn effect_op_from_unary_op(uop: UnaryOp) -> Option<EffectOps> {
     match uop {
+        UnaryOp::Abs => None,
         UnaryOp::Not => None,
     }
 }

--- a/src/rvsdg/to_dag.rs
+++ b/src/rvsdg/to_dag.rs
@@ -263,6 +263,7 @@ impl<'a> DagTranslator<'a> {
                     (ValueOps::And, [a, b]) => and(a.clone(), b.clone()),
                     (ValueOps::Or, [a, b]) => or(a.clone(), b.clone()),
                     (ValueOps::Not, [a]) => not(a.clone()),
+                    (ValueOps::Abs, [a]) => abs(a.clone()),
 
                     (ValueOps::PtrAdd, [a, b]) => ptradd(a.clone(), b.clone()),
                     (ValueOps::Load, [a, b]) => load(a.clone(), b.clone()),

--- a/tests/passing/small/if_invariant_dont_pull_out.rs
+++ b/tests/passing/small/if_invariant_dont_pull_out.rs
@@ -1,0 +1,22 @@
+// ARGS: 20
+fn unrelated_fn(input: i64, res: i64) -> i64 {
+    return input / (res / 3);
+}
+
+fn other_unrelated_fn(input: i64, res: i64) -> i64 {
+    return res / (input / 5);
+}
+
+fn main(input: i64) {
+    let mut res: i64 = abs(input) * 2;
+
+    if (input > 0) {
+        res = res + abs(input) - input;
+        res = unrelated_fn(input, res);
+    } else {
+        res = res + abs(input) + input;
+        res = other_unrelated_fn(input, res);
+    }
+
+    println!("{}", res);
+}

--- a/tests/slow/raytracewithscreen.rs
+++ b/tests/slow/raytracewithscreen.rs
@@ -110,7 +110,7 @@ fn main(xpos: f64, ypos: f64, zpos: f64, width: f64, height: f64) {
 
                 let brightness: f64 = 1.0 / (light_dist * light_dist);
                 let light_dot: f64 = dot(point_to_light_norm, res_ray[1]);
-                let abs_light_dot: f64 = abs(light_dot);
+                let abs_light_dot: f64 = fabs(light_dot);
 
                 output[row2 as usize][col2 as usize] = brightness * abs_light_dot;
                 drop(point_to_light);
@@ -200,7 +200,7 @@ fn vec_scale(a: [f64; 3], s: f64) -> [f64; 3] {
     return [a[0] * s, a[1] * s, a[2] * s];
 }
 
-fn abs(x: f64) -> f64 {
+fn fabs(x: f64) -> f64 {
     let mut res: f64 = x;
     if x < 0.0 {
         res = -res;
@@ -213,7 +213,7 @@ fn sqrt(x: f64) -> f64 {
     let tolerance: f64 = 1e-2; // Set precision level
     let mut num_iters: i64 = 100;
 
-    while (num_iters > 0 && abs(guess * guess - x) > tolerance) {
+    while (num_iters > 0 && fabs(guess * guess - x) > tolerance) {
         guess = (guess + x / guess) / 2.0;
         num_iters = num_iters - 1;
     }
@@ -424,7 +424,7 @@ fn partition_cost(
     return cost;
 }
 
-fn min(a: f64, b: f64) -> f64 {
+fn fmin(a: f64, b: f64) -> f64 {
     let mut res: f64 = a;
     if b < a {
         res = b;
@@ -432,7 +432,7 @@ fn min(a: f64, b: f64) -> f64 {
     return res;
 }
 
-fn max(a: f64, b: f64) -> f64 {
+fn fmax(a: f64, b: f64) -> f64 {
     let mut res: f64 = a;
     if b > a {
         res = b;
@@ -441,11 +441,11 @@ fn max(a: f64, b: f64) -> f64 {
 }
 
 fn point_max(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    return [max(a[0], b[0]), max(a[1], b[1]), max(a[2], b[2])];
+    return [fmax(a[0], b[0]), fmax(a[1], b[1]), fmax(a[2], b[2])];
 }
 
 fn point_min(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    return [min(a[0], b[0]), min(a[1], b[1]), min(a[2], b[2])];
+    return [fmin(a[0], b[0]), fmin(a[1], b[1]), fmin(a[2], b[2])];
 }
 
 fn triangle_min(tri: [[f64; 3]; 3]) -> [f64; 3] {
@@ -733,21 +733,21 @@ fn bbox_ray_intersect(bbox: [[f64; 3]; 2], ray: &[[f64; 3]; 2]) -> bool {
     let epsilon: f64 = 0.0000001;
     let t1: f64 = (bbox[0][0] - ray[0][0]) / ray[1][0];
     let t2: f64 = (bbox[1][0] - ray[0][0]) / ray[1][0];
-    let tmin: f64 = min(t1, t2);
-    let tmax: f64 = max(t1, t2);
+    let tmin: f64 = fmin(t1, t2);
+    let tmax: f64 = fmax(t1, t2);
 
     let t3: f64 = (bbox[0][1] - ray[0][1]) / ray[1][1];
     let t4: f64 = (bbox[1][1] - ray[0][1]) / ray[1][1];
-    let tmin2: f64 = min(t3, t4);
-    let tmax2: f64 = max(t3, t4);
+    let tmin2: f64 = fmin(t3, t4);
+    let tmax2: f64 = fmax(t3, t4);
 
     let t5: f64 = (bbox[0][2] - ray[0][2]) / ray[1][2];
     let t6: f64 = (bbox[1][2] - ray[0][2]) / ray[1][2];
-    let tmin3: f64 = min(t5, t6);
-    let tmax3: f64 = max(t5, t6);
+    let tmin3: f64 = fmin(t5, t6);
+    let tmax3: f64 = fmax(t5, t6);
 
-    let tmin_final: f64 = max(tmin, max(tmin2, tmin3));
-    let tmax_final: f64 = min(tmax, min(tmax2, tmax3));
+    let tmin_final: f64 = fmax(tmin, fmax(tmin2, tmin3));
+    let tmax_final: f64 = fmin(tmax, fmin(tmax2, tmax3));
 
     return tmax_final >= tmin_final && tmax_final > epsilon;
 }

--- a/tests/snapshots/files__branch_hoisting-optimize.snap
+++ b/tests/snapshots/files__branch_hoisting-optimize.snap
@@ -20,16 +20,16 @@ expression: visualization.result
   v14_: int = id c4_;
 .b15_:
   v16_: bool = eq v12_ v13_;
-  c17_: int = const 2;
-  c18_: int = const 1;
-  v19_: int = add c18_ v11_;
-  v20_: int = add c18_ v19_;
-  v21_: int = add c18_ v20_;
-  v22_: int = mul c17_ v21_;
+  c17_: int = const 1;
+  v18_: int = add c17_ v11_;
+  v19_: int = add c17_ v18_;
+  v20_: int = add c17_ v19_;
+  c21_: int = const 2;
+  v22_: int = mul c21_ v20_;
   c23_: int = const 3;
-  v24_: int = mul c23_ v21_;
+  v24_: int = mul c23_ v20_;
   v25_: int = select v16_ v22_ v24_;
-  v26_: int = add c18_ v21_;
+  v26_: int = add c17_ v20_;
   v27_: bool = lt v26_ v14_;
   v10_: int = id v25_;
   v11_: int = id v26_;

--- a/tests/snapshots/files__if_invariant_dont_pull_out-optimize-sequential.snap
+++ b/tests/snapshots/files__if_invariant_dont_pull_out-optimize-sequential.snap
@@ -1,0 +1,49 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@unrelated_fn(v0: int, v1: int): int {
+.b2_:
+  c3_: int = const 3;
+  v4_: int = div v1 c3_;
+  v5_: int = div v0 v4_;
+  ret v5_;
+}
+@other_unrelated_fn(v0: int, v1: int): int {
+.b2_:
+  c3_: int = const 5;
+  v4_: int = div v0 c3_;
+  v5_: int = div v1 v4_;
+  ret v5_;
+}
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  v3_: bool = gt v0 c2_;
+  v4_: int = abs v0;
+  c5_: int = const 2;
+  v6_: int = mul c5_ v4_;
+  br v3_ .b7_ .b8_;
+.b7_:
+  v9_: int = sub v6_ v0;
+  v10_: int = add v0 v9_;
+  c11_: int = const 3;
+  v12_: int = div v10_ c11_;
+  v13_: int = div v0 v12_;
+  v14_: int = id v13_;
+  print v14_;
+  ret;
+  jmp .b15_;
+.b8_:
+  v16_: int = abs v0;
+  v17_: int = add v16_ v6_;
+  v18_: int = add v0 v17_;
+  c19_: int = const 5;
+  v20_: int = div v0 c19_;
+  v21_: int = div v18_ v20_;
+  v14_: int = id v21_;
+  print v14_;
+  ret;
+.b15_:
+}

--- a/tests/snapshots/files__if_invariant_dont_pull_out-optimize.snap
+++ b/tests/snapshots/files__if_invariant_dont_pull_out-optimize.snap
@@ -1,0 +1,44 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@unrelated_fn(v0: int, v1: int): int {
+.b2_:
+  c3_: int = const 3;
+  v4_: int = div v1 c3_;
+  v5_: int = div v0 v4_;
+  ret v5_;
+}
+@other_unrelated_fn(v0: int, v1: int): int {
+.b2_:
+  c3_: int = const 5;
+  v4_: int = div v0 c3_;
+  v5_: int = div v1 v4_;
+  ret v5_;
+}
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  v3_: bool = gt v0 c2_;
+  v4_: int = abs v0;
+  c5_: int = const 2;
+  v6_: int = mul c5_ v4_;
+  br v3_ .b7_ .b8_;
+.b7_:
+  c9_: int = const 3;
+  v10_: int = div v6_ c9_;
+  v11_: int = div v0 v10_;
+  v12_: int = id v11_;
+  print v12_;
+  ret;
+  jmp .b13_;
+.b8_:
+  c14_: int = const 5;
+  v15_: int = div v0 c14_;
+  v16_: int = div v6_ v15_;
+  v12_: int = id v16_;
+  print v12_;
+  ret;
+.b13_:
+}


### PR DESCRIPTION
```
// ARGS: 20
fn unrelated_fn(input: i64, res: i64) -> i64 {
    return input / (res / 3);
}

fn other_unrelated_fn(input: i64, res: i64) -> i64 {
    return res / (input / 5);
}

fn main(input: i64) {
    let mut res: i64 = abs(input) * 2;

    if (input > 0) {
        res = res + abs(input) - input;
        res = unrelated_fn(input, res);
    } else {
        res = res + abs(input) + input;
        res = other_unrelated_fn(input, res);
    }

    println!("{}", res);
}
```

Output bril:
```
# ARGS: 20
@unrelated_fn(v0: int, v1: int): int {
.b2_:
  c3_: int = const 3;
  v4_: int = div v1 c3_;
  v5_: int = div v0 v4_;
  ret v5_;
}
@other_unrelated_fn(v0: int, v1: int): int {
.b2_:
  c3_: int = const 5;
  v4_: int = div v0 c3_;
  v5_: int = div v1 v4_;
  ret v5_;
}
@main(v0: int) {
.b1_:
  c2_: int = const 0;
  v3_: bool = gt v0 c2_;
  v4_: int = abs v0;
  c5_: int = const 2;
  v6_: int = mul c5_ v4_;
  br v3_ .b7_ .b8_;
.b7_:
  c9_: int = const 3;
  v10_: int = div v6_ c9_;
  v11_: int = div v0 v10_;
  v12_: int = id v11_;
  print v12_;
  ret;
  jmp .b13_;
.b8_:
  c14_: int = const 5;
  v15_: int = div v0 c14_;
  v16_: int = div v6_ v15_;
  v12_: int = id v16_;
  print v12_;
  ret;
.b13_:
}
```

SVGs
Before
![image](https://github.com/user-attachments/assets/9f5889d6-a942-4ecf-b141-6587c4279c37)

After
![image](https://github.com/user-attachments/assets/e178b0d9-796d-41cc-badf-878cc8a6c7a1)
