### PR TITLE
Fixes the cost calculation which counts all `Mul` in a region only once

### DIFF
--- a/dag_in_context/src/greedy_dag_extractor.rs
+++ b/dag_in_context/src/greedy_dag_extractor.rs
@@ -949,6 +949,8 @@ pub fn extract_with_paths(
         panic!("Failed to extract program! Found negative cost on result node.");
     }
 
+    log::info!("extracted with cost {}", root_cost);
+
     (root_costset, resulting_prog)
 }
 
@@ -1160,6 +1162,30 @@ fn enode_children(
             vec![
                 EnodeChild::new(egraph.nid_to_cid(ty).clone(), false, false),
                 EnodeChild::new(egraph.nid_to_cid(ctx).clone(), false, true),
+            ]
+        }
+        // We mark operators like (Add) and (Mul) as region roots
+        // because we want their cost to be counted every time they
+        // are referenced at a different place, just like a region.
+        ("Uop", [op, a]) => {
+            vec![
+                EnodeChild::new(egraph.nid_to_cid(op).clone(), true, false),
+                EnodeChild::new(egraph.nid_to_cid(a).clone(), false, false),
+            ]
+        }
+        ("Bop", [op, a, b]) => {
+            vec![
+                EnodeChild::new(egraph.nid_to_cid(op).clone(), true, false),
+                EnodeChild::new(egraph.nid_to_cid(a).clone(), false, false),
+                EnodeChild::new(egraph.nid_to_cid(b).clone(), false, false),
+            ]
+        }
+        ("Top", [op, a, b, c]) => {
+            vec![
+                EnodeChild::new(egraph.nid_to_cid(op).clone(), true, false),
+                EnodeChild::new(egraph.nid_to_cid(a).clone(), false, false),
+                EnodeChild::new(egraph.nid_to_cid(b).clone(), false, false),
+                EnodeChild::new(egraph.nid_to_cid(c).clone(), false, false),
             ]
         }
         _ => {

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -194,12 +194,12 @@ pub fn parallel_schedule() -> Vec<CompilerPass> {
     (saturate
       {helpers}
       passthrough)
-    (repeat 2
+    (repeat 4
         {helpers}
         all-optimizations
     )
 
-    (repeat 4
+    (repeat 2
         {helpers}
         cheap-optimizations
     )

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -194,12 +194,12 @@ pub fn parallel_schedule() -> Vec<CompilerPass> {
     (saturate
       {helpers}
       passthrough)
-    (repeat 4
+    (repeat 2
         {helpers}
         all-optimizations
     )
 
-    (repeat 2
+    (repeat 4
         {helpers}
         cheap-optimizations
     )

--- a/tests/snapshots/files__if_in_loop-optimize.snap
+++ b/tests/snapshots/files__if_in_loop-optimize.snap
@@ -8,24 +8,26 @@ expression: visualization.result
   c2_: int = const 0;
   c3_: int = const 1;
   c4_: int = const 10;
-  v5_: int = id c2_;
-  v6_: int = id c3_;
-  v7_: int = id v0;
-  v8_: int = id c2_;
-  v9_: int = id c4_;
-.b10_:
-  v11_: bool = lt v7_ v6_;
-  v12_: int = select v11_ v6_ v8_;
-  print v12_;
+  v5_: bool = lt v0 c3_;
+  v6_: int = id c2_;
+  v7_: int = id c3_;
+  v8_: int = id v0;
+  v9_: int = id c2_;
+  v10_: int = id c4_;
+  v11_: bool = id v5_;
+.b12_:
+  v13_: int = select v11_ v7_ v9_;
+  print v13_;
   print v11_;
-  v13_: int = add v5_ v6_;
-  v14_: bool = lt v5_ v9_;
-  v5_: int = id v13_;
-  v6_: int = id v6_;
+  v14_: int = add v6_ v7_;
+  v15_: bool = lt v6_ v10_;
+  v6_: int = id v14_;
   v7_: int = id v7_;
   v8_: int = id v8_;
   v9_: int = id v9_;
-  br v14_ .b10_ .b15_;
-.b15_:
+  v10_: int = id v10_;
+  v11_: bool = id v11_;
+  br v15_ .b12_ .b16_;
+.b16_:
   ret;
 }

--- a/tests/snapshots/files__loop_strength_reduction-optimize.snap
+++ b/tests/snapshots/files__loop_strength_reduction-optimize.snap
@@ -14,30 +14,20 @@ expression: visualization.result
   v7_: int = id c1_;
   v8_: int = id c3_;
   v9_: int = id c4_;
-.b10_:
-  v11_: int = add v6_ v7_;
-  v12_: int = add v11_ v6_;
-  v13_: int = add v12_ v6_;
-  v14_: int = mul v13_ v8_;
-  v15_: int = mul v12_ v8_;
-  v16_: int = mul v11_ v8_;
-  v17_: int = mul v7_ v8_;
-  print v17_;
-  print v16_;
-  print v15_;
-  print v14_;
-  v18_: int = add v5_ v6_;
-  v19_: int = add v18_ v6_;
-  v20_: int = add v19_ v6_;
-  v21_: int = add v20_ v6_;
-  v22_: int = add v13_ v6_;
-  v23_: bool = lt v21_ v9_;
-  v5_: int = id v21_;
+  v10_: int = id c1_;
+.b11_:
+  print v10_;
+  v12_: int = add v5_ v6_;
+  v13_: int = add v6_ v7_;
+  v14_: int = add v10_ v8_;
+  v15_: bool = lt v12_ v9_;
+  v5_: int = id v12_;
   v6_: int = id v6_;
-  v7_: int = id v22_;
+  v7_: int = id v13_;
   v8_: int = id v8_;
   v9_: int = id v9_;
-  br v23_ .b10_ .b24_;
-.b24_:
+  v10_: int = id v14_;
+  br v15_ .b11_ .b16_;
+.b16_:
   ret;
 }


### PR DESCRIPTION
This is the loop strength reduction example after this PR

![image](https://github.com/user-attachments/assets/364a6e5f-e08e-4fc6-82b8-040eb2ef98b2)

The cost of this is now computed as 27026, which is roughly 300 * (50 + 10 + 10 + 10 + 10) (the cost of add and lt is 10, and of print is 50)

Unfortunately, in this example, only LSR is applied, but not loop unrolling (which used to apply), because we only run our optimization twice. We can either bump the #iter opt is applied or the #batch to have loop unrolling and LSR both applied