### PR TITLE
Conditional Invariant Code Motion (Pull Out)

### DIFF
--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -255,7 +255,7 @@
         (>= lx 0)
       )
       ((union lhs x))
-      :ruleset interval-analysis)
+      :ruleset interval-rewrite)
 
 ; abs(x) = -x if x <= 0
 (rule (
@@ -266,7 +266,7 @@
         (ContextOf lhs ctx)
       )
       ((union lhs (Bop (Sub) (Const (Int 0) ty ctx) x)))
-      :ruleset interval-analysis)
+      :ruleset interval-rewrite)
 
 ; =================================
 ; Conditionals

--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -70,6 +70,7 @@ pub fn prologue() -> String {
         include_str!("optimizations/passthrough.egg"),
         include_str!("optimizations/loop_strength_reduction.egg"),
         include_str!("optimizations/ivt.egg"),
+        include_str!("optimizations/conditional_invariant_code_motion.egg"),
         include_str!("utility/debug-helper.egg"),
         &rulesets(),
     ]

--- a/dag_in_context/src/optimizations/conditional_invariant_code_motion.egg
+++ b/dag_in_context/src/optimizations/conditional_invariant_code_motion.egg
@@ -1,0 +1,49 @@
+(ruleset cicm)
+
+(rule (
+        (= if_e (If pred orig_ins thn els))
+        (HasArgType thn (TupleT tylist))
+        (HasArgType els (TupleT tylist))
+        (ContextOf if_e outer_ctx)
+
+        (= e1 (Uop o x))
+        (HasType e1 (Base ty))
+        (= (TCPair t1 c1) (ExtractedExpr e1))
+        (> 10 (Expr-size e1))
+        (ExprIsPure e1)
+        (ContextOf e1 (InIf true pred orig_ins))
+
+        (= e2 (Uop o y))
+        (HasType e2 (Base ty))
+        (= (TCPair t2 c2) (ExtractedExpr e2))
+        (> 10 (Expr-size e2))
+        (ExprIsPure e2)
+        (ContextOf e2 (InIf false pred orig_ins))
+
+        (= t1 t2)
+      )
+      (
+        ; pull the term out to the outer context
+        (let new_term (TermSubst outer_ctx orig_ins t1)) 
+        
+        ; Add it as an input to the new if
+        (let new_ins (Concat orig_ins (Single new_term)))
+        (let new_ins_ty (TupleT (TLConcat tylist (TCons ty (TNil)))))
+        (let orig_ins_len (TypeList-length tylist))
+
+        ; New contexts
+        (let if_tr (InIf true  pred new_ins))
+        (let if_fa (InIf false pred new_ins))
+
+        ; New regions
+        (let new_thn (Subst if_tr (SubTuple (Arg new_ins_ty if_tr) 0 orig_ins_len) thn))
+        (let new_els (Subst if_fa (SubTuple (Arg new_ins_ty if_fa) 0 orig_ins_len) els))
+        
+        ; Union the new arg with the original expr in each branch
+        (union (Get (Arg new_ins_ty if_tr) orig_ins_len) (Subst if_tr (SubTuple (Arg new_ins_ty if_tr) 0 orig_ins_len) e1))
+        (union (Get (Arg new_ins_ty if_fa) orig_ins_len) (Subst if_fa (SubTuple (Arg new_ins_ty if_fa) 0 orig_ins_len) e2))
+
+        ; Create new if and union it with the original
+        (union if_e (If pred new_ins new_thn new_els))
+      )
+    :ruleset cicm)

--- a/dag_in_context/src/optimizations/conditional_invariant_code_motion.egg
+++ b/dag_in_context/src/optimizations/conditional_invariant_code_motion.egg
@@ -35,13 +35,32 @@
         (let if_tr (InIf true  pred new_ins))
         (let if_fa (InIf false pred new_ins))
 
+        ; SubTuple- this is the sublist of the new inputs that corresponds
+        ; to the original inputs (without the pulled-out input)
+        (let st_tr (SubTuple (Arg new_ins_ty if_tr) 0 orig_ins_len))
+        (let st_fa (SubTuple (Arg new_ins_ty if_fa) 0 orig_ins_len))
+
         ; New regions
-        (let new_thn (Subst if_tr (SubTuple (Arg new_ins_ty if_tr) 0 orig_ins_len) thn))
-        (let new_els (Subst if_fa (SubTuple (Arg new_ins_ty if_fa) 0 orig_ins_len) els))
+        (let new_thn (Subst if_tr st_tr thn))
+        (let new_els (Subst if_fa st_fa els))
         
         ; Union the new arg with the original expr in each branch
-        (union (Get (Arg new_ins_ty if_tr) orig_ins_len) (Subst if_tr (SubTuple (Arg new_ins_ty if_tr) 0 orig_ins_len) e1))
-        (union (Get (Arg new_ins_ty if_fa) orig_ins_len) (Subst if_fa (SubTuple (Arg new_ins_ty if_fa) 0 orig_ins_len) e2))
+        (union (Get (Arg new_ins_ty if_tr) orig_ins_len) (Subst if_tr st_tr e1))
+        (union (Get (Arg new_ins_ty if_fa) orig_ins_len) (Subst if_fa st_fa e2))
+        
+        ; Subsume the original exprs now that the new arg is there
+        ; Doing this prevents us from pulling the same exprs out of the new if
+        ; Can only subsume an e-node (not an e-class), and we don't want to
+        ; subsume the Subst node directly, since it won't have a chance to do
+        ; the actual substitution, so manually compute the first round of
+        ; substitution so that we can subsume the Uop e-nodes.
+        ; First construct the Uop, so that it exists in the e-graph, because
+        ; you can't subsume things that don't exist in the e-graph already.
+        (Uop o (Subst if_tr st_tr x))
+        (Uop o (Subst if_fa st_fa y))
+        ; Now subsume:
+        (subsume (Uop o (Subst if_tr st_tr x)))
+        (subsume (Uop o (Subst if_fa st_fa y)))
 
         ; Create new if and union it with the original
         (union if_e (If pred new_ins new_thn new_els))

--- a/dag_in_context/src/optimizations/conditional_invariant_code_motion.egg
+++ b/dag_in_context/src/optimizations/conditional_invariant_code_motion.egg
@@ -66,3 +66,71 @@
         (union if_e (If pred new_ins new_thn new_els))
       )
     :ruleset cicm)
+
+(rule (
+        (= if_e (If pred orig_ins thn els))
+        (HasArgType thn (TupleT tylist))
+        (HasArgType els (TupleT tylist))
+        (ContextOf if_e outer_ctx)
+
+        (= e1 (Bop o x1 y1))
+        (HasType e1 (Base ty))
+        (= (TCPair t1 c1) (ExtractedExpr e1))
+        (> 10 (Expr-size e1))
+        (ExprIsPure e1)
+        (ContextOf e1 (InIf true pred orig_ins))
+
+        (= e2 (Bop o x2 y2))
+        (HasType e2 (Base ty))
+        (= (TCPair t2 c2) (ExtractedExpr e2))
+        (> 10 (Expr-size e2))
+        (ExprIsPure e2)
+        (ContextOf e2 (InIf false pred orig_ins))
+
+        (= t1 t2)
+      )
+      (
+        ; pull the term out to the outer context
+        (let new_term (TermSubst outer_ctx orig_ins t1)) 
+        
+        ; Add it as an input to the new if
+        (let new_ins (Concat orig_ins (Single new_term)))
+        (let new_ins_ty (TupleT (TLConcat tylist (TCons ty (TNil)))))
+        (let orig_ins_len (TypeList-length tylist))
+
+        ; New contexts
+        (let if_tr (InIf true  pred new_ins))
+        (let if_fa (InIf false pred new_ins))
+
+        ; SubTuple- this is the sublist of the new inputs that corresponds
+        ; to the original inputs (without the pulled-out input)
+        (let st_tr (SubTuple (Arg new_ins_ty if_tr) 0 orig_ins_len))
+        (let st_fa (SubTuple (Arg new_ins_ty if_fa) 0 orig_ins_len))
+
+        ; New regions
+        (let new_thn (Subst if_tr st_tr thn))
+        (let new_els (Subst if_fa st_fa els))
+        
+        ; Union the new arg with the original expr in each branch
+        (union (Get (Arg new_ins_ty if_tr) orig_ins_len) (Subst if_tr st_tr e1))
+        (union (Get (Arg new_ins_ty if_fa) orig_ins_len) (Subst if_fa st_fa e2))
+        
+        ; Subsume the original exprs now that the new arg is there
+        ; Doing this prevents us from pulling the same exprs out of the new if
+        ; Can only subsume an e-node (not an e-class), and we don't want to
+        ; subsume the Subst node directly, since it won't have a chance to do
+        ; the actual substitution, so manually compute the first round of
+        ; substitution so that we can subsume the Uop e-nodes.
+        ; First construct the Uop, so that it exists in the e-graph, because
+        ; you can't subsume things that don't exist in the e-graph already.
+        (Bop o (Subst if_tr st_tr x1) (Subst if_tr st_tr y1))
+        (Bop o (Subst if_fa st_fa x2) (Subst if_fa st_fa y2))
+        ; Now subsume:
+        (subsume (Bop o (Subst if_tr st_tr x1) (Subst if_tr st_tr y1)))
+        (subsume (Bop o (Subst if_fa st_fa x2) (Subst if_fa st_fa y2)))
+
+        ; Create new if and union it with the original
+        (union if_e (If pred new_ins new_thn new_els))
+      )
+    :ruleset cicm)
+

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -43,3 +43,5 @@
       )
       ((union expr (Bop (Mul) a (Bop (Add) x (Const (Int 1) ty ctx)))))
       :ruleset peepholes)
+
+(rewrite (Top (Select) pred x x) x :ruleset peepholes)

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -34,3 +34,12 @@
 
 ; (a + b) - c => a + (b - c)
 (rewrite (Bop (Sub) (Bop (Add) a b) c) (Bop (Add) a (Bop (Sub) b c)) :ruleset peepholes)
+
+; (a * x) + a => a * (x + 1)
+(rule (
+        (= expr (Bop (Add) (Bop (Mul) a x) a))
+        (HasArgType expr ty)
+        (ContextOf expr ctx)
+      )
+      ((union expr (Bop (Mul) a (Bop (Add) x (Const (Int 1) ty ctx)))))
+      :ruleset peepholes)

--- a/dag_in_context/src/schedule.rs
+++ b/dag_in_context/src/schedule.rs
@@ -89,6 +89,7 @@ fn optimizations() -> Vec<String> {
         "switch_rewrite",
         "loop-inv-motion",
         "loop-strength-reduction",
+        "cicm",
     ]
     .iter()
     .map(|opt| opt.to_string())

--- a/tests/passing/small/if_invariant_do_pull_out.rs
+++ b/tests/passing/small/if_invariant_do_pull_out.rs
@@ -1,0 +1,22 @@
+// ARGS: 20
+fn unrelated_fn(input: i64) -> i64 {
+    return input / 4;
+}
+
+fn other_unrelated_fn(input: i64) -> i64 {
+    return (input * 3) / 5;
+}
+
+fn main(input: i64) {
+    let mut res: i64 = abs(input) * 2;
+
+    if (input > 0) {
+        res = res + abs(input);
+        res = res + unrelated_fn(input);
+    } else {
+        res = res + abs(input);
+        res = res + other_unrelated_fn(input);
+    }
+
+    println!("{}", res);
+}

--- a/tests/passing/small/pull_out_small.rs
+++ b/tests/passing/small/pull_out_small.rs
@@ -2,11 +2,11 @@
 fn main(x: i64) {
     let a: i64 = x * 5;
     if (x > 0) {
-        let r: i64 = a + x;
-        let z: i64 = 10;
+        let r: i64 = x * 5;
+        let z: i64 = 20;
         println!("{}", z);
     } else {
-        let r: i64 = x + a;
+        let r: i64 = x * 5;
         let z: i64 = 20;
         println!("{}", z);
     }

--- a/tests/passing/small/pull_out_small.rs
+++ b/tests/passing/small/pull_out_small.rs
@@ -1,0 +1,14 @@
+// ARGS: 20
+fn main(x: i64) {
+    let a: i64 = x * 5;
+    if (x > 0) {
+        let r: i64 = a + x;
+        let z: i64 = 10;
+        println!("{}", z);
+    } else {
+        let r: i64 = x + a;
+        let z: i64 = 20;
+        println!("{}", z);
+    }
+    println!("{}", r);
+}

--- a/tests/snapshots/files__block-diamond-optimize-sequential.snap
+++ b/tests/snapshots/files__block-diamond-optimize-sequential.snap
@@ -5,32 +5,32 @@ expression: visualization.result
 # ARGS: 1
 @main(v0: int) {
 .b1_:
-  c2_: int = const 1;
-  c3_: int = const 2;
-  v4_: bool = lt v0 c3_;
-  c5_: int = const 0;
+  c2_: int = const 2;
+  v3_: bool = lt v0 c2_;
+  c4_: int = const 0;
+  c5_: int = const 1;
   c6_: int = const 5;
-  v7_: int = id c2_;
-  v8_: int = id c2_;
-  v9_: int = id c3_;
-  br v4_ .b10_ .b11_;
+  v7_: int = id c5_;
+  v8_: int = id c5_;
+  v9_: int = id c2_;
+  br v3_ .b10_ .b11_;
 .b10_:
   c12_: bool = const true;
   c13_: int = const 4;
-  v14_: int = select c12_ c13_ c3_;
+  v14_: int = select c12_ c13_ c2_;
   v7_: int = id v14_;
-  v8_: int = id c2_;
-  v9_: int = id c3_;
-  v15_: int = add c3_ v7_;
-  v16_: int = select v4_ v7_ v15_;
-  v17_: int = add c2_ v16_;
+  v8_: int = id c5_;
+  v9_: int = id c2_;
+  v15_: int = add c2_ v7_;
+  v16_: int = select v3_ v7_ v15_;
+  v17_: int = add c5_ v16_;
   print v17_;
   ret;
   jmp .b18_;
 .b11_:
-  v15_: int = add c3_ v7_;
-  v16_: int = select v4_ v7_ v15_;
-  v17_: int = add c2_ v16_;
+  v15_: int = add c2_ v7_;
+  v16_: int = select v3_ v7_ v15_;
+  v17_: int = add c5_ v16_;
   print v17_;
   ret;
 .b18_:

--- a/tests/snapshots/files__fib_recursive-optimize-sequential.snap
+++ b/tests/snapshots/files__fib_recursive-optimize-sequential.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/files.rs
 expression: visualization.result
-snapshot_kind: text
 ---
 # ARGS: 
 @fac(v0: int): int {
@@ -19,37 +18,37 @@ snapshot_kind: text
   br v9_ .b10_ .b11_;
 .b10_:
   v12_: bool = eq c2_ c2_;
-  v13_: int = id c4_;
+  v13_: int = id v0;
   br v12_ .b14_ .b15_;
 .b14_:
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b15_:
-  v17_: bool = eq c2_ c4_;
+  v17_: bool = eq c2_ v0;
   br v17_ .b18_ .b19_;
 .b18_:
   v20_: bool = eq c2_ c2_;
-  v21_: int = id c4_;
+  v21_: int = id v0;
   br v20_ .b22_ .b23_;
 .b22_:
-  v24_: int = id c4_;
+  v24_: int = id v0;
   v13_: int = id v24_;
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b23_:
-  v25_: bool = eq c2_ c4_;
+  v25_: bool = eq c2_ v0;
   br v25_ .b26_ .b27_;
 .b26_:
   v28_: int = call @fac c2_;
-  v29_: int = id c4_;
+  v29_: int = id v0;
   v21_: int = id v29_;
-  v24_: int = id c4_;
+  v24_: int = id v0;
   v13_: int = id v24_;
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -61,19 +60,19 @@ snapshot_kind: text
   v34_: int = add v31_ v33_;
   v29_: int = id v34_;
   v21_: int = id v29_;
-  v24_: int = id c4_;
+  v24_: int = id v0;
   v13_: int = id v24_;
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b19_:
   c35_: int = const -1;
   v36_: bool = eq c2_ c35_;
-  v37_: int = id c4_;
+  v37_: int = id v0;
   br v36_ .b38_ .b39_;
 .b39_:
-  v40_: bool = eq c35_ c4_;
+  v40_: bool = eq c35_ v0;
   br v40_ .b41_ .b42_;
 .b41_:
   v43_: int = call @fac c2_;
@@ -82,18 +81,18 @@ snapshot_kind: text
 .b38_:
   c45_: int = const -2;
   v46_: bool = eq c2_ c45_;
-  v47_: int = id c4_;
+  v47_: int = id v0;
   br v46_ .b48_ .b49_;
 .b48_:
   v50_: int = add v37_ v47_;
   v24_: int = id v50_;
   v13_: int = id v24_;
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
 .b49_:
-  v51_: bool = eq c45_ c4_;
+  v51_: bool = eq c45_ v0;
   br v51_ .b52_ .b53_;
 .b52_:
   v54_: int = call @fac c2_;
@@ -102,7 +101,7 @@ snapshot_kind: text
   v50_: int = add v37_ v47_;
   v24_: int = id v50_;
   v13_: int = id v24_;
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -117,7 +116,7 @@ snapshot_kind: text
   v50_: int = add v37_ v47_;
   v24_: int = id v50_;
   v13_: int = id v24_;
-  v16_: int = id c4_;
+  v16_: int = id v0;
   v5_: int = id v16_;
   ret v5_;
   jmp .b8_;
@@ -140,10 +139,10 @@ snapshot_kind: text
   br v71_ .b72_ .b73_;
 .b72_:
   v74_: bool = eq c2_ c2_;
-  v75_: int = id c4_;
+  v75_: int = id v66_;
   br v74_ .b76_ .b77_;
 .b76_:
-  v78_: int = id c4_;
+  v78_: int = id v66_;
   v68_: int = id v78_;
 .b69_:
   v79_: int = sub v66_ c4_;
@@ -161,10 +160,10 @@ snapshot_kind: text
   br v85_ .b86_ .b87_;
 .b86_:
   v88_: bool = eq c2_ c2_;
-  v89_: int = id c4_;
+  v89_: int = id v79_;
   br v88_ .b90_ .b91_;
 .b90_:
-  v92_: int = id c4_;
+  v92_: int = id v79_;
   v81_: int = id v92_;
   v84_: int = add v68_ v81_;
   v16_: int = id v84_;
@@ -172,13 +171,13 @@ snapshot_kind: text
   ret v5_;
   jmp .b8_;
 .b91_:
-  v93_: bool = eq c2_ c4_;
+  v93_: bool = eq c2_ v79_;
   br v93_ .b94_ .b95_;
 .b94_:
   v96_: int = call @fac c2_;
-  v97_: int = id c4_;
+  v97_: int = id v79_;
   v89_: int = id v97_;
-  v92_: int = id c4_;
+  v92_: int = id v79_;
   v81_: int = id v92_;
   v84_: int = add v68_ v81_;
   v16_: int = id v84_;
@@ -193,7 +192,7 @@ snapshot_kind: text
   v102_: int = add v101_ v99_;
   v97_: int = id v102_;
   v89_: int = id v97_;
-  v92_: int = id c4_;
+  v92_: int = id v79_;
   v81_: int = id v92_;
   v84_: int = add v68_ v81_;
   v16_: int = id v84_;
@@ -210,7 +209,7 @@ snapshot_kind: text
   br v108_ .b109_ .b110_;
 .b109_:
   v111_: int = call @fac c2_;
-  v112_: int = id c4_;
+  v112_: int = id v103_;
   v105_: int = id v112_;
 .b106_:
   v113_: int = sub v103_ c4_;
@@ -231,7 +230,7 @@ snapshot_kind: text
   br v119_ .b120_ .b121_;
 .b120_:
   v122_: int = call @fac c2_;
-  v123_: int = id c4_;
+  v123_: int = id v113_;
   v115_: int = id v123_;
   v118_: int = add v105_ v115_;
   v92_: int = id v118_;
@@ -267,13 +266,13 @@ snapshot_kind: text
   v105_: int = id v112_;
   jmp .b106_;
 .b77_:
-  v134_: bool = eq c2_ c4_;
+  v134_: bool = eq c2_ v66_;
   br v134_ .b135_ .b136_;
 .b135_:
   v137_: int = call @fac c2_;
-  v138_: int = id c4_;
+  v138_: int = id v66_;
   v75_: int = id v138_;
-  v78_: int = id c4_;
+  v78_: int = id v66_;
   v68_: int = id v78_;
   jmp .b69_;
 .b136_:
@@ -284,7 +283,7 @@ snapshot_kind: text
   v143_: int = add v140_ v142_;
   v138_: int = id v143_;
   v75_: int = id v138_;
-  v78_: int = id c4_;
+  v78_: int = id v66_;
   v68_: int = id v78_;
   jmp .b69_;
 .b73_:
@@ -350,12 +349,12 @@ snapshot_kind: text
   jmp .b8_;
 .b7_:
   v9_: bool = eq c1_ c4_;
-  br v9_ .b10_ .b11_;
-.b10_:
-  v12_: bool = eq c2_ c2_;
+  v10_: bool = eq c2_ c2_;
+  br v9_ .b11_ .b12_;
+.b11_:
   c13_: int = const 1;
   v14_: int = id c13_;
-  br v12_ .b15_ .b16_;
+  br v10_ .b15_ .b16_;
 .b15_:
   v17_: int = id c1_;
   v5_: int = id v17_;
@@ -387,62 +386,65 @@ snapshot_kind: text
   print v5_;
   ret;
   jmp .b8_;
-.b11_:
+.b12_:
   v28_: bool = eq c2_ c4_;
   v29_: int = id c4_;
   br v28_ .b30_ .b31_;
-.b31_:
-  v32_: bool = eq c4_ c4_;
-  br v32_ .b33_ .b34_;
-.b33_:
-  v35_: int = call @fac c2_;
-  v36_: int = id c4_;
-  v29_: int = id v36_;
 .b30_:
-  v37_: bool = eq c2_ c2_;
-  v38_: int = id c4_;
-  br v37_ .b39_ .b40_;
-.b39_:
-  v41_: int = add v29_ v38_;
-  v17_: int = id v41_;
-  v5_: int = id v17_;
-  print v5_;
-  ret;
-  jmp .b8_;
-.b40_:
-  v42_: bool = eq c2_ c4_;
-  br v42_ .b43_ .b44_;
-.b43_:
-  v45_: int = call @fac c2_;
-  v46_: int = id c4_;
-  v38_: int = id v46_;
-  v41_: int = add v29_ v38_;
-  v17_: int = id v41_;
-  v5_: int = id v17_;
-  print v5_;
-  ret;
-  jmp .b8_;
-.b44_:
-  c47_: int = const -1;
-  v48_: int = call @fac c47_;
-  c49_: int = const -2;
-  v50_: int = call @fac c49_;
-  v51_: int = add v48_ v50_;
-  v46_: int = id v51_;
-  v38_: int = id v46_;
-  v41_: int = add v29_ v38_;
-  v17_: int = id v41_;
-  v5_: int = id v17_;
-  print v5_;
-  ret;
-  jmp .b8_;
+  v32_: int = id c4_;
+.b33_:
+  br v10_ .b34_ .b35_;
 .b34_:
+  v36_: int = add v29_ v32_;
+  v17_: int = id v36_;
+  v5_: int = id v17_;
+  print v5_;
+  ret;
+  jmp .b8_;
+.b35_:
+  v37_: bool = eq c2_ c4_;
+  br v37_ .b38_ .b39_;
+.b38_:
+  v40_: int = call @fac c2_;
+  v41_: int = id c4_;
+  v32_: int = id v41_;
+  v36_: int = add v29_ v32_;
+  v17_: int = id v36_;
+  v5_: int = id v17_;
+  print v5_;
+  ret;
+  jmp .b8_;
+.b39_:
+  c42_: int = const -1;
+  v43_: int = call @fac c42_;
+  c44_: int = const -2;
+  v45_: int = call @fac c44_;
+  v46_: int = add v43_ v45_;
+  v41_: int = id v46_;
+  v32_: int = id v41_;
+  v36_: int = add v29_ v32_;
+  v17_: int = id v36_;
+  v5_: int = id v17_;
+  print v5_;
+  ret;
+  jmp .b8_;
+.b31_:
+  v47_: bool = eq c4_ c4_;
+  br v47_ .b48_ .b49_;
+.b48_:
+  v50_: int = call @fac c2_;
+  v51_: int = id c4_;
+  v29_: int = id v51_;
+  v32_: int = id c4_;
+  jmp .b33_;
+.b49_:
   v52_: int = call @fac c2_;
   c53_: int = const -1;
   v54_: int = call @fac c53_;
   v55_: int = add v52_ v54_;
-  v36_: int = id v55_;
-  v29_: int = id v36_;
-  jmp .b30_;
+  v51_: int = id v55_;
+  v29_: int = id v51_;
+  v32_: int = id c4_;
+  jmp .b33_;
 .b8_:
 }

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -367,12 +367,12 @@ expression: visualization.result
   jmp .b8_;
 .b7_:
   v9_: bool = eq c2_ c4_;
-  br v9_ .b10_ .b11_;
-.b10_:
-  v12_: bool = eq c1_ c1_;
+  v10_: bool = eq c1_ c1_;
+  br v9_ .b11_ .b12_;
+.b11_:
   c13_: int = const 1;
   v14_: int = id c13_;
-  br v12_ .b15_ .b16_;
+  br v10_ .b15_ .b16_;
 .b15_:
   v17_: int = id c4_;
   v5_: int = id v17_;
@@ -404,66 +404,65 @@ expression: visualization.result
   print v5_;
   ret;
   jmp .b8_;
-.b11_:
-  v28_: bool = eq c1_ c1_;
-  v29_: bool = eq c1_ c4_;
-  v30_: int = id c4_;
-  br v29_ .b31_ .b32_;
-.b31_:
-  v33_: int = id c4_;
+.b12_:
+  v28_: bool = eq c1_ c4_;
+  v29_: int = id c4_;
+  br v28_ .b30_ .b31_;
+.b30_:
+  v32_: int = id c4_;
+.b33_:
+  br v10_ .b34_ .b35_;
 .b34_:
-  br v28_ .b35_ .b36_;
+  v36_: int = add v29_ v32_;
+  v17_: int = id v36_;
+  v5_: int = id v17_;
+  print v5_;
+  ret;
+  jmp .b8_;
 .b35_:
-  v37_: int = add v30_ v33_;
-  v17_: int = id v37_;
+  v37_: bool = eq c1_ c4_;
+  br v37_ .b38_ .b39_;
+.b38_:
+  v40_: int = call @fac c1_;
+  v41_: int = id c4_;
+  v32_: int = id v41_;
+  v36_: int = add v29_ v32_;
+  v17_: int = id v36_;
   v5_: int = id v17_;
   print v5_;
   ret;
   jmp .b8_;
-.b36_:
-  v38_: bool = eq c1_ c4_;
-  br v38_ .b39_ .b40_;
 .b39_:
-  v41_: int = call @fac c1_;
-  v42_: int = id c4_;
-  v33_: int = id v42_;
-  v37_: int = add v30_ v33_;
-  v17_: int = id v37_;
+  c42_: int = const -2;
+  c43_: int = const -1;
+  v44_: int = call @fac c43_;
+  v45_: int = call @fac c42_;
+  v46_: int = add v44_ v45_;
+  v41_: int = id v46_;
+  v32_: int = id v41_;
+  v36_: int = add v29_ v32_;
+  v17_: int = id v36_;
   v5_: int = id v17_;
   print v5_;
   ret;
   jmp .b8_;
-.b40_:
-  c43_: int = const -2;
-  c44_: int = const -1;
-  v45_: int = call @fac c44_;
-  v46_: int = call @fac c43_;
-  v47_: int = add v45_ v46_;
-  v42_: int = id v47_;
-  v33_: int = id v42_;
-  v37_: int = add v30_ v33_;
-  v17_: int = id v37_;
-  v5_: int = id v17_;
-  print v5_;
-  ret;
-  jmp .b8_;
-.b32_:
-  v48_: bool = eq c4_ c4_;
-  br v48_ .b49_ .b50_;
+.b31_:
+  v47_: bool = eq c4_ c4_;
+  br v47_ .b48_ .b49_;
+.b48_:
+  v50_: int = call @fac c1_;
+  v51_: int = id c4_;
+  v29_: int = id v51_;
+  v32_: int = id c4_;
+  jmp .b33_;
 .b49_:
-  v51_: int = call @fac c1_;
-  v52_: int = id c4_;
-  v30_: int = id v52_;
-  v33_: int = id c4_;
-  jmp .b34_;
-.b50_:
-  c53_: int = const -1;
-  v54_: int = call @fac c1_;
-  v55_: int = call @fac c53_;
-  v56_: int = add v54_ v55_;
-  v52_: int = id v56_;
-  v30_: int = id v52_;
-  v33_: int = id c4_;
-  jmp .b34_;
+  c52_: int = const -1;
+  v53_: int = call @fac c1_;
+  v54_: int = call @fac c52_;
+  v55_: int = add v53_ v54_;
+  v51_: int = id v55_;
+  v29_: int = id v51_;
+  v32_: int = id c4_;
+  jmp .b33_;
 .b8_:
 }

--- a/tests/snapshots/files__if_invariant_do_pull_out-optimize-sequential.snap
+++ b/tests/snapshots/files__if_invariant_do_pull_out-optimize-sequential.snap
@@ -1,0 +1,48 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@unrelated_fn(v0: int): int {
+.b1_:
+  c2_: int = const 4;
+  v3_: int = div v0 c2_;
+  ret v3_;
+}
+@other_unrelated_fn(v0: int): int {
+.b1_:
+  c2_: int = const 3;
+  v3_: int = mul c2_ v0;
+  c4_: int = const 5;
+  v5_: int = div v3_ c4_;
+  ret v5_;
+}
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  v3_: bool = gt v0 c2_;
+  v4_: int = abs v0;
+  c5_: int = const 2;
+  v6_: int = mul c5_ v4_;
+  c7_: int = const 3;
+  v8_: int = mul c7_ v4_;
+  br v3_ .b9_ .b10_;
+.b9_:
+  c11_: int = const 4;
+  v12_: int = div v0 c11_;
+  v13_: int = add v12_ v8_;
+  v14_: int = id v13_;
+  print v14_;
+  ret;
+  jmp .b15_;
+.b10_:
+  c16_: int = const 3;
+  v17_: int = mul c16_ v0;
+  c18_: int = const 5;
+  v19_: int = div v17_ c18_;
+  v20_: int = add v19_ v8_;
+  v14_: int = id v20_;
+  print v14_;
+  ret;
+.b15_:
+}

--- a/tests/snapshots/files__if_invariant_do_pull_out-optimize.snap
+++ b/tests/snapshots/files__if_invariant_do_pull_out-optimize.snap
@@ -1,0 +1,48 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@unrelated_fn(v0: int): int {
+.b1_:
+  c2_: int = const 4;
+  v3_: int = div v0 c2_;
+  ret v3_;
+}
+@other_unrelated_fn(v0: int): int {
+.b1_:
+  c2_: int = const 3;
+  v3_: int = mul c2_ v0;
+  c4_: int = const 5;
+  v5_: int = div v3_ c4_;
+  ret v5_;
+}
+@main(v0: int) {
+.b1_:
+  c2_: int = const 0;
+  v3_: bool = gt v0 c2_;
+  v4_: int = abs v0;
+  c5_: int = const 2;
+  v6_: int = mul c5_ v4_;
+  br v3_ .b7_ .b8_;
+.b7_:
+  c9_: int = const 4;
+  v10_: int = div v0 c9_;
+  v11_: int = add v0 v6_;
+  v12_: int = add v10_ v11_;
+  v13_: int = id v12_;
+  print v13_;
+  ret;
+  jmp .b14_;
+.b8_:
+  c15_: int = const 3;
+  v16_: int = mul c15_ v0;
+  c17_: int = const 5;
+  v18_: int = div v16_ c17_;
+  v19_: int = sub v6_ v0;
+  v20_: int = add v18_ v19_;
+  v13_: int = id v20_;
+  print v13_;
+  ret;
+.b14_:
+}

--- a/tests/snapshots/files__if_invariant_dont_pull_out-optimize-sequential.snap
+++ b/tests/snapshots/files__if_invariant_dont_pull_out-optimize-sequential.snap
@@ -24,26 +24,25 @@ expression: visualization.result
   v4_: int = abs v0;
   c5_: int = const 2;
   v6_: int = mul c5_ v4_;
-  br v3_ .b7_ .b8_;
-.b7_:
-  v9_: int = sub v6_ v0;
-  v10_: int = add v0 v9_;
-  c11_: int = const 3;
-  v12_: int = div v10_ c11_;
-  v13_: int = div v0 v12_;
-  v14_: int = id v13_;
-  print v14_;
+  c7_: int = const 3;
+  v8_: int = mul c7_ v4_;
+  br v3_ .b9_ .b10_;
+.b9_:
+  v11_: int = sub v8_ v0;
+  c12_: int = const 3;
+  v13_: int = div v11_ c12_;
+  v14_: int = div v0 v13_;
+  v15_: int = id v14_;
+  print v15_;
   ret;
-  jmp .b15_;
-.b8_:
-  v16_: int = abs v0;
-  v17_: int = add v16_ v6_;
-  v18_: int = add v0 v17_;
-  c19_: int = const 5;
-  v20_: int = div v0 c19_;
-  v21_: int = div v18_ v20_;
-  v14_: int = id v21_;
-  print v14_;
+  jmp .b16_;
+.b10_:
+  v17_: int = add v0 v8_;
+  c18_: int = const 5;
+  v19_: int = div v0 c18_;
+  v20_: int = div v17_ v19_;
+  v15_: int = id v20_;
+  print v15_;
   ret;
-.b15_:
+.b16_:
 }

--- a/tests/snapshots/files__pull_out_small-optimize-sequential.snap
+++ b/tests/snapshots/files__pull_out_small-optimize-sequential.snap
@@ -5,25 +5,23 @@ expression: visualization.result
 # ARGS: 20
 @main(v0: int) {
 .b1_:
-  c2_: int = const 6;
+  c2_: int = const 5;
   v3_: int = mul c2_ v0;
   c4_: int = const 0;
   v5_: bool = lt c4_ v0;
-  c6_: int = const 5;
-  v7_: int = mul c6_ v0;
-  br v5_ .b8_ .b9_;
-.b8_:
-  c10_: int = const 10;
-  print c10_;
-  v11_: int = id v3_;
+  br v5_ .b6_ .b7_;
+.b6_:
+  c8_: int = const 20;
+  print c8_;
+  v9_: int = id v3_;
   print v3_;
   ret;
-  jmp .b12_;
-.b9_:
-  c13_: int = const 20;
-  print c13_;
-  v11_: int = id v3_;
+  jmp .b10_;
+.b7_:
+  c11_: int = const 20;
+  print c11_;
+  v9_: int = id v3_;
   print v3_;
   ret;
-.b12_:
+.b10_:
 }

--- a/tests/snapshots/files__pull_out_small-optimize-sequential.snap
+++ b/tests/snapshots/files__pull_out_small-optimize-sequential.snap
@@ -1,0 +1,29 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+.b1_:
+  c2_: int = const 6;
+  v3_: int = mul c2_ v0;
+  c4_: int = const 0;
+  v5_: bool = lt c4_ v0;
+  c6_: int = const 5;
+  v7_: int = mul c6_ v0;
+  br v5_ .b8_ .b9_;
+.b8_:
+  c10_: int = const 10;
+  print c10_;
+  v11_: int = id v3_;
+  print v3_;
+  ret;
+  jmp .b12_;
+.b9_:
+  c13_: int = const 20;
+  print c13_;
+  v11_: int = id v3_;
+  print v3_;
+  ret;
+.b12_:
+}

--- a/tests/snapshots/files__pull_out_small-optimize.snap
+++ b/tests/snapshots/files__pull_out_small-optimize.snap
@@ -1,0 +1,31 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+.b1_:
+  c2_: int = const 6;
+  v3_: int = mul c2_ v0;
+  c4_: int = const 0;
+  v5_: bool = lt c4_ v0;
+  c6_: int = const 5;
+  v7_: int = mul c6_ v0;
+  br v5_ .b8_ .b9_;
+.b8_:
+  c10_: int = const 10;
+  print c10_;
+  v11_: int = add v0 v7_;
+  v12_: int = id v11_;
+  print v3_;
+  ret;
+  jmp .b13_;
+.b9_:
+  c14_: int = const 20;
+  print c14_;
+  v15_: int = add v0 v7_;
+  v12_: int = id v15_;
+  print v3_;
+  ret;
+.b13_:
+}

--- a/tests/snapshots/files__pull_out_small-optimize.snap
+++ b/tests/snapshots/files__pull_out_small-optimize.snap
@@ -5,27 +5,23 @@ expression: visualization.result
 # ARGS: 20
 @main(v0: int) {
 .b1_:
-  c2_: int = const 6;
+  c2_: int = const 5;
   v3_: int = mul c2_ v0;
   c4_: int = const 0;
   v5_: bool = lt c4_ v0;
-  c6_: int = const 5;
-  v7_: int = mul c6_ v0;
-  br v5_ .b8_ .b9_;
-.b8_:
-  c10_: int = const 10;
-  print c10_;
-  v11_: int = add v0 v7_;
-  v12_: int = id v11_;
+  br v5_ .b6_ .b7_;
+.b6_:
+  c8_: int = const 20;
+  print c8_;
+  v9_: int = id v3_;
   print v3_;
   ret;
-  jmp .b13_;
-.b9_:
-  c14_: int = const 20;
-  print c14_;
-  v15_: int = add v0 v7_;
-  v12_: int = id v15_;
+  jmp .b10_;
+.b7_:
+  c11_: int = const 20;
+  print c11_;
+  v9_: int = id v3_;
   print v3_;
   ret;
-.b13_:
+.b10_:
 }

--- a/tests/snapshots/files__reassoc-optimize-sequential.snap
+++ b/tests/snapshots/files__reassoc-optimize-sequential.snap
@@ -5,13 +5,13 @@ expression: visualization.result
 # ARGS: 2 4
 @main(v0: int, v1: int) {
 .b2_:
-  c3_: int = const 4;
-  v4_: int = add c3_ v1;
-  c5_: int = const 3;
-  v6_: int = add c5_ v0;
-  v7_: int = add v4_ v6_;
-  c8_: int = const 1;
-  v9_: int = add c8_ v7_;
+  c3_: int = const 1;
+  c4_: int = const 3;
+  v5_: int = add c4_ v0;
+  c6_: int = const 4;
+  v7_: int = add c6_ v1;
+  v8_: int = add v5_ v7_;
+  v9_: int = add c3_ v8_;
   print v9_;
   ret;
 }

--- a/tests/snapshots/files__select-optimize-sequential.snap
+++ b/tests/snapshots/files__select-optimize-sequential.snap
@@ -23,30 +23,27 @@ expression: visualization.result
 .b17_:
   c18_: int = const 1;
   v19_: int = add c18_ v15_;
-  v20_: bool = eq v16_ v19_;
-  v21_: int = add v13_ v19_;
-  v22_: int = select v20_ v21_ v21_;
-  c23_: int = const 5;
-  v24_: int = select v20_ c23_ v14_;
-  v25_: int = select v20_ v19_ v19_;
-  v26_: int = select v20_ v16_ v16_;
-  v27_: bool = eq c23_ v24_;
-  v28_: bool = not v27_;
-  v13_: int = id v22_;
-  v14_: int = id v24_;
-  v15_: int = id v25_;
-  v16_: int = id v26_;
-  br v28_ .b17_ .b29_;
-.b29_:
+  v20_: int = add v13_ v19_;
+  v21_: bool = eq v16_ v19_;
+  c22_: int = const 5;
+  v23_: int = select v21_ c22_ v14_;
+  v24_: bool = eq c22_ v23_;
+  v25_: bool = not v24_;
+  v13_: int = id v20_;
+  v14_: int = id v23_;
+  v15_: int = id v19_;
+  v16_: int = id v16_;
+  br v25_ .b17_ .b26_;
+.b26_:
   v7_: int = id v13_;
   v8_: int = id v14_;
   v9_: int = id v15_;
   v10_: int = id v16_;
   print v7_;
   ret;
-  jmp .b30_;
+  jmp .b27_;
 .b12_:
   print v7_;
   ret;
-.b30_:
+.b27_:
 }


### PR DESCRIPTION
With this rule:
```
(rule ((Bop (Mul) (Uop (Abs) x) (Const (Int 3) ty ctx)))
      ((panic "good")) :ruleset peepholes)
```
we can tell that the optimization is firing and finding the way to pull `res = res + abs(input)` out of both branches, but due to extraction issues, we're not extracting that program.