### PR TITLE
Ablate any ruleset

### DIFF
--- a/dag_in_context/src/schema.egg
+++ b/dag_in_context/src/schema.egg
@@ -292,3 +292,5 @@
 
 ; (constructor TermDoWhile (Term Term) Term)
 
+
+(ruleset never)

--- a/infra/graphs.py
+++ b/infra/graphs.py
@@ -7,15 +7,24 @@ import matplotlib.ticker as mticker
 import numpy as np
 import sys
 import os
+import profile
 
 RUN_MODES = ["llvm-O0-O0", "llvm-eggcc-O0-O0", "llvm-O3-O0"]
 BAR_CHART_RUN_MODES = ["llvm-O3-O3", "llvm-O3-O0", "llvm-eggcc-O0-O0"]
+
+if profile.TO_ABLATE != "":
+  RUN_MODES.extend(["llvm-eggcc-ablation-O0-O0", "llvm-eggcc-ablation-O3-O0", "llvm-eggcc-ablation-O3-O3"])
+  BAR_CHART_RUN_MODES.extend(["llvm-eggcc-ablation-O0-O0", "llvm-eggcc-ablation-O3-O0", "llvm-eggcc-ablation-O3-O3"])
+
 # copied from chart.js
 COLOR_MAP = {
   "llvm-O0-O0" : "purple",
   "llvm-eggcc-O0-O0" : "pink",
   "llvm-O3-O0" : "gray",
   "llvm-O3-O3": "gold",
+  "llvm-eggcc-ablation-O0-O0": "blue",
+  "llvm-eggcc-ablation-O3-O0": "green",
+  "llvm-eggcc-ablation-O3-O3": "orange",
 }
 BENCHMARK_SPACE = 1.0 / len(RUN_MODES)
 CIRCLE_SIZE = 15

--- a/infra/nightly-resources/chart.js
+++ b/infra/nightly-resources/chart.js
@@ -9,6 +9,9 @@ const COLORS = {
   "llvm-eggcc-sequential-O0-O0": "blue",
   "llvm-eggcc-O3-O0": "brown",
   "llvm-eggcc-O3-O3": "lightblue",
+  "llvm-eggcc-ablation-O0-O0": "blue",
+  "llvm-eggcc-ablation-O3-O0": "green",
+  "llvm-eggcc-ablation-O3-O3": "orange",
 };
 
 const BASELINE_MODE = "llvm-O0-O0";

--- a/infra/nightly-resources/data.js
+++ b/infra/nightly-resources/data.js
@@ -80,7 +80,7 @@ function getOverallStatistics(suite) {
 
   // generate one row per treatment...
   const result = [];
-  for (const treatment of treatments) {
+  for (const treatment of treatments()) {
     const normalized_cycles = [];
     // for each benchmark, calculate the normalized cycles
     for (const benchmark of benchmarks) {

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -1,17 +1,4 @@
 // copied from profile.py
-const treatments = [
-  "rvsdg-round-trip-to-executable",
-  "llvm-O0-O0",
-  "llvm-O1-O0",
-  "llvm-O2-O0",
-  "llvm-eggcc-O0-O0",
-  "llvm-eggcc-sequential-O0-O0",
-  "llvm-O3-O0",
-  "llvm-O3-O3",
-  "llvm-eggcc-O3-O0",
-  "llvm-eggcc-O3-O3",
-];
-
 const GLOBAL_DATA = {
   checkedModes: new Set(),
   checkedSuites: new Set(),
@@ -25,6 +12,10 @@ const GLOBAL_DATA = {
     sortBy: undefined,
   },
 };
+
+function treatments() {
+  return GLOBAL_DATA.currentRun.map((x) => x.runMethod);
+}
 
 // filter to all the benchmark names that are enabled
 // using checkedSuites and checkedBenchmarks
@@ -182,7 +173,7 @@ function makeCheckbox(parent, mode) {
 }
 
 function makeSelectors() {
-  treatments.forEach((mode) => {
+  treatments().forEach((mode) => {
     const checkbox = makeCheckbox(
       document.getElementById("modeCheckboxes"),
       mode,

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -27,6 +27,7 @@ def num_samples():
 def average(lst):
   return sum(lst) / len(lst)
 
+TO_ABLATE = "" # change to a ruleset to ablate
 
 treatments = [
   "rvsdg-round-trip-to-executable",
@@ -41,6 +42,13 @@ treatments = [
   "llvm-eggcc-O3-O0",
   "llvm-eggcc-O3-O3",
 ]
+
+if TO_ABLATE != "":
+  treatments.extend([
+    "llvm-eggcc-ablation-O0-O0",
+    "llvm-eggcc-ablation-O3-O0",
+    "llvm-eggcc-ablation-O3-O3",
+  ])
 
 # Where to output files that are needed for nightly report
 DATA_DIR = None
@@ -76,6 +84,12 @@ def get_eggcc_options(benchmark):
       return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O0')
     case "llvm-eggcc-O3-O3":
       return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O3')
+    case "llvm-eggcc-ablation-O0-O0":
+      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0 --ablate {TO_ABLATE}')
+    case "llvm-eggcc-ablation-O3-O0":
+      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O0 --ablate {TO_ABLATE}')
+    case "llvm-eggcc-ablation-O3-O3":
+      return (f'optimize', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O3_O3 --ablate {TO_ABLATE}')
     case _:
       raise Exception("Unexpected run mode: " + benchmark.treatment)
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,9 @@ struct Args {
 
     #[clap(long)]
     optimize_function: Option<String>,
+
+    #[clap(long)]
+    ablate: Option<String>,
 }
 
 fn main() {
@@ -124,6 +127,7 @@ fn main() {
             stop_after_n_passes: args.stop_after_n_passes.unwrap_or(i64::MAX),
             linearity: !args.no_linearity,
             optimize_functions: args.optimize_function.map(|s| once(s.clone()).collect()),
+            ablate: args.ablate,
         },
     };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -760,7 +760,7 @@ impl Run {
                 let rvsdg =
                     crate::Optimizer::program_to_rvsdg(&self.prog_with_args.program).unwrap();
                 let tree = rvsdg.to_dag_encoding();
-                let unfolded_program = build_program(&tree, None, &tree.fns(), "");
+                let unfolded_program = build_program(&tree, None, &tree.fns(), "", None);
                 let folded_program = tree.pretty_print_to_egglog();
                 let program =
                     format!("{unfolded_program} \n {folded_program} \n (check (= PROG_PP PROG))");
@@ -839,6 +839,7 @@ impl Run {
                     inline_program,
                     &dag.fns(),
                     last_schedule_step.egglog_schedule(),
+                    eggcc_config.ablate.as_deref(),
                 );
                 (
                     vec![Visualization {


### PR DESCRIPTION
Remove a ruleset with `--ablate RULESET`

To see a `localnightly.sh` with ablated versions, set the following string in `profile.py` to non-empty (e.g. "loop-inv-motion").
```
TO_ABLATE = "" # change to a ruleset to ablate
```