### PR TITLE
Add optimizations to support talk example

### DIFF
--- a/dag_in_context/src/interval_analysis.egg
+++ b/dag_in_context/src/interval_analysis.egg
@@ -268,6 +268,14 @@
       ((union lhs (Bop (Sub) (Const (Int 0) ty ctx) x)))
       :ruleset interval-rewrite)
 
+(rule
+  (
+    (= lhs (Bop (Div) (Const (Int x) ty ctx) (Const (Int x) ty ctx)))
+    (!= x 0)
+  )
+  ((union lhs (Const (Int 1) ty ctx)))
+  :ruleset interval-rewrite)
+
 ; =================================
 ; Conditionals
 ; =================================

--- a/dag_in_context/src/optimizations/mem_simple.egg
+++ b/dag_in_context/src/optimizations/mem_simple.egg
@@ -80,19 +80,6 @@
       )
       :ruleset mem-simple)
 
-; Two writes can be swapped if they don't alias
-(rule (    
-        (NoAlias w1-addr w2-addr)
-        (= w1 (Top (Write) w1-addr w1-val st))
-        (= w2 (Top (Write) w2-addr w2-val w1))
-      )
-      (
-        (let new-w1 (Top (Write) w2-addr w2-val st))
-        (let new-w2 (Top (Write) w1-addr w1-val new-w1))
-        (union new-w2 w2)
-      )
-      :ruleset mem-simple)
-
 ; A load then a write to different addresses can be swapped
 ; Actually, does this break WeaklyLinear if the stored value depends on the
 ; loaded value? Commenting this out for now.
@@ -139,12 +126,6 @@
        (DidMemOptimization "shadowed write"))
       :ruleset mem-simple)
 
-; A load doesn't change the state
-; TODO: why does this break weaklylinear?
-(rule ((= load (Bop (Load) addr state)))
-      ((union (Get load 1) state)
-       (DidMemOptimization "drop load"))
-      :ruleset mem-simple)
 
 ; (rule ((DidMemOptimization _))
 ;       ((panic "DidMemOptimization"))

--- a/dag_in_context/src/optimizations/mem_simple.egg
+++ b/dag_in_context/src/optimizations/mem_simple.egg
@@ -80,6 +80,19 @@
       )
       :ruleset mem-simple)
 
+; Two writes can be swapped if they don't alias
+(rule (    
+        (NoAlias w1-addr w2-addr)
+        (= w1 (Top (Write) w1-addr w1-val st))
+        (= w2 (Top (Write) w2-addr w2-val w1))
+      )
+      (
+        (let new-w1 (Top (Write) w2-addr w2-val st))
+        (let new-w2 (Top (Write) w1-addr w1-val new-w1))
+        (union new-w2 w2)
+      )
+      :ruleset mem-simple)
+
 ; A load then a write to different addresses can be swapped
 ; Actually, does this break WeaklyLinear if the stored value depends on the
 ; loaded value? Commenting this out for now.
@@ -128,9 +141,10 @@
 
 ; A load doesn't change the state
 ; TODO: why does this break weaklylinear?
-; (rule ((= load (Bop (Load) addr state)))
-;       ((union (Get load 1) state))
-;       :ruleset mem-simple)
+(rule ((= load (Bop (Load) addr state)))
+      ((union (Get load 1) state)
+       (DidMemOptimization "drop load"))
+      :ruleset mem-simple)
 
 ; (rule ((DidMemOptimization _))
 ;       ((panic "DidMemOptimization"))

--- a/dag_in_context/src/optimizations/non_weakly_linear.egg
+++ b/dag_in_context/src/optimizations/non_weakly_linear.egg
@@ -68,3 +68,16 @@
   (set (LoopNumItersGuess new-loop-input new-loop-body) (- old_cost 1))
   )
  :ruleset non-weakly-linear)
+
+ ; Two writes can be swapped if they don't alias
+(rule (    
+        (NoAlias w1-addr w2-addr)
+        (= w1 (Top (Write) w1-addr w1-val st))
+        (= w2 (Top (Write) w2-addr w2-val w1))
+      )
+      (
+        (let new-w1 (Top (Write) w2-addr w2-val st))
+        (let new-w2 (Top (Write) w1-addr w1-val new-w1))
+        (union new-w2 w2)
+      )
+      :ruleset non-weakly-linear)

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -55,3 +55,14 @@
 (rewrite (Bop (PtrAdd) (Bop (PtrAdd) p x) y)
          (Bop (PtrAdd) p (Bop (Add) x y))
          :ruleset peepholes)
+
+(rewrite (Bop (Div) (Bop (Mul) a b) c) (Bop (Mul) a (Bop (Div) b c)) :ruleset peepholes)
+
+(rule
+  (
+    (= expr (Bop (Eq) a a))
+    (ContextOf expr ctx)
+    (HasArgType expr ty)
+  )
+  ((union expr (Const (Bool true) ty ctx)))
+  :ruleset peepholes)

--- a/dag_in_context/src/optimizations/peepholes.egg
+++ b/dag_in_context/src/optimizations/peepholes.egg
@@ -2,6 +2,9 @@
 
 (ruleset peepholes)
 
+(rewrite (Uop (Not) (Const (Bool true) ty ctx))  (Const (Bool false) ty ctx) :ruleset peepholes)
+(rewrite (Uop (Not) (Const (Bool false) ty ctx)) (Const (Bool true) ty ctx)  :ruleset peepholes)
+
 (rewrite (Bop (Mul) (Const (Int 0) ty ctx) e) (Const (Int 0) ty ctx) :ruleset peepholes)
 (rewrite (Bop (Mul) e (Const (Int 0) ty ctx)) (Const (Int 0) ty ctx) :ruleset peepholes)
 (rewrite (Bop (Mul) (Const (Int 1) ty ctx) e) e :ruleset peepholes)

--- a/tests/passing/small/imp.bril
+++ b/tests/passing/small/imp.bril
@@ -24,6 +24,9 @@
     print one_hundred;
   
   .els:
+    la3: int = load pa;
+    foola3: int = call @foo la3;
+    store pa foola3;
 }
 
 @main(x: int, y: int) {

--- a/tests/passing/small/intermediate1.bril
+++ b/tests/passing/small/intermediate1.bril
@@ -10,7 +10,20 @@
 @bar(pa: ptr<int>, pb: ptr<int>) {
   la: int = load pa;
   foola: int = call @foo la;
-  store pa foola;
+  store pb foola;
+
+  la2: int = load pa;
+  lb: int = load pb;
+  
+  cmp: bool = eq la2 lb;
+  cond: bool = not cmp;
+  br cond .thn .els;
+
+  .thn:
+    one_hundred: int = const 100;
+    print one_hundred;
+  
+  .els:
 }
 
 @main(x: int, y: int) {

--- a/tests/passing/small/intermediate1.bril
+++ b/tests/passing/small/intermediate1.bril
@@ -1,0 +1,29 @@
+# ARGS : 10 20
+
+@foo(x : int): int {
+  two: int = const 2;
+  tmp: int = mul x two;
+  r: int = div tmp two;
+  ret r;
+}
+
+@bar(pa: ptr<int>, pb: ptr<int>) {
+  la: int = load pa;
+  foola: int = call @foo la;
+  store pa foola;
+}
+
+@main(x: int, y: int) {
+  zero: int = const 0;
+  one: int = const 1;
+  two: int = const 2;
+  pa: ptr<int> = alloc two;
+  pb: ptr<int> = ptradd pa one;
+
+  store pa x;
+  store pb y;
+  
+  call @bar pa pb;
+
+  ret;
+}

--- a/tests/passing/small/pure.rs
+++ b/tests/passing/small/pure.rs
@@ -1,0 +1,5 @@
+// ARGS: 20
+fn main(x: i64) {
+    let r: i64 = (x * 2) / 2;
+    println!("{}", r);
+}

--- a/tests/snapshots/files__fib_recursive-optimize-sequential.snap
+++ b/tests/snapshots/files__fib_recursive-optimize-sequential.snap
@@ -16,340 +16,174 @@ expression: visualization.result
   v8_: bool = eq c3_ v0;
   br v8_ .b9_ .b10_;
 .b9_:
-  v11_: bool = eq c1_ c1_;
+  c11_: bool = const true;
   v12_: int = id c3_;
-  br v11_ .b13_ .b14_;
-.b13_:
-  v15_: int = id c3_;
-  v4_: int = id v15_;
+  v13_: int = id c3_;
+  v4_: int = id v13_;
   ret v4_;
   jmp .b7_;
-.b14_:
-  v16_: bool = eq c1_ c3_;
-  br v16_ .b17_ .b18_;
-.b17_:
-  v19_: bool = eq c1_ c1_;
-  v20_: int = id c3_;
-  br v19_ .b21_ .b22_;
-.b21_:
-  v23_: int = id c3_;
-  v12_: int = id v23_;
-  v15_: int = id c3_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b22_:
-  v24_: bool = eq c1_ c3_;
-  br v24_ .b25_ .b26_;
-.b25_:
-  v27_: int = call @fac c1_;
-  v28_: int = id c3_;
-  v20_: int = id v28_;
-  v23_: int = id c3_;
-  v12_: int = id v23_;
-  v15_: int = id c3_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b26_:
-  c29_: int = const -1;
-  v30_: int = call @fac c29_;
-  c31_: int = const -2;
-  v32_: int = call @fac c31_;
-  v33_: int = add v30_ v32_;
-  v28_: int = id v33_;
-  v20_: int = id v28_;
-  v23_: int = id c3_;
-  v12_: int = id v23_;
-  v15_: int = id c3_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b18_:
-  c34_: int = const -2;
-  v35_: bool = eq c1_ c34_;
-  c36_: int = const -1;
-  v37_: bool = eq c1_ c36_;
-  v38_: int = id c3_;
-  br v37_ .b39_ .b40_;
-.b39_:
-  v41_: int = id c3_;
-.b42_:
-  br v35_ .b43_ .b44_;
-.b43_:
-  v45_: int = add v38_ v41_;
-  v23_: int = id v45_;
-  v12_: int = id v23_;
-  v15_: int = id c3_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b44_:
-  v46_: bool = eq c34_ c3_;
-  br v46_ .b47_ .b48_;
-.b47_:
-  v49_: int = call @fac c1_;
-  v50_: int = id c34_;
-  v41_: int = id v50_;
-  v45_: int = add v38_ v41_;
-  v23_: int = id v45_;
-  v12_: int = id v23_;
-  v15_: int = id c3_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b48_:
-  c51_: int = const -3;
-  v52_: int = call @fac c51_;
-  c53_: int = const -4;
-  v54_: int = call @fac c53_;
-  v55_: int = add v52_ v54_;
-  v50_: int = id v55_;
-  v41_: int = id v50_;
-  v45_: int = add v38_ v41_;
-  v23_: int = id v45_;
-  v12_: int = id v23_;
-  v15_: int = id c3_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b40_:
-  v56_: bool = eq c36_ c3_;
-  br v56_ .b57_ .b58_;
-.b57_:
-  v59_: int = call @fac c1_;
-  v60_: int = id c36_;
-  v38_: int = id v60_;
-  v41_: int = id c3_;
-  jmp .b42_;
-.b58_:
-  c61_: int = const -2;
-  v62_: int = call @fac c61_;
-  c63_: int = const -3;
-  v64_: int = call @fac c63_;
-  v65_: int = add v62_ v64_;
-  v60_: int = id v65_;
-  v38_: int = id v60_;
-  v41_: int = id c3_;
-  jmp .b42_;
 .b10_:
-  v66_: int = sub v0 c3_;
-  v67_: int = sub v66_ c3_;
-  v68_: bool = eq c1_ v67_;
-  v69_: bool = eq c1_ v66_;
-  v70_: int = id c3_;
-  br v69_ .b71_ .b72_;
-.b71_:
-  v73_: int = id c3_;
-.b74_:
-  br v68_ .b75_ .b76_;
+  v14_: int = sub v0 c3_;
+  v15_: int = sub v14_ c3_;
+  v16_: bool = eq c1_ v15_;
+  v17_: bool = eq c1_ v14_;
+  v18_: int = id c3_;
+  br v17_ .b19_ .b20_;
+.b19_:
+  v21_: int = id c3_;
+.b22_:
+  br v16_ .b23_ .b24_;
+.b23_:
+  v25_: int = add v18_ v21_;
+  v13_: int = id v25_;
+  v4_: int = id v13_;
+  ret v4_;
+  jmp .b7_;
+.b24_:
+  v26_: bool = eq c3_ v15_;
+  br v26_ .b27_ .b28_;
+.b27_:
+  c29_: bool = const true;
+  v30_: int = id c3_;
+  v31_: int = id c3_;
+  v21_: int = id v31_;
+  v25_: int = add v18_ v21_;
+  v13_: int = id v25_;
+  v4_: int = id v13_;
+  ret v4_;
+  jmp .b7_;
+.b28_:
+  v32_: int = sub v15_ c3_;
+  v33_: int = sub v32_ c3_;
+  v34_: bool = eq c1_ v33_;
+  v35_: bool = eq c1_ v32_;
+  v36_: int = id c3_;
+  br v35_ .b37_ .b38_;
+.b37_:
+  v39_: int = id c3_;
+.b40_:
+  br v34_ .b41_ .b42_;
+.b41_:
+  v43_: int = add v36_ v39_;
+  v31_: int = id v43_;
+  v21_: int = id v31_;
+  v25_: int = add v18_ v21_;
+  v13_: int = id v25_;
+  v4_: int = id v13_;
+  ret v4_;
+  jmp .b7_;
+.b42_:
+  v44_: bool = eq c3_ v33_;
+  br v44_ .b45_ .b46_;
+.b45_:
+  v47_: int = call @fac c1_;
+  v48_: int = id c3_;
+  v39_: int = id v48_;
+  v43_: int = add v36_ v39_;
+  v31_: int = id v43_;
+  v21_: int = id v31_;
+  v25_: int = add v18_ v21_;
+  v13_: int = id v25_;
+  v4_: int = id v13_;
+  ret v4_;
+  jmp .b7_;
+.b46_:
+  v49_: int = sub v33_ c3_;
+  v50_: int = sub v49_ c3_;
+  v51_: int = call @fac v49_;
+  v52_: int = call @fac v50_;
+  v53_: int = add v51_ v52_;
+  v48_: int = id v53_;
+  v39_: int = id v48_;
+  v43_: int = add v36_ v39_;
+  v31_: int = id v43_;
+  v21_: int = id v31_;
+  v25_: int = add v18_ v21_;
+  v13_: int = id v25_;
+  v4_: int = id v13_;
+  ret v4_;
+  jmp .b7_;
+.b38_:
+  v54_: bool = eq c3_ v32_;
+  br v54_ .b55_ .b56_;
+.b55_:
+  v57_: int = call @fac c1_;
+  v58_: int = id c3_;
+  v36_: int = id v58_;
+  v39_: int = id c3_;
+  jmp .b40_;
+.b56_:
+  v59_: int = sub v32_ c3_;
+  v60_: int = sub v59_ c3_;
+  v61_: int = call @fac v59_;
+  v62_: int = call @fac v60_;
+  v63_: int = add v61_ v62_;
+  v58_: int = id v63_;
+  v36_: int = id v58_;
+  v39_: int = id c3_;
+  jmp .b40_;
+.b20_:
+  v64_: bool = eq c3_ v14_;
+  br v64_ .b65_ .b66_;
+.b65_:
+  c67_: bool = const true;
+  v68_: int = id c3_;
+  v69_: int = id c3_;
+  v18_: int = id v69_;
+  v21_: int = id c3_;
+  jmp .b22_;
+.b66_:
+  v70_: int = sub v14_ c3_;
+  v71_: int = sub v70_ c3_;
+  v72_: bool = eq c1_ v71_;
+  v73_: bool = eq c1_ v70_;
+  v74_: int = id c3_;
+  br v73_ .b75_ .b76_;
 .b75_:
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b76_:
-  v78_: bool = eq c3_ v67_;
-  br v78_ .b79_ .b80_;
-.b79_:
-  v81_: bool = eq c1_ c1_;
-  v82_: int = id c3_;
-  br v81_ .b83_ .b84_;
-.b83_:
-  v85_: int = id c3_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b84_:
-  v86_: bool = eq c1_ c3_;
-  br v86_ .b87_ .b88_;
-.b87_:
-  v89_: int = call @fac c1_;
-  v90_: int = id c3_;
-  v82_: int = id v90_;
-  v85_: int = id c3_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b88_:
-  c91_: int = const -1;
-  v92_: int = call @fac c91_;
-  c93_: int = const -2;
-  v94_: int = call @fac c93_;
-  v95_: int = add v92_ v94_;
-  v90_: int = id v95_;
-  v82_: int = id v90_;
-  v85_: int = id c3_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
+  v77_: int = id c3_;
+.b78_:
+  br v72_ .b79_ .b80_;
 .b80_:
-  v96_: int = sub v67_ c3_;
-  v97_: int = sub v96_ c3_;
-  v98_: bool = eq c1_ v97_;
-  v99_: bool = eq c1_ v96_;
-  v100_: int = id c3_;
-  br v99_ .b101_ .b102_;
-.b101_:
-  v103_: int = id c3_;
-.b104_:
-  br v98_ .b105_ .b106_;
-.b105_:
-  v107_: int = add v100_ v103_;
-  v85_: int = id v107_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b106_:
-  v108_: bool = eq c3_ v97_;
-  br v108_ .b109_ .b110_;
-.b109_:
-  v111_: int = call @fac c1_;
-  v112_: int = id c3_;
-  v103_: int = id v112_;
-  v107_: int = add v100_ v103_;
-  v85_: int = id v107_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b110_:
-  v113_: int = sub v97_ c3_;
-  v114_: int = sub v113_ c3_;
-  v115_: int = call @fac v113_;
-  v116_: int = call @fac v114_;
-  v117_: int = add v115_ v116_;
-  v112_: int = id v117_;
-  v103_: int = id v112_;
-  v107_: int = add v100_ v103_;
-  v85_: int = id v107_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b102_:
-  v118_: bool = eq c3_ v96_;
-  br v118_ .b119_ .b120_;
-.b119_:
-  v121_: int = call @fac c1_;
-  v122_: int = id c3_;
-  v100_: int = id v122_;
-  v103_: int = id c3_;
-  jmp .b104_;
-.b120_:
-  v123_: int = sub v96_ c3_;
-  v124_: int = sub v123_ c3_;
-  v125_: int = call @fac v123_;
-  v126_: int = call @fac v124_;
-  v127_: int = add v125_ v126_;
-  v122_: int = id v127_;
-  v100_: int = id v122_;
-  v103_: int = id c3_;
-  jmp .b104_;
-.b72_:
-  v128_: bool = eq c3_ v66_;
-  br v128_ .b129_ .b130_;
-.b129_:
-  v131_: bool = eq c1_ c1_;
-  v132_: int = id c3_;
-  br v131_ .b133_ .b134_;
-.b133_:
-  v135_: int = id c3_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b134_:
-  v136_: bool = eq c1_ c3_;
-  br v136_ .b137_ .b138_;
-.b137_:
-  v139_: int = call @fac c1_;
-  v140_: int = id c3_;
-  v132_: int = id v140_;
-  v135_: int = id c3_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b138_:
-  c141_: int = const -1;
-  v142_: int = call @fac c141_;
-  c143_: int = const -2;
-  v144_: int = call @fac c143_;
-  v145_: int = add v142_ v144_;
-  v140_: int = id v145_;
-  v132_: int = id v140_;
-  v135_: int = id c3_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b130_:
-  v146_: int = sub v66_ c3_;
-  v147_: int = sub v146_ c3_;
-  v148_: bool = eq c1_ v147_;
-  v149_: bool = eq c1_ v146_;
-  v150_: int = id c3_;
-  br v149_ .b151_ .b152_;
-.b151_:
-  v153_: int = id c3_;
-.b154_:
-  br v148_ .b155_ .b156_;
-.b156_:
-  v157_: bool = eq c3_ v147_;
-  br v157_ .b158_ .b159_;
-.b158_:
-  v160_: int = call @fac c1_;
-  v161_: int = id c3_;
-  v153_: int = id v161_;
-.b155_:
-  v162_: int = add v150_ v153_;
-  v135_: int = id v162_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b159_:
-  v163_: int = sub v147_ c3_;
-  v164_: int = sub v163_ c3_;
-  v165_: int = call @fac v163_;
-  v166_: int = call @fac v164_;
-  v167_: int = add v165_ v166_;
-  v161_: int = id v167_;
-  v153_: int = id v161_;
-  jmp .b155_;
-.b152_:
-  v168_: bool = eq c3_ v146_;
-  br v168_ .b169_ .b170_;
-.b169_:
-  v171_: int = call @fac c1_;
-  v172_: int = id c3_;
-  v150_: int = id v172_;
-  v153_: int = id c3_;
-  jmp .b154_;
-.b170_:
-  v173_: int = sub v146_ c3_;
-  v174_: int = sub v173_ c3_;
-  v175_: int = call @fac v173_;
-  v176_: int = call @fac v174_;
-  v177_: int = add v175_ v176_;
-  v172_: int = id v177_;
-  v150_: int = id v172_;
-  v153_: int = id c3_;
-  jmp .b154_;
+  v81_: bool = eq c3_ v71_;
+  br v81_ .b82_ .b83_;
+.b82_:
+  v84_: int = call @fac c1_;
+  v85_: int = id c3_;
+  v77_: int = id v85_;
+.b79_:
+  v86_: int = add v74_ v77_;
+  v69_: int = id v86_;
+  v18_: int = id v69_;
+  v21_: int = id c3_;
+  jmp .b22_;
+.b83_:
+  v87_: int = sub v71_ c3_;
+  v88_: int = sub v87_ c3_;
+  v89_: int = call @fac v87_;
+  v90_: int = call @fac v88_;
+  v91_: int = add v89_ v90_;
+  v85_: int = id v91_;
+  v77_: int = id v85_;
+  jmp .b79_;
+.b76_:
+  v92_: bool = eq c3_ v70_;
+  br v92_ .b93_ .b94_;
+.b93_:
+  v95_: int = call @fac c1_;
+  v96_: int = id c3_;
+  v74_: int = id v96_;
+  v77_: int = id c3_;
+  jmp .b78_;
+.b94_:
+  v97_: int = sub v70_ c3_;
+  v98_: int = sub v97_ c3_;
+  v99_: int = call @fac v97_;
+  v100_: int = call @fac v98_;
+  v101_: int = add v100_ v99_;
+  v96_: int = id v101_;
+  v74_: int = id v96_;
+  v77_: int = id c3_;
+  jmp .b78_;
 .b7_:
 }
 @main {
@@ -365,102 +199,67 @@ expression: visualization.result
   jmp .b7_;
 .b6_:
   v8_: bool = eq c1_ c3_;
-  v9_: bool = eq c0_ c0_;
+  c9_: bool = const true;
   br v8_ .b10_ .b11_;
 .b10_:
   c12_: int = const 1;
   v13_: int = id c12_;
-  br v9_ .b14_ .b15_;
-.b14_:
-  v16_: int = id c1_;
-  v4_: int = id v16_;
-  print v4_;
-  ret;
-  jmp .b7_;
-.b15_:
-  v17_: bool = eq c0_ c12_;
-  br v17_ .b18_ .b19_;
-.b18_:
-  v20_: int = call @fac c12_;
-  v21_: int = id c12_;
-  v13_: int = id v21_;
-  v16_: int = id c1_;
-  v4_: int = id v16_;
-  print v4_;
-  ret;
-  jmp .b7_;
-.b19_:
-  c22_: int = const -2;
-  c23_: int = const -1;
-  v24_: int = call @fac c23_;
-  v25_: int = call @fac c22_;
-  v26_: int = add v24_ v25_;
-  v21_: int = id v26_;
-  v13_: int = id v21_;
-  v16_: int = id c1_;
-  v4_: int = id v16_;
+  v14_: int = id c1_;
+  v4_: int = id v14_;
   print v4_;
   ret;
   jmp .b7_;
 .b11_:
-  v27_: bool = eq c0_ c3_;
-  v28_: int = id c3_;
-  br v27_ .b29_ .b30_;
-.b29_:
-  v31_: int = id c3_;
-.b32_:
-  br v9_ .b33_ .b34_;
-.b33_:
-  v35_: int = add v28_ v31_;
-  v16_: int = id v35_;
-  v4_: int = id v16_;
+  v15_: bool = eq c0_ c3_;
+  v16_: int = id c3_;
+  br v15_ .b17_ .b18_;
+.b17_:
+  v19_: int = id c3_;
+  v20_: int = add v16_ v19_;
+  v14_: int = id v20_;
+  v4_: int = id v14_;
   print v4_;
   ret;
   jmp .b7_;
-.b34_:
-  v36_: bool = eq c0_ c3_;
-  br v36_ .b37_ .b38_;
-.b37_:
-  v39_: int = call @fac c0_;
-  v40_: int = id c3_;
-  v31_: int = id v40_;
-  v35_: int = add v28_ v31_;
-  v16_: int = id v35_;
-  v4_: int = id v16_;
+.b18_:
+  c21_: bool = const true;
+  v22_: int = call @fac c0_;
+  v23_: int = id c3_;
+  v16_: int = id v23_;
+  v19_: int = id c3_;
+  br c9_ .b24_ .b25_;
+.b24_:
+  v20_: int = add v16_ v19_;
+  v14_: int = id v20_;
+  v4_: int = id v14_;
   print v4_;
   ret;
   jmp .b7_;
-.b38_:
-  c41_: int = const -2;
-  c42_: int = const -1;
-  v43_: int = call @fac c42_;
-  v44_: int = call @fac c41_;
-  v45_: int = add v43_ v44_;
-  v40_: int = id v45_;
-  v31_: int = id v40_;
-  v35_: int = add v28_ v31_;
-  v16_: int = id v35_;
-  v4_: int = id v16_;
+.b25_:
+  v26_: bool = eq c0_ c3_;
+  br v26_ .b27_ .b28_;
+.b27_:
+  v29_: int = call @fac c0_;
+  v30_: int = id c3_;
+  v19_: int = id v30_;
+  v20_: int = add v16_ v19_;
+  v14_: int = id v20_;
+  v4_: int = id v14_;
   print v4_;
   ret;
   jmp .b7_;
-.b30_:
-  v46_: bool = eq c3_ c3_;
-  br v46_ .b47_ .b48_;
-.b47_:
-  v49_: int = call @fac c0_;
-  v50_: int = id c3_;
-  v28_: int = id v50_;
-  v31_: int = id c3_;
-  jmp .b32_;
-.b48_:
-  c51_: int = const -1;
-  v52_: int = call @fac c0_;
-  v53_: int = call @fac c51_;
-  v54_: int = add v52_ v53_;
-  v50_: int = id v54_;
-  v28_: int = id v50_;
-  v31_: int = id c3_;
-  jmp .b32_;
+.b28_:
+  c31_: int = const -2;
+  c32_: int = const -1;
+  v33_: int = call @fac c32_;
+  v34_: int = call @fac c31_;
+  v35_: int = add v33_ v34_;
+  v30_: int = id v35_;
+  v19_: int = id v30_;
+  v20_: int = add v16_ v19_;
+  v14_: int = id v20_;
+  v4_: int = id v14_;
+  print v4_;
+  ret;
 .b7_:
 }

--- a/tests/snapshots/files__fib_recursive-optimize.snap
+++ b/tests/snapshots/files__fib_recursive-optimize.snap
@@ -14,342 +14,170 @@ expression: visualization.result
   jmp .b7_;
 .b6_:
   v8_: bool = eq c3_ v0;
-  br v8_ .b9_ .b10_;
-.b9_:
-  v11_: bool = eq c1_ c1_;
-  v12_: int = id v0;
-  br v11_ .b13_ .b14_;
-.b13_:
-  v15_: int = id v0;
-  v4_: int = id v15_;
+  v9_: int = id v0;
+  br v8_ .b10_ .b11_;
+.b10_:
+  v4_: int = id v9_;
   ret v4_;
   jmp .b7_;
-.b14_:
-  v16_: bool = eq c1_ v0;
-  br v16_ .b17_ .b18_;
+.b11_:
+  v12_: int = sub v0 c3_;
+  v13_: int = sub v12_ c3_;
+  v14_: bool = eq c1_ v13_;
+  v15_: bool = eq c1_ v12_;
+  v16_: int = id c3_;
+  br v15_ .b17_ .b18_;
 .b17_:
-  v19_: bool = eq c1_ c1_;
-  v20_: int = id c1_;
-  br v19_ .b21_ .b22_;
+  v19_: int = id c3_;
+.b20_:
+  br v14_ .b21_ .b22_;
 .b21_:
-  v23_: int = id c1_;
-  v12_: int = id v23_;
-  v15_: int = id v0;
-  v4_: int = id v15_;
+  v23_: int = add v16_ v19_;
+  v9_: int = id v23_;
+  v4_: int = id v9_;
   ret v4_;
   jmp .b7_;
 .b22_:
-  v24_: bool = eq c1_ c1_;
-  br v24_ .b25_ .b26_;
-.b25_:
-  v27_: int = call @fac c1_;
-  v28_: int = id c1_;
-  v20_: int = id v28_;
-  v23_: int = id c1_;
-  v12_: int = id v23_;
-  v15_: int = id v0;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
+  v24_: bool = eq c3_ v13_;
+  v25_: int = id v13_;
+  br v24_ .b26_ .b27_;
 .b26_:
-  c29_: int = const -1;
-  v30_: int = call @fac c29_;
-  c31_: int = const -2;
-  v32_: int = call @fac c31_;
-  v33_: int = add v30_ v32_;
-  v28_: int = id v33_;
-  v20_: int = id v28_;
-  v23_: int = id c1_;
-  v12_: int = id v23_;
-  v15_: int = id v0;
-  v4_: int = id v15_;
+  v19_: int = id v25_;
+  v23_: int = add v16_ v19_;
+  v9_: int = id v23_;
+  v4_: int = id v9_;
   ret v4_;
   jmp .b7_;
-.b18_:
-  c34_: int = const -2;
-  v35_: bool = eq c1_ c34_;
-  c36_: int = const -1;
-  v37_: bool = eq c1_ c36_;
-  v38_: int = id v0;
-  br v37_ .b39_ .b40_;
-.b39_:
-  v41_: int = id v0;
+.b27_:
+  v28_: int = sub v13_ c3_;
+  v29_: int = sub v28_ c3_;
+  v30_: bool = eq c1_ v29_;
+  v31_: bool = eq c1_ v28_;
+  v32_: int = id c3_;
+  br v31_ .b33_ .b34_;
+.b33_:
+  v35_: int = id c3_;
+.b36_:
+  br v30_ .b37_ .b38_;
+.b37_:
+  v39_: int = add v32_ v35_;
+  v25_: int = id v39_;
+  v19_: int = id v25_;
+  v23_: int = add v16_ v19_;
+  v9_: int = id v23_;
+  v4_: int = id v9_;
+  ret v4_;
+  jmp .b7_;
+.b38_:
+  v40_: bool = eq c3_ v29_;
+  br v40_ .b41_ .b42_;
+.b41_:
+  v43_: int = call @fac c1_;
+  v44_: int = id v29_;
+  v35_: int = id v44_;
+  v39_: int = add v32_ v35_;
+  v25_: int = id v39_;
+  v19_: int = id v25_;
+  v23_: int = add v16_ v19_;
+  v9_: int = id v23_;
+  v4_: int = id v9_;
+  ret v4_;
+  jmp .b7_;
 .b42_:
-  br v35_ .b43_ .b44_;
-.b43_:
-  v45_: int = add v38_ v41_;
-  v23_: int = id v45_;
-  v12_: int = id v23_;
-  v15_: int = id v0;
-  v4_: int = id v15_;
+  v45_: int = sub v29_ c3_;
+  v46_: int = sub v45_ c3_;
+  v47_: int = call @fac v45_;
+  v48_: int = call @fac v46_;
+  v49_: int = add v47_ v48_;
+  v44_: int = id v49_;
+  v35_: int = id v44_;
+  v39_: int = add v32_ v35_;
+  v25_: int = id v39_;
+  v19_: int = id v25_;
+  v23_: int = add v16_ v19_;
+  v9_: int = id v23_;
+  v4_: int = id v9_;
   ret v4_;
   jmp .b7_;
-.b44_:
-  v46_: bool = eq c34_ v0;
-  br v46_ .b47_ .b48_;
-.b47_:
-  v49_: int = call @fac c1_;
-  v50_: int = id c34_;
-  v41_: int = id v50_;
-  v45_: int = add v38_ v41_;
-  v23_: int = id v45_;
-  v12_: int = id v23_;
-  v15_: int = id v0;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b48_:
-  c51_: int = const -3;
-  v52_: int = call @fac c51_;
-  c53_: int = const -4;
-  v54_: int = call @fac c53_;
-  v55_: int = add v52_ v54_;
-  v50_: int = id v55_;
-  v41_: int = id v50_;
-  v45_: int = add v38_ v41_;
-  v23_: int = id v45_;
-  v12_: int = id v23_;
-  v15_: int = id v0;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b40_:
-  v56_: bool = eq c36_ v0;
-  br v56_ .b57_ .b58_;
-.b57_:
-  v59_: int = call @fac c1_;
-  v60_: int = id c36_;
-  v38_: int = id v60_;
-  v41_: int = id v0;
-  jmp .b42_;
-.b58_:
-  c61_: int = const -2;
-  v62_: int = call @fac c61_;
-  c63_: int = const -3;
-  v64_: int = call @fac c63_;
-  v65_: int = add v62_ v64_;
-  v60_: int = id v65_;
-  v38_: int = id v60_;
-  v41_: int = id v0;
-  jmp .b42_;
-.b10_:
-  v66_: int = sub v0 c3_;
-  v67_: int = sub v66_ c3_;
-  v68_: bool = eq c1_ v67_;
-  v69_: bool = eq c1_ v66_;
-  v70_: int = id c3_;
-  br v69_ .b71_ .b72_;
-.b71_:
-  v73_: int = id c3_;
+.b34_:
+  v50_: bool = eq c3_ v28_;
+  br v50_ .b51_ .b52_;
+.b51_:
+  v53_: int = call @fac c1_;
+  v54_: int = id v28_;
+  v32_: int = id v54_;
+  v35_: int = id c3_;
+  jmp .b36_;
+.b52_:
+  v55_: int = sub v28_ c3_;
+  v56_: int = sub v55_ c3_;
+  v57_: int = call @fac v55_;
+  v58_: int = call @fac v56_;
+  v59_: int = add v57_ v58_;
+  v54_: int = id v59_;
+  v32_: int = id v54_;
+  v35_: int = id c3_;
+  jmp .b36_;
+.b18_:
+  v60_: bool = eq c3_ v12_;
+  v61_: int = id v12_;
+  br v60_ .b62_ .b63_;
+.b62_:
+  v16_: int = id v61_;
+  v19_: int = id c3_;
+  jmp .b20_;
+.b63_:
+  v64_: int = sub v12_ c3_;
+  v65_: int = sub v64_ c3_;
+  v66_: bool = eq c1_ v65_;
+  v67_: bool = eq c1_ v64_;
+  v68_: int = id c3_;
+  br v67_ .b69_ .b70_;
+.b69_:
+  v71_: int = id c3_;
+.b72_:
+  br v66_ .b73_ .b74_;
 .b74_:
-  br v68_ .b75_ .b76_;
-.b75_:
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
+  v75_: bool = eq c3_ v65_;
+  br v75_ .b76_ .b77_;
 .b76_:
-  v78_: bool = eq c3_ v67_;
-  br v78_ .b79_ .b80_;
-.b79_:
-  v81_: bool = eq c1_ c1_;
-  v82_: int = id v67_;
-  br v81_ .b83_ .b84_;
-.b83_:
-  v85_: int = id v67_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b84_:
-  v86_: bool = eq c1_ v67_;
+  v78_: int = call @fac c1_;
+  v79_: int = id v65_;
+  v71_: int = id v79_;
+.b73_:
+  v80_: int = add v68_ v71_;
+  v61_: int = id v80_;
+  v16_: int = id v61_;
+  v19_: int = id c3_;
+  jmp .b20_;
+.b77_:
+  v81_: int = sub v65_ c3_;
+  v82_: int = sub v81_ c3_;
+  v83_: int = call @fac v81_;
+  v84_: int = call @fac v82_;
+  v85_: int = add v83_ v84_;
+  v79_: int = id v85_;
+  v71_: int = id v79_;
+  jmp .b73_;
+.b70_:
+  v86_: bool = eq c3_ v64_;
   br v86_ .b87_ .b88_;
 .b87_:
   v89_: int = call @fac c1_;
-  v90_: int = id c1_;
-  v82_: int = id v90_;
-  v85_: int = id v67_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
+  v90_: int = id v64_;
+  v68_: int = id v90_;
+  v71_: int = id c3_;
+  jmp .b72_;
 .b88_:
-  c91_: int = const -1;
-  v92_: int = call @fac c91_;
-  c93_: int = const -2;
-  v94_: int = call @fac c93_;
-  v95_: int = add v92_ v94_;
+  v91_: int = sub v64_ c3_;
+  v92_: int = sub v91_ c3_;
+  v93_: int = call @fac v91_;
+  v94_: int = call @fac v92_;
+  v95_: int = add v93_ v94_;
   v90_: int = id v95_;
-  v82_: int = id v90_;
-  v85_: int = id v67_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b80_:
-  v96_: int = sub v67_ c3_;
-  v97_: int = sub v96_ c3_;
-  v98_: bool = eq c1_ v97_;
-  v99_: bool = eq c1_ v96_;
-  v100_: int = id c3_;
-  br v99_ .b101_ .b102_;
-.b101_:
-  v103_: int = id c3_;
-.b104_:
-  br v98_ .b105_ .b106_;
-.b105_:
-  v107_: int = add v100_ v103_;
-  v85_: int = id v107_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b106_:
-  v108_: bool = eq c3_ v97_;
-  br v108_ .b109_ .b110_;
-.b109_:
-  v111_: int = call @fac c1_;
-  v112_: int = id v97_;
-  v103_: int = id v112_;
-  v107_: int = add v100_ v103_;
-  v85_: int = id v107_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b110_:
-  v113_: int = sub v97_ c3_;
-  v114_: int = sub v113_ c3_;
-  v115_: int = call @fac v113_;
-  v116_: int = call @fac v114_;
-  v117_: int = add v115_ v116_;
-  v112_: int = id v117_;
-  v103_: int = id v112_;
-  v107_: int = add v100_ v103_;
-  v85_: int = id v107_;
-  v73_: int = id v85_;
-  v77_: int = add v70_ v73_;
-  v15_: int = id v77_;
-  v4_: int = id v15_;
-  ret v4_;
-  jmp .b7_;
-.b102_:
-  v118_: bool = eq c3_ v96_;
-  br v118_ .b119_ .b120_;
-.b119_:
-  v121_: int = call @fac c1_;
-  v122_: int = id v96_;
-  v100_: int = id v122_;
-  v103_: int = id c3_;
-  jmp .b104_;
-.b120_:
-  v123_: int = sub v96_ c3_;
-  v124_: int = sub v123_ c3_;
-  v125_: int = call @fac v123_;
-  v126_: int = call @fac v124_;
-  v127_: int = add v125_ v126_;
-  v122_: int = id v127_;
-  v100_: int = id v122_;
-  v103_: int = id c3_;
-  jmp .b104_;
-.b72_:
-  v128_: bool = eq c3_ v66_;
-  br v128_ .b129_ .b130_;
-.b129_:
-  v131_: bool = eq c1_ c1_;
-  v132_: int = id v66_;
-  br v131_ .b133_ .b134_;
-.b133_:
-  v135_: int = id v66_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b134_:
-  v136_: bool = eq c1_ v66_;
-  br v136_ .b137_ .b138_;
-.b137_:
-  v139_: int = call @fac c1_;
-  v140_: int = id c1_;
-  v132_: int = id v140_;
-  v135_: int = id v66_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b138_:
-  c141_: int = const -1;
-  v142_: int = call @fac c141_;
-  c143_: int = const -2;
-  v144_: int = call @fac c143_;
-  v145_: int = add v142_ v144_;
-  v140_: int = id v145_;
-  v132_: int = id v140_;
-  v135_: int = id v66_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b130_:
-  v146_: int = sub v66_ c3_;
-  v147_: int = sub v146_ c3_;
-  v148_: bool = eq c1_ v147_;
-  v149_: bool = eq c1_ v146_;
-  v150_: int = id c3_;
-  br v149_ .b151_ .b152_;
-.b151_:
-  v153_: int = id c3_;
-.b154_:
-  br v148_ .b155_ .b156_;
-.b156_:
-  v157_: bool = eq c3_ v147_;
-  br v157_ .b158_ .b159_;
-.b158_:
-  v160_: int = call @fac c1_;
-  v161_: int = id v147_;
-  v153_: int = id v161_;
-.b155_:
-  v162_: int = add v150_ v153_;
-  v135_: int = id v162_;
-  v70_: int = id v135_;
-  v73_: int = id c3_;
-  jmp .b74_;
-.b159_:
-  v163_: int = sub v147_ c3_;
-  v164_: int = sub v163_ c3_;
-  v165_: int = call @fac v163_;
-  v166_: int = call @fac v164_;
-  v167_: int = add v165_ v166_;
-  v161_: int = id v167_;
-  v153_: int = id v161_;
-  jmp .b155_;
-.b152_:
-  v168_: bool = eq c3_ v146_;
-  br v168_ .b169_ .b170_;
-.b169_:
-  v171_: int = call @fac c1_;
-  v172_: int = id v146_;
-  v150_: int = id v172_;
-  v153_: int = id c3_;
-  jmp .b154_;
-.b170_:
-  v173_: int = sub v146_ c3_;
-  v174_: int = sub v173_ c3_;
-  v175_: int = call @fac v173_;
-  v176_: int = call @fac v174_;
-  v177_: int = add v175_ v176_;
-  v172_: int = id v177_;
-  v150_: int = id v172_;
-  v153_: int = id c3_;
-  jmp .b154_;
+  v68_: int = id v90_;
+  v71_: int = id c3_;
+  jmp .b72_;
 .b7_:
 }
 @main {
@@ -365,103 +193,29 @@ expression: visualization.result
   jmp .b7_;
 .b6_:
   v8_: bool = eq c0_ c3_;
-  br v8_ .b9_ .b10_;
-.b9_:
-  v11_: bool = eq c1_ c1_;
-  c12_: int = const 1;
-  v13_: int = id c12_;
-  br v11_ .b14_ .b15_;
+  v9_: int = id c0_;
+  br v8_ .b10_ .b11_;
+.b10_:
+  v4_: int = id v9_;
+  print v4_;
+  ret;
+  jmp .b7_;
+.b11_:
+  v12_: bool = eq c1_ c3_;
+  v13_: int = id c1_;
+  br v12_ .b14_ .b15_;
 .b14_:
-  v16_: int = id c0_;
-  v4_: int = id v16_;
+  v9_: int = id c0_;
+  v4_: int = id v9_;
   print v4_;
   ret;
   jmp .b7_;
 .b15_:
-  v17_: bool = eq c12_ c1_;
-  br v17_ .b18_ .b19_;
-.b18_:
-  v20_: int = call @fac c1_;
-  v21_: int = id c1_;
-  v13_: int = id v21_;
-  v16_: int = id c0_;
-  v4_: int = id v16_;
+  v16_: int = call @fac c1_;
+  v13_: int = id c3_;
+  v9_: int = id c0_;
+  v4_: int = id v9_;
   print v4_;
   ret;
-  jmp .b7_;
-.b19_:
-  c22_: int = const -2;
-  c23_: int = const -1;
-  v24_: int = call @fac c23_;
-  v25_: int = call @fac c22_;
-  v26_: int = add v24_ v25_;
-  v21_: int = id v26_;
-  v13_: int = id v21_;
-  v16_: int = id c0_;
-  v4_: int = id v16_;
-  print v4_;
-  ret;
-  jmp .b7_;
-.b10_:
-  v27_: bool = eq c1_ c1_;
-  v28_: bool = eq c1_ c3_;
-  v29_: int = id c3_;
-  br v28_ .b30_ .b31_;
-.b30_:
-  v32_: int = id c3_;
-.b33_:
-  br v27_ .b34_ .b35_;
-.b34_:
-  v36_: int = add v29_ v32_;
-  v16_: int = id v36_;
-  v4_: int = id v16_;
-  print v4_;
-  ret;
-  jmp .b7_;
-.b35_:
-  v37_: bool = eq c1_ c3_;
-  br v37_ .b38_ .b39_;
-.b38_:
-  v40_: int = call @fac c3_;
-  v41_: int = id c3_;
-  v32_: int = id v41_;
-  v36_: int = add v29_ v32_;
-  v16_: int = id v36_;
-  v4_: int = id v16_;
-  print v4_;
-  ret;
-  jmp .b7_;
-.b39_:
-  c42_: int = const -2;
-  c43_: int = const -1;
-  v44_: int = call @fac c43_;
-  v45_: int = call @fac c42_;
-  v46_: int = add v44_ v45_;
-  v41_: int = id v46_;
-  v32_: int = id v41_;
-  v36_: int = add v29_ v32_;
-  v16_: int = id v36_;
-  v4_: int = id v16_;
-  print v4_;
-  ret;
-  jmp .b7_;
-.b31_:
-  v47_: bool = eq c3_ c3_;
-  br v47_ .b48_ .b49_;
-.b48_:
-  v50_: int = call @fac c1_;
-  v51_: int = id c3_;
-  v29_: int = id v51_;
-  v32_: int = id c3_;
-  jmp .b33_;
-.b49_:
-  c52_: int = const -1;
-  v53_: int = call @fac c1_;
-  v54_: int = call @fac c52_;
-  v55_: int = add v53_ v54_;
-  v51_: int = id v55_;
-  v29_: int = id v51_;
-  v32_: int = id c3_;
-  jmp .b33_;
 .b7_:
 }

--- a/tests/snapshots/files__if_invariant_do_pull_out-optimize-no-ctx.snap
+++ b/tests/snapshots/files__if_invariant_do_pull_out-optimize-no-ctx.snap
@@ -10,9 +10,9 @@ expression: visualization.result
 }
 @other_unrelated_fn(v0: int): int {
   c1_: int = const 3;
-  v2_: int = mul c1_ v0;
-  c3_: int = const 5;
-  v4_: int = div v2_ c3_;
+  c2_: int = const 5;
+  v3_: int = div v0 c2_;
+  v4_: int = mul c1_ v3_;
   ret v4_;
 }
 @main(v0: int) {
@@ -36,9 +36,9 @@ expression: visualization.result
   v15_: int = abs v0;
   v16_: int = add v15_ v5_;
   c17_: int = const 3;
-  v18_: int = mul c17_ v0;
-  c19_: int = const 5;
-  v20_: int = div v18_ c19_;
+  c18_: int = const 5;
+  v19_: int = div v0 c18_;
+  v20_: int = mul c17_ v19_;
   v21_: int = add v16_ v20_;
   v13_: int = id v21_;
   print v13_;

--- a/tests/snapshots/files__if_invariant_do_pull_out-optimize-sequential.snap
+++ b/tests/snapshots/files__if_invariant_do_pull_out-optimize-sequential.snap
@@ -10,9 +10,9 @@ expression: visualization.result
 }
 @other_unrelated_fn(v0: int): int {
   c1_: int = const 3;
-  v2_: int = mul c1_ v0;
-  c3_: int = const 5;
-  v4_: int = div v2_ c3_;
+  c2_: int = const 5;
+  v3_: int = div v0 c2_;
+  v4_: int = mul c1_ v3_;
   ret v4_;
 }
 @main(v0: int) {
@@ -32,9 +32,9 @@ expression: visualization.result
   jmp .b12_;
 .b7_:
   c13_: int = const 3;
-  v14_: int = mul c13_ v0;
-  c15_: int = const 5;
-  v16_: int = div v14_ c15_;
+  c14_: int = const 5;
+  v15_: int = div v0 c14_;
+  v16_: int = mul c13_ v15_;
   v17_: int = add v16_ v5_;
   v11_: int = id v17_;
   print v11_;

--- a/tests/snapshots/files__if_invariant_do_pull_out-optimize.snap
+++ b/tests/snapshots/files__if_invariant_do_pull_out-optimize.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/files.rs
 expression: visualization.result
-snapshot_kind: text
 ---
 # ARGS: 20
 @unrelated_fn(v0: int): int {
@@ -11,9 +10,9 @@ snapshot_kind: text
 }
 @other_unrelated_fn(v0: int): int {
   c1_: int = const 3;
-  v2_: int = mul c1_ v0;
-  c3_: int = const 5;
-  v4_: int = div v2_ c3_;
+  c2_: int = const 5;
+  v3_: int = div v0 c2_;
+  v4_: int = mul c1_ v3_;
   ret v4_;
 }
 @main(v0: int) {
@@ -33,9 +32,9 @@ snapshot_kind: text
   jmp .b12_;
 .b7_:
   c13_: int = const 3;
-  v14_: int = mul c13_ v0;
-  c15_: int = const 5;
-  v16_: int = div v14_ c15_;
+  c14_: int = const 5;
+  v15_: int = div v0 c14_;
+  v16_: int = mul c13_ v15_;
   v17_: int = add v16_ v5_;
   v11_: int = id v17_;
   print v11_;

--- a/tests/snapshots/files__imp-optimize-no-ctx.snap
+++ b/tests/snapshots/files__imp-optimize-no-ctx.snap
@@ -1,0 +1,41 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@foo(v0: int): int {
+  ret v0;
+}
+@bar(v0: ptr<int>, v1: ptr<int>) {
+  v2_: int = load v0;
+  store v1 v2_;
+  v3_: int = load v0;
+  v4_: int = load v1;
+  v5_: bool = eq v3_ v4_;
+  v6_: bool = not v5_;
+  v7_: ptr<int> = id v0;
+  br v6_ .b8_ .b9_;
+.b8_:
+  c10_: int = const 100;
+  print c10_;
+  v7_: ptr<int> = id v0;
+  v11_: int = load v0;
+  store v0 v11_;
+  ret;
+  jmp .b12_;
+.b9_:
+  v11_: int = load v0;
+  store v0 v11_;
+  ret;
+.b12_:
+}
+@main(v0: int, v1: int) {
+  c2_: int = const 2;
+  v3_: ptr<int> = alloc c2_;
+  c4_: int = const 1;
+  v5_: ptr<int> = ptradd v3_ c4_;
+  store v3_ v0;
+  store v5_ v0;
+  store v3_ v0;
+  ret;
+}

--- a/tests/snapshots/files__imp-optimize-sequential.snap
+++ b/tests/snapshots/files__imp-optimize-sequential.snap
@@ -1,0 +1,70 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 
+@foo(v0: int): int {
+  c1_: int = const 2;
+  v2_: int = div v0 c1_;
+  v3_: int = mul c1_ v2_;
+  ret v3_;
+}
+@bar(v0: ptr<int>, v1: ptr<int>) {
+  v2_: int = load v0;
+  c3_: int = const 2;
+  v4_: int = div c3_ c3_;
+  v5_: int = mul v2_ v4_;
+  store v1 v5_;
+  v6_: int = load v0;
+  v7_: int = load v1;
+  v8_: bool = eq v6_ v7_;
+  v9_: bool = not v8_;
+  v10_: ptr<int> = id v0;
+  br v9_ .b11_ .b12_;
+.b11_:
+  c13_: int = const 100;
+  print c13_;
+  v10_: ptr<int> = id v0;
+  v14_: int = load v0;
+  v15_: int = mul v14_ v4_;
+  store v0 v15_;
+  ret;
+  jmp .b16_;
+.b12_:
+  v14_: int = load v0;
+  v15_: int = mul v14_ v4_;
+  store v0 v15_;
+  ret;
+.b16_:
+}
+@main(v0: int, v1: int) {
+  c2_: int = const 2;
+  v3_: ptr<int> = alloc c2_;
+  v4_: int = div v0 c2_;
+  v5_: int = mul c2_ v4_;
+  v6_: bool = eq v0 v5_;
+  v7_: bool = not v6_;
+  c8_: int = const 1;
+  v9_: ptr<int> = ptradd v3_ c8_;
+  store v3_ v0;
+  store v9_ v5_;
+  v10_: ptr<int> = id v3_;
+  br v7_ .b11_ .b12_;
+.b11_:
+  c13_: int = const 100;
+  print c13_;
+  v10_: ptr<int> = id v3_;
+  v14_: int = load v3_;
+  v15_: int = div c2_ c2_;
+  v16_: int = mul v14_ v15_;
+  store v3_ v16_;
+  ret;
+  jmp .b17_;
+.b12_:
+  v14_: int = load v3_;
+  v15_: int = div c2_ c2_;
+  v16_: int = mul v14_ v15_;
+  store v3_ v16_;
+  ret;
+.b17_:
+}

--- a/tests/snapshots/files__pure-optimize-no-ctx.snap
+++ b/tests/snapshots/files__pure-optimize-no-ctx.snap
@@ -1,0 +1,9 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+  print v0;
+  ret;
+}

--- a/tests/snapshots/files__pure-optimize-sequential.snap
+++ b/tests/snapshots/files__pure-optimize-sequential.snap
@@ -1,0 +1,12 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+  c1_: int = const 2;
+  v2_: int = div v0 c1_;
+  v3_: int = mul c1_ v2_;
+  print v3_;
+  ret;
+}

--- a/tests/snapshots/files__pure-optimize.snap
+++ b/tests/snapshots/files__pure-optimize.snap
@@ -1,0 +1,9 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+# ARGS: 20
+@main(v0: int) {
+  print v0;
+  ret;
+}


### PR DESCRIPTION
```
def foo(x): return (x * 2) / 2

def bar(a, b):
	x = load(a)
set(b, foo(x))
if load(a) != load(b):
	print 100
set(a, foo(load(a))
```

Added peepholes:

- x/x => 1 for constants not equal to 0
- Not false => true + Not true => false
- (a * b) / c => a * (b/c)
- x = x => true

Added memory optimizations (may not be weakly linear but thats okay)
- reorder writes if they don't alias
- load doesn't change state edge (load dropping)