### PR TITLE
Make gurobi optional so nightly runs again

### DIFF
--- a/dag_in_context/src/lib.rs
+++ b/dag_in_context/src/lib.rs
@@ -376,6 +376,8 @@ pub struct EggccConfig {
     pub tiger_ilp: bool,
     /// When true, collect region timing samples by running both the tiger and ILP extractors.
     pub time_ilp: bool,
+    /// Percentage of regions to run ILP timing on (0.0 to 100.0). Regions are selected randomly.
+    pub percent_regions: f64,
     pub use_context: bool,
     /// When using the tiger ILP extractor, minimize the objective in the solver.
     pub ilp_minimize_objective: bool,
@@ -458,6 +460,7 @@ impl Default for EggccConfig {
             use_tiger: false,
             tiger_ilp: false,
             time_ilp: false,
+            percent_regions: 100.0,
             use_context: true,
             ilp_minimize_objective: true,
             ilp_solver: IlpSolver::default(),
@@ -593,6 +596,8 @@ fn run_tiger_pipeline(
 
     let extract_timing_file = if eggcc_config.time_ilp {
         tiger_args.push(OsString::from("--time-ilp"));
+        tiger_args.push(OsString::from("--percent-regions"));
+        tiger_args.push(OsString::from(eggcc_config.percent_regions.to_string()));
         let file = NamedTempFile::new()
             .map_err(|err| format!("failed to create extract timing tempfile: {err}"))
             .unwrap();

--- a/dag_in_context/src/tiger/main.cpp
+++ b/dag_in_context/src/tiger/main.cpp
@@ -1,6 +1,8 @@
 #include<cassert>
+#include<cmath>
 #include<cstdio>
 #include<cstring>
+#include<stdexcept>
 
 #include "main.h"
 #include "json2egraphin.h"
@@ -34,8 +36,20 @@ int main(int argc, char *argv[]) {
         } else if (strcmp(argv[i], "--time-ilp") == 0) {
             g_config.time_ilp = true;
         } else if (strcmp(argv[i], "--percent-regions") == 0) {
-            assert(i + 1 < argc);
-            g_config.percent_regions = std::stod(argv[i + 1]);
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "--percent-regions requires a value\n");
+                return 1;
+            }
+            try {
+                g_config.percent_regions = std::stod(argv[i + 1]);
+            } catch (const std::exception &e) {
+                std::fprintf(stderr, "Invalid value for --percent-regions: %s\n", argv[i + 1]);
+                return 1;
+            }
+            if (!std::isfinite(g_config.percent_regions) || g_config.percent_regions < 0.0 || g_config.percent_regions > 100.0) {
+                std::fprintf(stderr, "--percent-regions must be a finite number between 0.0 and 100.0, got: %s\n", argv[i + 1]);
+                return 1;
+            }
             ++i;
         } else if (strcmp(argv[i], "--ilp-solver") == 0) {
             assert(i + 1 < argc);

--- a/dag_in_context/src/tiger/main.cpp
+++ b/dag_in_context/src/tiger/main.cpp
@@ -33,6 +33,10 @@ int main(int argc, char *argv[]) {
             requested_ilp_no_minimize = true;
         } else if (strcmp(argv[i], "--time-ilp") == 0) {
             g_config.time_ilp = true;
+        } else if (strcmp(argv[i], "--percent-regions") == 0) {
+            assert(i + 1 < argc);
+            g_config.percent_regions = std::stod(argv[i + 1]);
+            ++i;
         } else if (strcmp(argv[i], "--ilp-solver") == 0) {
             assert(i + 1 < argc);
             const char *solver = argv[i + 1];

--- a/dag_in_context/src/tiger/main.h
+++ b/dag_in_context/src/tiger/main.h
@@ -11,6 +11,7 @@ struct Config {
     bool ilp_minimize_objective = true;
     int ilp_timeout_seconds = 5 * 60; // 5 minutes
     bool time_ilp = false;
+    double percent_regions = 100.0; // Percentage of regions to run ILP timing on (0.0 to 100.0)
 };
 
 extern Config g_config;

--- a/dag_in_context/src/tiger/time_ilp.cpp
+++ b/dag_in_context/src/tiger/time_ilp.cpp
@@ -114,34 +114,59 @@ compute_extract_region_timings(const EGraph &g,
                                const vector<EClassId> &fun_roots) {
   vector<EClassId> region_roots = find_all_region_roots(g, fun_roots);
 
+  if (region_roots.empty()) {
+    return {};
+  }
+
+  // Select a random subset of regions based on percent_regions BEFORE preparing them
+  // Calculate the number of regions to run on (rounded up)
+  size_t num_regions_to_run = static_cast<size_t>(
+    std::ceil(region_roots.size() * g_config.percent_regions / 100.0));
+  if (num_regions_to_run == 0) {
+    num_regions_to_run = 1; // Always run at least one region if there are any
+  }
+
+  // Create indices and shuffle them to get random selection
+  vector<size_t> region_indices(region_roots.size());
+  for (size_t i = 0; i < region_roots.size(); ++i) {
+    region_indices[i] = i;
+  }
+  
+  // Only shuffle and subset if we're not running all regions
+  if (num_regions_to_run < region_roots.size()) {
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::shuffle(region_indices.begin(), region_indices.end(), rng);
+    region_indices.resize(num_regions_to_run);
+  }
+
   vector<vector<Cost>> statewalk_cost = compute_statewalk_cost(g);
 
-  vector<ExtractRegionTiming> timings(region_roots.size());
-  if (region_roots.empty()) {
-    return timings;
-  }
+  // timings only contains entries for the regions we are actually measuring
+  vector<ExtractRegionTiming> timings(region_indices.size());
 
   struct PreparedRegion {
     EGraph egraph;
     EClassId root;
-    size_t index;
+    size_t timings_index; // index into the timings vector
     vector<vector<Cost>> statewalk_cost;
   };
 
   vector<PreparedRegion> prepared_regions;
-  prepared_regions.reserve(region_roots.size());
+  prepared_regions.reserve(region_indices.size());
 
-  for (size_t idx = 0; idx < region_roots.size(); ++idx) {
-    auto regionalized = construct_regionalized_egraph(g, region_roots[idx]);
+  for (size_t timings_idx = 0; timings_idx < region_indices.size(); ++timings_idx) {
+    size_t region_idx = region_indices[timings_idx];
+    auto regionalized = construct_regionalized_egraph(g, region_roots[region_idx]);
     PreparedRegion prepared{};
     prepared.egraph = std::move(regionalized.first);
     prepared.root = regionalized.second.first;
-    prepared.index = idx;
+    prepared.timings_index = timings_idx;
 
     const EGraphMapping &gr2g = regionalized.second.second;
     prepared.statewalk_cost = project_statewalk_cost(gr2g, statewalk_cost);
 
-    ExtractRegionTiming sample;
+    ExtractRegionTiming sample{};
 
     // compute egraph size: number of nodes in the regionalized egraph
     size_t egraph_size = 0;
@@ -149,35 +174,12 @@ compute_extract_region_timings(const EGraph &g,
       egraph_size += eclass.enodes.size();
     }
 
-
     sample.egraph_size = egraph_size;
     compute_tiger_metrics(sample, prepared.egraph, prepared.root,
                           prepared.statewalk_cost);
-    timings[idx] = sample;
+    timings[timings_idx] = sample;
 
     prepared_regions.push_back(std::move(prepared));
-  }
-
-  // Select a random subset of regions based on percent_regions
-  // Calculate the number of regions to run ILP on (rounded up)
-  size_t num_regions_to_run = static_cast<size_t>(
-    std::ceil(prepared_regions.size() * g_config.percent_regions / 100.0));
-  if (num_regions_to_run == 0 && !prepared_regions.empty()) {
-    num_regions_to_run = 1; // Always run at least one region if there are any
-  }
-
-  // Create indices and shuffle them to get random selection
-  vector<size_t> region_indices(prepared_regions.size());
-  for (size_t i = 0; i < prepared_regions.size(); ++i) {
-    region_indices[i] = i;
-  }
-  
-  // Only shuffle and subset if we're not running all regions
-  if (num_regions_to_run < prepared_regions.size()) {
-    std::random_device rd;
-    std::mt19937 rng(rd());
-    std::shuffle(region_indices.begin(), region_indices.end(), rng);
-    region_indices.resize(num_regions_to_run);
   }
 
   unsigned int hardware_threads = std::thread::hardware_concurrency();
@@ -189,25 +191,24 @@ compute_extract_region_timings(const EGraph &g,
   }
 
   
-  size_t worker_count = min<size_t>(usable_threads, region_indices.size());
+  size_t worker_count = min<size_t>(usable_threads, prepared_regions.size());
   if (worker_count == 0) {
     worker_count = 1;
   }
 
   std::atomic<size_t> next_index{0};
 
-  cerr << "Running ILP timing on " << region_indices.size() << "/" << prepared_regions.size() << " regions, one dot per region:";
+  cerr << "Running ILP timing on " << region_indices.size() << "/" << region_roots.size() << " regions, one dot per region:";
   auto worker = [&]() {
     while (true) {
       size_t work_idx = next_index.fetch_add(1, std::memory_order_relaxed);
-      if (work_idx >= region_indices.size()) {
+      if (work_idx >= prepared_regions.size()) {
         break;
       }
       cerr << ".";
       cerr.flush();
-      size_t idx = region_indices[work_idx];
-      const PreparedRegion &prepared = prepared_regions[idx];
-      ExtractRegionTiming &sample = timings[prepared.index];
+      const PreparedRegion &prepared = prepared_regions[work_idx];
+      ExtractRegionTiming &sample = timings[prepared.timings_index];
       compute_ilp_metrics(sample, prepared.egraph, prepared.root,
           prepared.statewalk_cost);
     }

--- a/dag_in_context/src/tiger/time_ilp.cpp
+++ b/dag_in_context/src/tiger/time_ilp.cpp
@@ -3,14 +3,17 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <optional>
+#include <random>
 #include <thread>
 #include <unordered_set>
 #include <iostream>
 
 #include "greedy.h"
 #include "ilp.h"
+#include "main.h"
 #include "regionalize.h"
 #include "tiger.h"
 
@@ -155,6 +158,28 @@ compute_extract_region_timings(const EGraph &g,
     prepared_regions.push_back(std::move(prepared));
   }
 
+  // Select a random subset of regions based on percent_regions
+  // Calculate the number of regions to run ILP on (rounded up)
+  size_t num_regions_to_run = static_cast<size_t>(
+    std::ceil(prepared_regions.size() * g_config.percent_regions / 100.0));
+  if (num_regions_to_run == 0 && !prepared_regions.empty()) {
+    num_regions_to_run = 1; // Always run at least one region if there are any
+  }
+
+  // Create indices and shuffle them to get random selection
+  vector<size_t> region_indices(prepared_regions.size());
+  for (size_t i = 0; i < prepared_regions.size(); ++i) {
+    region_indices[i] = i;
+  }
+  
+  // Only shuffle and subset if we're not running all regions
+  if (num_regions_to_run < prepared_regions.size()) {
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::shuffle(region_indices.begin(), region_indices.end(), rng);
+    region_indices.resize(num_regions_to_run);
+  }
+
   unsigned int hardware_threads = std::thread::hardware_concurrency();
   unsigned int usable_threads = hardware_threads == 0 ? 1 : hardware_threads;
 
@@ -164,22 +189,23 @@ compute_extract_region_timings(const EGraph &g,
   }
 
   
-  size_t worker_count = min<size_t>(usable_threads, prepared_regions.size());
+  size_t worker_count = min<size_t>(usable_threads, region_indices.size());
   if (worker_count == 0) {
     worker_count = 1;
   }
 
   std::atomic<size_t> next_index{0};
 
-  cerr << "Running ILP timing on regions, one dot per region:";
+  cerr << "Running ILP timing on " << region_indices.size() << "/" << prepared_regions.size() << " regions, one dot per region:";
   auto worker = [&]() {
     while (true) {
-      size_t idx = next_index.fetch_add(1, std::memory_order_relaxed);
-      if (idx >= prepared_regions.size()) {
+      size_t work_idx = next_index.fetch_add(1, std::memory_order_relaxed);
+      if (work_idx >= region_indices.size()) {
         break;
       }
       cerr << ".";
       cerr.flush();
+      size_t idx = region_indices[work_idx];
       const PreparedRegion &prepared = prepared_regions[idx];
       ExtractRegionTiming &sample = timings[prepared.index];
       compute_ilp_metrics(sample, prepared.egraph, prepared.root,

--- a/infra/graph_helpers.py
+++ b/infra/graph_helpers.py
@@ -56,8 +56,13 @@ SHAPE_MAP = {
   "eggcc-ablation-O0-O0": "o",
   "eggcc-ablation-O3-O0": "o",
   "eggcc-ablation-O3-O3": "o",
+  "eggcc-tiger-WL-O0-O0": "o",
   "eggcc-tiger-O0-O0": "o",
-  'eggcc-tiger-ILP-O0-O0': "^",
+  "eggcc-tiger-ILP-O0-O0": "^",
+  "eggcc-tiger-ILP-CBC-O0-O0": "^",
+  "eggcc-tiger-ILP-NOMIN-O0-O0": "^",
+  "eggcc-tiger-ILP-WITHCTX-O0-O0": "^",
+  "eggcc-WITHCTX-O0-O0": "o",
 }
 
 EXTRACTION_INSET_BOUNDS = (0.4, 0.3, 0.38 * 1.5, 0.35 * 1.5) # x y width height

--- a/infra/graphs.py
+++ b/infra/graphs.py
@@ -819,7 +819,11 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
   benchmark_suites = [f for f in os.listdir(benchmark_suite_folder) if os.path.isdir(os.path.join(benchmark_suite_folder, f))]
   benchmark_suites = [os.path.join(benchmark_suite_folder, f) for f in benchmark_suites]
 
-  make_extraction_time_cdf(data, f'{graphs_folder}/extraction-time-cdf.pdf', use_log_x=True, use_exp_y=False)
+  # Only generate ILP-comparison graphs if Gurobi treatments were run
+  if profile.USE_GUROBI:
+    make_extraction_time_cdf(data, f'{graphs_folder}/extraction-time-cdf.pdf', use_log_x=True, use_exp_y=False)
+  else:
+    print("Skipping extraction-time-cdf graph (requires Gurobi treatments)")
 
   # if UNSAFE_TREATMENTS is true and TREATMENTS isn't a subset of treatments, exit
   if profile.UNSAFE_TREATMENTS and not set(NECESSARY_MODES).issubset(set(profile.treatments)):
@@ -828,9 +832,12 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
 
   make_jitter(data, 4, f'{graphs_folder}/jitter-plot-max-4.png')
 
-  make_region_extract_plot(data, f'{graphs_folder}/egraph-size-vs-tiger-time.pdf', plot_ilp=False)
-  make_region_extract_plot(data, f'{graphs_folder}/egraph-size-vs-ILP-time.pdf', plot_ilp=True)
-  make_extraction_time_histogram(data, f'{graphs_folder}/extraction-time-histogram.pdf')
+  if profile.USE_GUROBI:
+    make_region_extract_plot(data, f'{graphs_folder}/egraph-size-vs-tiger-time.pdf', plot_ilp=False)
+    make_region_extract_plot(data, f'{graphs_folder}/egraph-size-vs-ILP-time.pdf', plot_ilp=True)
+    make_extraction_time_histogram(data, f'{graphs_folder}/extraction-time-histogram.pdf')
+  else:
+    print("Skipping region extract plots and extraction-time-histogram (requires Gurobi treatments)")
   #make_ilp_encoding_scatter(
   #  profile,
   #  f'{graphs_folder}/ilp-encoding-vs-egraph-size.pdf',
@@ -852,92 +859,96 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
   ilp_gurobi = StatewalkTreatment(runtime="ilp_gurobi", liveness_on=False, satellite_on=False)
   ilp_cbc = StatewalkTreatment(runtime="ilp_cbc", liveness_on=False, satellite_on=False)
 
-  make_statewalk_width_histogram(
-    data,
-    f'{graphs_folder}/statewalk-width-histogram-with-liveness.pdf',
-    tiger_optimizations_on,
-    is_average=False,
-    max_width=statewalk_histogram_max_width,
-  )
-  make_statewalk_width_histogram(
-    data,
-    f'{graphs_folder}/statewalk-width-histogram.pdf',
-    tiger_optimizations_off,
-    is_average=False,
-    max_width=statewalk_histogram_max_width,
-  )
-  print_top_statewalk_width_samples(
-    data,
-    tiger_optimizations_off,
-    is_average=False,
-    max_width=statewalk_histogram_max_width,
-  )
+  # All statewalk and ILP-related graphs require eggcc-tiger-ILP-COMPARISON data
+  if profile.USE_GUROBI:
+    make_statewalk_width_histogram(
+      data,
+      f'{graphs_folder}/statewalk-width-histogram-with-liveness.pdf',
+      tiger_optimizations_on,
+      is_average=False,
+      max_width=statewalk_histogram_max_width,
+    )
+    make_statewalk_width_histogram(
+      data,
+      f'{graphs_folder}/statewalk-width-histogram.pdf',
+      tiger_optimizations_off,
+      is_average=False,
+      max_width=statewalk_histogram_max_width,
+    )
+    print_top_statewalk_width_samples(
+      data,
+      tiger_optimizations_off,
+      is_average=False,
+      max_width=statewalk_histogram_max_width,
+    )
 
-  make_statewalk_width_performance_scatter_multi(
-    data,
-    f'{graphs_folder}/statewalk-width-vs-tiger-time.pdf',
-    [tiger_optimizations_off, tiger_optimizations_on],
-    is_average=False,
-    scale_by_egraph_size=False,
-    y_break=(0.6, 4.5),
-    y_break_runtimes={'tiger'},
-  )
-  make_statewalk_width_performance_scatter_multi(
-    data,
-    f'{graphs_folder}/statewalk-width-vs-ilp-time.pdf',
-    [ilp_cbc, ilp_gurobi],
-    is_average=False,
-    scale_by_egraph_size=False,
-  )
-  
-  make_egraph_size_vs_statewalk_width_heatmap(
-    data,
-    f'{graphs_folder}/heatmap-tiger-time-with-egraph-size-vs-statewalk-width-no-raytrace.pdf',
-    tiger_optimizations_off,
-    is_average=False,
-    min_width=1,
-  )
-  make_egraph_size_vs_statewalk_width_heatmap(
-    data,
-    f'{graphs_folder}/heatmap-ilp-time-with-egraph-size-vs-statewalk-width-no-raytrace.pdf',
-    ilp_gurobi,
-    is_average=False,
-    min_width=1,
-  )
-  make_egraph_size_vs_statewalk_width_heatmap(
-    data,
-    f'{graphs_folder}/heatmap-tiger-time-with-egraph-size-vs-statewalk-width-no-raytrace-max6000.pdf',
-    tiger_optimizations_off,
-    is_average=False,
-    min_width=1,
-    max_width=6000,
-  )
-  make_egraph_size_vs_statewalk_width_heatmap(
-    data,
-    f'{graphs_folder}/heatmap-ilp-time-with-egraph-size-vs-statewalk-width-no-raytrace-max6000.pdf',
-    ilp_gurobi,
-    is_average=False,
-    min_width=1,
-    max_width=6000,
-  )
-  make_ilp_encoding_scatter(
-    data,
-    f'{graphs_folder}/ilp-encoding-size-scatter.pdf',
-  )
-  make_ilp_encoding_time_scatter(
-    data,
-    f'{graphs_folder}/ilp-encoding-size-vs-solve-time.pdf',
-  )
-  make_cbc_encoding_time_scatter(
-    data,
-    f'{graphs_folder}/ilp-encoding-size-vs-cbc-solve-time.pdf',
-  )
-  make_peggy_comparison_graph(
-    data,
-    "./infra/peggy_data.csv",
-    f'{graphs_folder}/eggcc-extraction-time-ratio.pdf',
-    f'{graphs_folder}/peggy-extraction-time-ratio.pdf'
-  )
+    make_statewalk_width_performance_scatter_multi(
+      data,
+      f'{graphs_folder}/statewalk-width-vs-tiger-time.pdf',
+      [tiger_optimizations_off, tiger_optimizations_on],
+      is_average=False,
+      scale_by_egraph_size=False,
+      y_break=(0.6, 4.5),
+      y_break_runtimes={'tiger'},
+    )
+    make_statewalk_width_performance_scatter_multi(
+      data,
+      f'{graphs_folder}/statewalk-width-vs-ilp-time.pdf',
+      [ilp_cbc, ilp_gurobi],
+      is_average=False,
+      scale_by_egraph_size=False,
+    )
+    
+    make_egraph_size_vs_statewalk_width_heatmap(
+      data,
+      f'{graphs_folder}/heatmap-tiger-time-with-egraph-size-vs-statewalk-width-no-raytrace.pdf',
+      tiger_optimizations_off,
+      is_average=False,
+      min_width=1,
+    )
+    make_egraph_size_vs_statewalk_width_heatmap(
+      data,
+      f'{graphs_folder}/heatmap-ilp-time-with-egraph-size-vs-statewalk-width-no-raytrace.pdf',
+      ilp_gurobi,
+      is_average=False,
+      min_width=1,
+    )
+    make_egraph_size_vs_statewalk_width_heatmap(
+      data,
+      f'{graphs_folder}/heatmap-tiger-time-with-egraph-size-vs-statewalk-width-no-raytrace-max6000.pdf',
+      tiger_optimizations_off,
+      is_average=False,
+      min_width=1,
+      max_width=6000,
+    )
+    make_egraph_size_vs_statewalk_width_heatmap(
+      data,
+      f'{graphs_folder}/heatmap-ilp-time-with-egraph-size-vs-statewalk-width-no-raytrace-max6000.pdf',
+      ilp_gurobi,
+      is_average=False,
+      min_width=1,
+      max_width=6000,
+    )
+    make_ilp_encoding_scatter(
+      data,
+      f'{graphs_folder}/ilp-encoding-size-scatter.pdf',
+    )
+    make_ilp_encoding_time_scatter(
+      data,
+      f'{graphs_folder}/ilp-encoding-size-vs-solve-time.pdf',
+    )
+    make_cbc_encoding_time_scatter(
+      data,
+      f'{graphs_folder}/ilp-encoding-size-vs-cbc-solve-time.pdf',
+    )
+    make_peggy_comparison_graph(
+      data,
+      "./infra/peggy_data.csv",
+      f'{graphs_folder}/eggcc-extraction-time-ratio.pdf',
+      f'{graphs_folder}/peggy-extraction-time-ratio.pdf'
+    )
+  else:
+    print("Skipping statewalk and ILP-related graphs (requires Gurobi treatments)")
   
   for suite_path in benchmark_suites:
     suite = os.path.basename(suite_path)
@@ -955,6 +966,12 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       width = 6
       height = 5.0
 
+    # Choose treatments based on whether Gurobi is available
+    if profile.USE_GUROBI:
+      chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"]
+    else:
+      chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-CBC-O0-O0", "llvm-O0-O0"]
+
     if suite == "bril":
       benchmarks_under3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") <= 3.0]
       benchmarks_over3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") > 3.0]
@@ -962,7 +979,7 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       make_normalized_chart(
         profile_for_suite,
         f'{graphs_folder}/normalized-binary-perf-chart-under3-{suite}.pdf',
-        ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"],
+        chart_treatments,
         y_max,
         width,
         height + 0.5,
@@ -974,7 +991,7 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       make_normalized_chart(
         profile_for_suite,
         f'{graphs_folder}/normalized-binary-perf-chart-over3-{suite}.pdf',
-        ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"],
+        chart_treatments,
         20.0,
         2,
         height,
@@ -988,7 +1005,7 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       make_normalized_chart(
         profile_for_suite,
         f'{graphs_folder}/normalized-binary-perf-chart-{suite}.pdf',
-        ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"],
+        chart_treatments,
         y_max,
         width,
         height,

--- a/infra/graphs.py
+++ b/infra/graphs.py
@@ -10,8 +10,8 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
 import numpy as np
 import sys
 import os
-import profile
 
+from profile import NightlyConfig
 from graph_helpers import *
 from statewalk_graphs import *
 from extract_time_graph import *
@@ -808,8 +808,7 @@ def make_code_size_vs_compile_and_extraction_time(profile, compile_time_output, 
 
 
 
-def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_folder):
-
+def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_folder, config: NightlyConfig):
   # Read profile.json from nightly/output/data/profile.json
   data = []
   with open(profile_file) as f:
@@ -820,19 +819,14 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
   benchmark_suites = [os.path.join(benchmark_suite_folder, f) for f in benchmark_suites]
 
   # Only generate ILP-comparison graphs if Gurobi treatments were run
-  if profile.USE_GUROBI:
+  if config.use_gurobi:
     make_extraction_time_cdf(data, f'{graphs_folder}/extraction-time-cdf.pdf', use_log_x=True, use_exp_y=False)
   else:
     print("Skipping extraction-time-cdf graph (requires Gurobi treatments)")
 
-  # if UNSAFE_TREATMENTS is true and TREATMENTS isn't a subset of treatments, exit
-  if profile.UNSAFE_TREATMENTS and not set(NECESSARY_MODES).issubset(set(profile.treatments)):
-      print("Skipping graphing: NECESSARY_MODES is true and GRAPH_RUN_MODES is not a subset of treatments")
-      sys.exit(0)
-
   make_jitter(data, 4, f'{graphs_folder}/jitter-plot-max-4.png')
 
-  if profile.USE_GUROBI:
+  if config.use_gurobi:
     make_region_extract_plot(data, f'{graphs_folder}/egraph-size-vs-tiger-time.pdf', plot_ilp=False)
     make_region_extract_plot(data, f'{graphs_folder}/egraph-size-vs-ILP-time.pdf', plot_ilp=True)
     make_extraction_time_histogram(data, f'{graphs_folder}/extraction-time-histogram.pdf')
@@ -860,7 +854,7 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
   ilp_cbc = StatewalkTreatment(runtime="ilp_cbc", liveness_on=False, satellite_on=False)
 
   # All statewalk and ILP-related graphs require eggcc-tiger-ILP-COMPARISON data
-  if profile.USE_GUROBI:
+  if config.use_gurobi:
     make_statewalk_width_histogram(
       data,
       f'{graphs_folder}/statewalk-width-histogram-with-liveness.pdf',
@@ -967,7 +961,7 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       height = 5.0
 
     # Choose treatments based on whether Gurobi is available
-    if profile.USE_GUROBI:
+    if config.use_gurobi:
       chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"]
     else:
       chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-CBC-O0-O0", "llvm-O0-O0"]
@@ -1027,12 +1021,16 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
     json.dump(graph_names, f)
 
 if __name__ == '__main__':
-  # parse two arguments: the output folder and the profile.json file
-  if len(sys.argv) != 5:
-      print("Usage: python graphs.py <nightly_output_folder> <graphs_folder> <profile.json> <benchmark_suite_folder>")
+  # parse arguments: the output folder, graphs folder, profile.json file, and benchmark suite folder
+  # optionally --paper or --use-gurobi flags
+  if len(sys.argv) < 5:
+      print("Usage: python graphs.py <nightly_output_folder> <graphs_folder> <profile.json> <benchmark_suite_folder> [--paper] [--use-gurobi]")
       sys.exit(1)
 
+  paper_mode = "--paper" in sys.argv
+  use_gurobi = "--use-gurobi" in sys.argv or paper_mode
+  config = NightlyConfig(paper_mode=paper_mode, use_gurobi=use_gurobi)
   
-  make_graphs(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+  make_graphs(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], config)
 
 

--- a/infra/graphs.py
+++ b/infra/graphs.py
@@ -960,11 +960,12 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       width = 6
       height = 5.0
 
-    # Choose treatments based on whether Gurobi is available
-    if config.use_gurobi:
-      chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"]
-    else:
-      chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-CBC-O0-O0", "llvm-O0-O0"]
+    # Only generate normalized charts with ILP when Gurobi is available
+    if not config.use_gurobi:
+      print(f"Skipping normalized charts for {suite} (requires Gurobi treatments)")
+      continue
+
+    chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"]
 
     if suite == "bril":
       benchmarks_under3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") <= 3.0]
@@ -1019,18 +1020,3 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
       graph_names.append(filename)
   with open(f'{output_folder}/graphs.json', 'w') as f:
     json.dump(graph_names, f)
-
-if __name__ == '__main__':
-  # parse arguments: the output folder, graphs folder, profile.json file, and benchmark suite folder
-  # optionally --paper or --use-gurobi flags
-  if len(sys.argv) < 5:
-      print("Usage: python graphs.py <nightly_output_folder> <graphs_folder> <profile.json> <benchmark_suite_folder> [--paper] [--use-gurobi]")
-      sys.exit(1)
-
-  paper_mode = "--paper" in sys.argv
-  use_gurobi = "--use-gurobi" in sys.argv or paper_mode
-  config = NightlyConfig(paper_mode=paper_mode, use_gurobi=use_gurobi)
-  
-  make_graphs(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], config)
-
-

--- a/infra/graphs.py
+++ b/infra/graphs.py
@@ -950,8 +950,11 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
   else:
     for suite_path in benchmark_suites:
       suite = os.path.basename(suite_path)
-      suite_benchmarks = benchmarks_in_folder(suite_path)
-      profile_for_suite = [b for b in data if b['benchmark'] in suite_benchmarks]
+      suite_benchmarks_all = benchmarks_in_folder(suite_path)
+      profile_for_suite = [b for b in data if b['benchmark'] in suite_benchmarks_all]
+      # Filter suite_benchmarks to only include benchmarks that have profile data
+      profiled_benchmarks = set(b['benchmark'] for b in profile_for_suite)
+      suite_benchmarks = [b for b in suite_benchmarks_all if b in profiled_benchmarks]
 
       width = 10
       height = 4

--- a/infra/graphs.py
+++ b/infra/graphs.py
@@ -944,73 +944,75 @@ def make_graphs(output_folder, graphs_folder, profile_file, benchmark_suite_fold
   else:
     print("Skipping statewalk and ILP-related graphs (requires Gurobi treatments)")
   
-  for suite_path in benchmark_suites:
-    suite = os.path.basename(suite_path)
-    suite_benchmarks = benchmarks_in_folder(suite_path)
-    profile_for_suite = [b for b in data if b['benchmark'] in suite_benchmarks]
+  # Normalized charts require Gurobi treatments (eggcc-tiger-ILP-O0-O0)
+  if not config.use_gurobi:
+    print("Skipping normalized charts for all suites (requires Gurobi treatments)")
+  else:
+    for suite_path in benchmark_suites:
+      suite = os.path.basename(suite_path)
+      suite_benchmarks = benchmarks_in_folder(suite_path)
+      profile_for_suite = [b for b in data if b['benchmark'] in suite_benchmarks]
 
-    width = 10
-    height = 4
-    y_max = 3.5
-    xanchor = 0.02
-    yanchor = 0.98
+      width = 10
+      height = 4
+      y_max = 3.5
+      xanchor = 0.02
+      yanchor = 0.98
 
-    if suite == "polybench":
-      y_max = 10.0
-      width = 6
-      height = 5.0
+      if suite == "polybench":
+        y_max = 10.0
+        width = 6
+        height = 5.0
 
-    # Only generate normalized charts with ILP when Gurobi is available
-    if not config.use_gurobi:
-      print(f"Skipping normalized charts for {suite} (requires Gurobi treatments)")
-      continue
+      chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"]
 
-    chart_treatments = ["eggcc-tiger-O0-O0", "eggcc-tiger-ILP-O0-O0", "llvm-O0-O0"]
+      if suite == "bril":
+        benchmarks_under3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") <= 3.0]
+        benchmarks_over3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") > 3.0]
 
-    if suite == "bril":
-      benchmarks_under3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") <= 3.0]
-      benchmarks_over3 = [b for b in suite_benchmarks if normalized(data, b, "eggcc-tiger-O0-O0") > 3.0]
+        make_normalized_chart(
+          profile_for_suite,
+          f'{graphs_folder}/normalized-binary-perf-chart-under3-{suite}.pdf',
+          chart_treatments,
+          y_max,
+          width,
+          height + 0.5,
+          xanchor,
+          yanchor,
+          benchmarks_under3,
+          legend=True,
+        )
+        make_normalized_chart(
+          profile_for_suite,
+          f'{graphs_folder}/normalized-binary-perf-chart-over3-{suite}.pdf',
+          chart_treatments,
+          20.0,
+          2,
+          height,
+          xanchor,
+          yanchor,
+          benchmarks_over3,
+          legend=False,
+        )
 
-      make_normalized_chart(
-        profile_for_suite,
-        f'{graphs_folder}/normalized-binary-perf-chart-under3-{suite}.pdf',
-        chart_treatments,
-        y_max,
-        width,
-        height + 0.5,
-        xanchor,
-        yanchor,
-        benchmarks_under3,
-        legend=True,
-      )
-      make_normalized_chart(
-        profile_for_suite,
-        f'{graphs_folder}/normalized-binary-perf-chart-over3-{suite}.pdf',
-        chart_treatments,
-        20.0,
-        2,
-        height,
-        xanchor,
-        yanchor,
-        benchmarks_over3,
-        legend=False,
-      )
+      else:
+        make_normalized_chart(
+          profile_for_suite,
+          f'{graphs_folder}/normalized-binary-perf-chart-{suite}.pdf',
+          chart_treatments,
+          y_max,
+          width,
+          height,
+          xanchor,
+          yanchor,
+          None,
+          legend=True,
+        )
 
-    else:
-      make_normalized_chart(
-        profile_for_suite,
-        f'{graphs_folder}/normalized-binary-perf-chart-{suite}.pdf',
-        chart_treatments,
-        y_max,
-        width,
-        height,
-        xanchor,
-        yanchor,
-        None,
-        legend=True,
-      )
-
-  make_macros(data, benchmark_suites, f'{graphs_folder}/nightlymacros.tex')
+  if config.use_gurobi:
+    make_macros(data, benchmark_suites, f'{graphs_folder}/nightlymacros.tex')
+  else:
+    print("Skipping macro generation (requires Gurobi treatments)")
 
   # make json list of graph names and put in in output
   graph_names = []

--- a/infra/localnightly.sh
+++ b/infra/localnightly.sh
@@ -1,14 +1,15 @@
 # Usage example:
 # bash infra/localnightly.sh benchmarks/passing/bril/core --parallel
 # First argument: path to benchmark or benchmark folder to run.
-# Second argument: optional flag to run timing measurements in parallel (innacurate).
-
-# optionally, the first argument can be --update to skip profiling and only update the front end visualizations
+# Additional arguments: optional flags like --parallel, --update, --paper, etc.
+#
+# This script runs nightly.sh in local mode (skips rustup update and tokei install)
+# and then serves the results on http://localhost:8002
 
 # -x: before executing each command, print it
 # -e: exit immediately upon first error
 set -x -e
 
-# pass arguments to nightly.sh
-LOCAL=1 bash infra/nightly.sh "$@"
+# pass arguments to nightly.sh with --local flag
+bash infra/nightly.sh --local "$@"
 cd nightly/output && python3 -m http.server 8002

--- a/infra/macros.py
+++ b/infra/macros.py
@@ -53,13 +53,14 @@ def make_macros(profile, benchmark_suites, output_file):
     )
 
     if "polybench" not in suite_region_counts:
-      raise ValueError("No polybench suite benchmarks found when computing regionalized e-graphs per benchmark")
-    out.write(
-      format_latex_macro(
-        "AvgPolybenchRegionalizedEgraphsPerBenchmark",
-        f"{round(mean(suite_region_counts['polybench']))}",
+      print("WARNING: No polybench suite benchmarks found when computing regionalized e-graphs per benchmark")
+    else:
+      out.write(
+        format_latex_macro(
+          "AvgPolybenchRegionalizedEgraphsPerBenchmark",
+          f"{round(mean(suite_region_counts['polybench']))}",
+        )
       )
-    )
 
     # report number of benchmarks in each benchmark suite
     for suite in benchmark_suites:
@@ -158,32 +159,35 @@ def make_macros(profile, benchmark_suites, output_file):
       )
     )
 
-    raytrace_row = get_row(profile, "raytrace", "eggcc-tiger-ILP-COMPARISON")
-    raytrace_timings = raytrace_row["extractRegionTimings"]
-    out.write(
-      format_latex_macro("NumRaytraceRegionalizedEgraphs", len(raytrace_timings))
-    )
-    out.write(
-      format_latex_macro(
-        "MaxRaytraceRegionalizedEgraphTerms",
-        f"{max(sample["egraph_size"] for sample in raytrace_timings):.4f}",
+    if "raytrace" in benchmarks:
+      raytrace_row = get_row(profile, "raytrace", "eggcc-tiger-ILP-COMPARISON")
+      raytrace_timings = raytrace_row["extractRegionTimings"]
+      out.write(
+        format_latex_macro("NumRaytraceRegionalizedEgraphs", len(raytrace_timings))
       )
-    )
-    out.write(
-      format_latex_macro(
-        "MaxRaytraceTigerExtractionTimeSecs",
-        f"{max(
-          duration_to_seconds(sample['extract_time_liveon_satelliteon'])
-          for sample in raytrace_timings
-        ):.6f}",
+      out.write(
+        format_latex_macro(
+          "MaxRaytraceRegionalizedEgraphTerms",
+          f"{max(sample["egraph_size"] for sample in raytrace_timings):.4f}",
+        )
       )
-    )
-    out.write(
-      format_latex_macro(
-        "NumRaytraceILPRegionalizedEgraphTimeouts",
-        sum(1 for sample in raytrace_timings if sample["ilp_timed_out"]),
+      out.write(
+        format_latex_macro(
+          "MaxRaytraceTigerExtractionTimeSecs",
+          f"{max(
+            duration_to_seconds(sample['extract_time_liveon_satelliteon'])
+            for sample in raytrace_timings
+          ):.6f}",
+        )
       )
-    )
+      out.write(
+        format_latex_macro(
+          "NumRaytraceILPRegionalizedEgraphTimeouts",
+          sum(1 for sample in raytrace_timings if sample["ilp_timed_out"]),
+        )
+      )
+    else:
+      print("WARNING: No raytrace benchmark found; skipping raytrace macro generation")
 
     total_regionalized_egraphs = len(region_points)
     if total_regionalized_egraphs == 0:

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -3,6 +3,7 @@
 <html>
 
 <head>
+  <link rel="icon" href="data:,">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
   <script src="./Plugin.Errorbars.js"></script>
   <script src="chart.js"></script>

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -231,12 +231,14 @@ async function buildNightlyDropdown(element, previousRuns, initialIdx) {
 async function refreshLatexMacros(tableMacros) {
   const latexMacrosTextArea = document.getElementById("latex-macros-text");
   let latexMacros = "";
-  
+
   // Check if file exists first using HEAD request to avoid 404 error in console
-  const headResponse = await fetch("paper/nightlymacros.tex", { method: "HEAD" });
+  const headResponse = await fetch("paper/nightlymacros.tex", {
+    method: "HEAD",
+  });
   if (!headResponse.ok) {
     console.info(
-      "nightlymacros.tex not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS."
+      "nightlymacros.tex not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS.",
     );
   } else {
     try {
@@ -263,7 +265,7 @@ function addGraphs() {
     .then((headResponse) => {
       if (!headResponse.ok) {
         console.info(
-          "graphs.json not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS."
+          "graphs.json not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS.",
         );
         return null;
       }
@@ -275,7 +277,7 @@ function addGraphs() {
     })
     .then((data) => {
       if (!data) return;
-      
+
       const sortedPlots = data.slice().sort((a, b) => a.localeCompare(b));
 
       const list = document.createElement("ul");

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -231,17 +231,20 @@ async function buildNightlyDropdown(element, previousRuns, initialIdx) {
 async function refreshLatexMacros(tableMacros) {
   const latexMacrosTextArea = document.getElementById("latex-macros-text");
   let latexMacros = "";
-  try {
-    const response = await fetch("paper/nightlymacros.tex");
-    if (!response.ok) {
-      throw new Error(
-        `Failed to load nightlymacros.tex: ${response.status}. This is expected if you are running with UNSAFE_TREATMENTS.`,
-      );
+  
+  // Check if file exists first using HEAD request to avoid 404 error in console
+  const headResponse = await fetch("paper/nightlymacros.tex", { method: "HEAD" });
+  if (!headResponse.ok) {
+    console.info(
+      "nightlymacros.tex not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS."
+    );
+  } else {
+    try {
+      const response = await fetch("paper/nightlymacros.tex");
+      latexMacros = await response.text();
+    } catch (error) {
+      console.error("Could not load nightlymacros.tex:", error);
     }
-    latexMacros = await response.text();
-  } catch (error) {
-    console.error(error);
-    addWarning(error);
   }
   latexMacrosTextArea.value = tableMacros + latexMacros;
 }
@@ -255,16 +258,24 @@ function addGraphs() {
 
   container.innerHTML = "";
 
-  fetch("graphs.json")
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(
-          `Failed to load graphs.json: ${response.status}. Expected if you have UNSAFE_TREATMENTS enabled.`,
+  // Check if file exists first using HEAD request to avoid 404 error in console
+  fetch("graphs.json", { method: "HEAD" })
+    .then((headResponse) => {
+      if (!headResponse.ok) {
+        console.info(
+          "graphs.json not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS."
         );
+        return null;
       }
+      return fetch("graphs.json");
+    })
+    .then((response) => {
+      if (!response) return null;
       return response.json();
     })
     .then((data) => {
+      if (!data) return;
+      
       const sortedPlots = data.slice().sort((a, b) => a.localeCompare(b));
 
       const list = document.createElement("ul");
@@ -291,8 +302,7 @@ function addGraphs() {
       container.appendChild(list);
     })
     .catch((error) => {
-      console.error(error);
-      addWarning(error);
+      console.info("Could not load graphs.json:", error);
     });
 }
 

--- a/infra/nightly-resources/index.js
+++ b/infra/nightly-resources/index.js
@@ -233,20 +233,24 @@ async function refreshLatexMacros(tableMacros) {
   let latexMacros = "";
 
   // Check if file exists first using HEAD request to avoid 404 error in console
-  const headResponse = await fetch("paper/nightlymacros.tex", {
-    method: "HEAD",
-  });
-  if (!headResponse.ok) {
-    console.info(
-      "nightlymacros.tex not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS.",
-    );
-  } else {
-    try {
-      const response = await fetch("paper/nightlymacros.tex");
-      latexMacros = await response.text();
-    } catch (error) {
-      console.error("Could not load nightlymacros.tex:", error);
+  try {
+    const headResponse = await fetch("paper/nightlymacros.tex", {
+      method: "HEAD",
+    });
+    if (!headResponse.ok) {
+      console.info(
+        "nightlymacros.tex not found. This is expected if running without Gurobi (--use-gurobi) or with UNSAFE_TREATMENTS.",
+      );
+    } else {
+      try {
+        const response = await fetch("paper/nightlymacros.tex");
+        latexMacros = await response.text();
+      } catch (error) {
+        console.error("Could not load nightlymacros.tex:", error);
+      }
     }
+  } catch (error) {
+    console.info("Could not check nightlymacros.tex:", error);
   }
   latexMacrosTextArea.value = tableMacros + latexMacros;
 }

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Runs profile.py, graphs.py, and generate_line_counts.py in sequence to produce the data and plots for the nightly paper.
+Moves the html over to the output folder, and gzips all JSON and SVG files for upload to the nightly-results server.
+
+Use the --update flag to only update the front end (output folder) without re-running the benchmarking. This is useful for quickly iterating on the HTML/CSS/JS without waiting benchmarking.
+"""
+
+import os
+import sys
+import subprocess
+import shutil
+from pathlib import Path
+
+def run_cmd(cmd, cwd=None):
+    """Run a command and exit on failure."""
+    print(f"+ {cmd}")
+    result = subprocess.run(cmd, shell=True, cwd=cwd)
+    if result.returncode != 0:
+        print(f"Command failed with exit code {result.returncode}")
+        sys.exit(result.returncode)
+
+def main():
+    print("Beginning eggcc nightly script...")
+
+    # Determine directories
+    script_dir = Path(__file__).resolve().parent
+    top_dir = script_dir.parent
+    resource_dir = script_dir / "nightly-resources"
+
+    # Nightly run directories
+    nightly_dir = top_dir / "nightly"
+    output_dir = nightly_dir / "output"
+    paper_dir = output_dir / "paper"
+    data_dir = nightly_dir / "data"
+    output_data_dir = output_dir / "data"
+    llvm_dir = data_dir / "llvm"
+    log_file = output_dir / "log.txt"
+    profile_json = data_dir / "profile.json"
+
+    # Check environment
+    is_local = os.environ.get("LOCAL", "") != ""
+    args = sys.argv[1:]
+    update_only = "--update" in args
+
+    # Make sure we're in the right place
+    os.chdir(script_dir)
+    print(f"Switching to nightly script directory: {script_dir}")
+
+    # Setup rustup and tokei if not local
+    if not is_local:
+        run_cmd("rustup update")
+        run_cmd("cargo install tokei")
+
+    # Clean previous nightly run
+    if update_only:
+        print("Updating front end only (output folder) due to --update flag")
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paper_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        if nightly_dir.exists():
+            shutil.rmtree(nightly_dir)
+        nightly_dir.mkdir(parents=True, exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        llvm_dir.mkdir(parents=True, exist_ok=True)
+        paper_dir.mkdir(parents=True, exist_ok=True)
+
+    os.chdir(top_dir)
+
+    # Run profiler
+    if update_only:
+        print("Skipping profile.py, updating front end")
+    elif is_local:
+        # In local mode, pass all arguments to profile.py
+        args_str = " ".join(f'"{arg}"' for arg in args)
+        run_cmd(f'./infra/profile.py "{data_dir}" {args_str} 2>&1 | tee "{log_file}"')
+    else:
+        os.environ["LLVM_SYS_180_PREFIX"] = "/usr/lib/llvm-18/"
+        run_cmd("make runtime")
+        # Run on all benchmarks in nightly
+        run_cmd(f'./infra/profile.py "{data_dir}" benchmarks/passing 2>&1 | tee "{log_file}"')
+
+    # Generate the plots
+    run_cmd(f'./infra/graphs.py "{output_dir}" "{paper_dir}" "{profile_json}" benchmarks/passing 2>&1 | tee "{log_file}"')
+
+    # Generate latex after running the profiler (depends on profile.json)
+    run_cmd(f'./infra/generate_line_counts.py "{data_dir}" 2>&1 | tee "{log_file}"')
+
+    os.chdir(script_dir)
+
+    # Update HTML index page
+    if resource_dir.exists():
+        for item in resource_dir.iterdir():
+            dest = output_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, dest)
+
+    # Copy data over to output
+    if data_dir.exists():
+        shutil.copytree(data_dir, output_data_dir, dirs_exist_ok=True)
+
+    # Gzip all JSON and SVGs in the nightly dir (only in non-local mode)
+    if not is_local:
+        if profile_json.exists():
+            run_cmd(f'gzip "{profile_json}"')
+        run_cmd(f'find "{output_dir}" -name "*.svg" -exec gzip {{}} +')
+        run_cmd(f'find "{output_dir}" -name "*.ll" -exec gzip {{}} +')
+
+    print("Nightly script completed successfully!")
+
+if __name__ == "__main__":
+    main()

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -139,7 +139,8 @@ def main():
         print("Updating rustup...")
         run_cmd("rustup update")
         print("Installing tokei...")
-        run_cmd("cargo install tokei")
+        # Install tokei v13.0.0 which works with Rust 1.87
+        run_cmd("cargo install tokei --version 13.0.0 --locked")
 
     # Build config - paper mode implies use_gurobi
     use_gurobi = args.paper or args.use_gurobi

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -146,11 +146,6 @@ def main():
     os.chdir(script_dir)
     print(f"Switching to nightly script directory: {script_dir}")
 
-    # Setup rustup and tokei if not local
-    if not is_local:
-        run_cmd("rustup update")
-        run_cmd("cargo install tokei")
-
     # Clean previous nightly run
     if args.update:
         print("Updating front end only (output folder) due to --update flag")

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -3,7 +3,10 @@
 Runs profile.py, graphs.py, and generate_line_counts.py in sequence to produce the data and plots for the nightly paper.
 Moves the html over to the output folder, and gzips all JSON and SVG files for upload to the nightly-results server.
 
-Use the --update flag to only update the front end (output folder) without re-running the benchmarking. This is useful for quickly iterating on the HTML/CSS/JS without waiting benchmarking.
+Use the --update flag to only update the front end (output folder) without re-running the benchmarking.
+Use the --paper flag for production nightly runs (100% regions, Gurobi enabled, many samples).
+Use the --use-gurobi flag to enable Gurobi treatments without full paper mode.
+Use the --parallel flag to run benchmarks in parallel (benchmarking results may not be super trustworthy and have large variance).
 """
 
 import os
@@ -11,6 +14,10 @@ import sys
 import subprocess
 import shutil
 from pathlib import Path
+
+from profile import NightlyConfig, run_profile, get_treatments
+from graphs import make_graphs
+from generate_line_counts import generate_latex
 
 def run_cmd(cmd, cwd=None):
     """Run a command and exit on failure."""
@@ -22,6 +29,17 @@ def run_cmd(cmd, cwd=None):
 
 def main():
     print("Beginning eggcc nightly script...")
+
+    # Parse arguments
+    args = sys.argv[1:]
+    update_only = "--update" in args
+    paper_mode = "--paper" in args
+    use_gurobi_flag = "--use-gurobi" in args
+    parallel = "--parallel" in args
+
+    # Build config - paper mode implies use_gurobi
+    use_gurobi = paper_mode or use_gurobi_flag
+    config = NightlyConfig(paper_mode=paper_mode, use_gurobi=use_gurobi)
 
     # Determine directories
     script_dir = Path(__file__).resolve().parent
@@ -40,8 +58,6 @@ def main():
 
     # Check environment
     is_local = os.environ.get("LOCAL", "") != ""
-    args = sys.argv[1:]
-    update_only = "--update" in args
 
     # Make sure we're in the right place
     os.chdir(script_dir)
@@ -73,21 +89,24 @@ def main():
     # Run profiler
     if update_only:
         print("Skipping profile.py, updating front end")
-    elif is_local:
-        # In local mode, pass all arguments to profile.py
-        args_str = " ".join(f'"{arg}"' for arg in args)
-        run_cmd(f'./infra/profile.py "{data_dir}" {args_str} 2>&1 | tee "{log_file}"')
     else:
-        os.environ["LLVM_SYS_180_PREFIX"] = "/usr/lib/llvm-18/"
-        run_cmd("make runtime")
-        # Run on all benchmarks in nightly
-        run_cmd(f'./infra/profile.py "{data_dir}" benchmarks/passing 2>&1 | tee "{log_file}"')
+        if not is_local:
+            os.environ["LLVM_SYS_180_PREFIX"] = "/usr/lib/llvm-18/"
+            run_cmd("make runtime")
+        
+        # Determine bril directory
+        bril_dir = "benchmarks/passing"
+        
+        print(f"Running profile with data_dir={data_dir}, bril_dir={bril_dir}, parallel={parallel}")
+        run_profile(str(data_dir), bril_dir, config, parallel=parallel)
 
     # Generate the plots
-    run_cmd(f'./infra/graphs.py "{output_dir}" "{paper_dir}" "{profile_json}" benchmarks/passing 2>&1 | tee "{log_file}"')
+    print(f"Generating graphs...")
+    make_graphs(str(output_dir), str(paper_dir), str(profile_json), "benchmarks/passing", config)
 
     # Generate latex after running the profiler (depends on profile.json)
-    run_cmd(f'./infra/generate_line_counts.py "{data_dir}" 2>&1 | tee "{log_file}"')
+    print(f"Generating line counts...")
+    generate_latex(str(data_dir))
 
     os.chdir(script_dir)
 

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -115,10 +115,31 @@ def main():
         action="store_true",
         help="Run benchmarks in parallel (results may have higher variance)"
     )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Local mode: skip rustup update and tokei install"
+    )
     
     args = parser.parse_args()
 
     print("Beginning eggcc nightly script...")
+
+    # Use the flag instead of environment variable
+    is_local = args.local
+
+    # Set up PATH for cargo/rustup (needed before running rustup/cargo commands)
+    home_dir = os.path.expanduser("~")
+    cargo_bin = os.path.join(home_dir, ".cargo", "bin")
+    if cargo_bin not in os.environ.get("PATH", ""):
+        os.environ["PATH"] = f"{cargo_bin}:{os.environ.get('PATH', '')}"
+
+    # Install/update rustup and tokei (skip in local mode)
+    if not is_local:
+        print("Updating rustup...")
+        run_cmd("rustup update")
+        print("Installing tokei...")
+        run_cmd("cargo install tokei")
 
     # Build config - paper mode implies use_gurobi
     use_gurobi = args.paper or args.use_gurobi
@@ -138,9 +159,6 @@ def main():
     llvm_dir = data_dir / "llvm"
     log_file = output_dir / "log.txt"
     profile_json = data_dir / "profile.json"
-
-    # Check environment
-    is_local = os.environ.get("LOCAL", "") != ""
 
     # Make sure we're in the right place
     os.chdir(script_dir)

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -34,7 +34,7 @@ class TeeWriter:
 def run_cmd(cmd, cwd=None):
     """Run a command and exit on failure."""
     print(f"+ {cmd}")
-    result = subprocess.run(cmd, shell=True, cwd=cwd, shell=True)
+    result = subprocess.run(cmd, shell=True, cwd=cwd)
     if result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
         sys.exit(result.returncode)

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -34,7 +34,7 @@ class TeeWriter:
 def run_cmd(cmd, cwd=None):
     """Run a command and exit on failure."""
     print(f"+ {cmd}")
-    result = subprocess.run(cmd, shell=True, cwd=cwd)
+    result = subprocess.run(['bash', '-l', '-c', cmd], cwd=cwd)
     if result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
         sys.exit(result.returncode)

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -2,13 +2,9 @@
 """
 Runs profile.py, graphs.py, and generate_line_counts.py in sequence to produce the data and plots for the nightly paper.
 Moves the html over to the output folder, and gzips all JSON and SVG files for upload to the nightly-results server.
-
-Use the --update flag to only update the front end (output folder) without re-running the benchmarking.
-Use the --paper flag for production nightly runs (100% regions, Gurobi enabled, many samples).
-Use the --use-gurobi flag to enable Gurobi treatments without full paper mode.
-Use the --parallel flag to run benchmarks in parallel (benchmarking results may not be super trustworthy and have large variance).
 """
 
+import argparse
 import os
 import sys
 import subprocess
@@ -28,18 +24,43 @@ def run_cmd(cmd, cwd=None):
         sys.exit(result.returncode)
 
 def main():
+    parser = argparse.ArgumentParser(
+        description="Run eggcc nightly benchmarks and generate reports."
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        nargs="?",
+        default="benchmarks/passing",
+        help="Directory or file containing benchmarks to run (default: benchmarks/passing)"
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Only update the front end (output folder) without re-running benchmarks"
+    )
+    parser.add_argument(
+        "--paper",
+        action="store_true",
+        help="Production mode: 100%% regions, Gurobi enabled, many samples"
+    )
+    parser.add_argument(
+        "--use-gurobi",
+        action="store_true",
+        help="Enable Gurobi treatments without full paper mode"
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run benchmarks in parallel (results may have higher variance)"
+    )
+    
+    args = parser.parse_args()
+
     print("Beginning eggcc nightly script...")
 
-    # Parse arguments
-    args = sys.argv[1:]
-    update_only = "--update" in args
-    paper_mode = "--paper" in args
-    use_gurobi_flag = "--use-gurobi" in args
-    parallel = "--parallel" in args
-
     # Build config - paper mode implies use_gurobi
-    use_gurobi = paper_mode or use_gurobi_flag
-    config = NightlyConfig(paper_mode=paper_mode, use_gurobi=use_gurobi)
+    use_gurobi = args.paper or args.use_gurobi
+    config = NightlyConfig(paper_mode=args.paper, use_gurobi=use_gurobi)
 
     # Determine directories
     script_dir = Path(__file__).resolve().parent
@@ -69,7 +90,7 @@ def main():
         run_cmd("cargo install tokei")
 
     # Clean previous nightly run
-    if update_only:
+    if args.update:
         print("Updating front end only (output folder) due to --update flag")
         if output_dir.exists():
             shutil.rmtree(output_dir)
@@ -87,25 +108,22 @@ def main():
     os.chdir(top_dir)
 
     # Run profiler
-    if update_only:
+    if args.update:
         print("Skipping profile.py, updating front end")
     else:
         if not is_local:
             os.environ["LLVM_SYS_180_PREFIX"] = "/usr/lib/llvm-18/"
             run_cmd("make runtime")
         
-        # Determine bril directory
-        bril_dir = "benchmarks/passing"
-        
-        print(f"Running profile with data_dir={data_dir}, bril_dir={bril_dir}, parallel={parallel}")
-        run_profile(str(data_dir), bril_dir, config, parallel=parallel)
+        print(f"Running profile with data_dir={data_dir}, bril_dir={args.benchmark_dir}, parallel={args.parallel}")
+        run_profile(str(data_dir), args.benchmark_dir, config, parallel=args.parallel)
 
     # Generate the plots
-    print(f"Generating graphs...")
+    print("Generating graphs...")
     make_graphs(str(output_dir), str(paper_dir), str(profile_json), "benchmarks/passing", config)
 
     # Generate latex after running the profiler (depends on profile.json)
-    print(f"Generating line counts...")
+    print("Generating line counts...")
     generate_latex(str(data_dir))
 
     os.chdir(script_dir)

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -11,9 +11,25 @@ import subprocess
 import shutil
 from pathlib import Path
 
-from profile import NightlyConfig, run_profile, get_treatments
+from profile import NightlyConfig, run_profile
 from graphs import make_graphs
 from generate_line_counts import generate_latex
+
+class TeeWriter:
+    """Write to both a file and the original stream."""
+    def __init__(self, file, stream):
+        self.file = file
+        self.stream = stream
+    
+    def write(self, data):
+        self.stream.write(data)
+        self.stream.flush()
+        self.file.write(data)
+        self.file.flush()
+    
+    def flush(self):
+        self.stream.flush()
+        self.file.flush()
 
 def run_cmd(cmd, cwd=None):
     """Run a command and exit on failure."""
@@ -22,6 +38,52 @@ def run_cmd(cmd, cwd=None):
     if result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
         sys.exit(result.returncode)
+
+def run_nightly(args, config, top_dir, script_dir, resource_dir, nightly_dir, output_dir, 
+                paper_dir, data_dir, output_data_dir, profile_json, is_local):
+    """Main nightly workflow - run profiler, generate graphs, and package output."""
+    # Run profiler
+    if args.update:
+        print("Skipping profile.py, updating front end")
+    else:
+        if not is_local:
+            os.environ["LLVM_SYS_180_PREFIX"] = "/usr/lib/llvm-18/"
+            run_cmd("make runtime")
+        
+        print(f"Running profile with data_dir={data_dir}, bril_dir={args.benchmark_dir}, parallel={args.parallel}")
+        run_profile(str(data_dir), args.benchmark_dir, config, parallel=args.parallel)
+
+    # Generate the plots
+    print("Generating graphs...")
+    make_graphs(str(output_dir), str(paper_dir), str(profile_json), "benchmarks/passing", config)
+
+    # Generate latex after running the profiler (depends on profile.json)
+    print("Generating line counts...")
+    generate_latex(str(data_dir))
+
+    os.chdir(script_dir)
+
+    # Update HTML index page
+    if resource_dir.exists():
+        for item in resource_dir.iterdir():
+            dest = output_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, dest)
+
+    # Copy data over to output
+    if data_dir.exists():
+        shutil.copytree(data_dir, output_data_dir, dirs_exist_ok=True)
+
+    # Gzip all JSON and SVGs in the nightly dir (only in non-local mode)
+    if not is_local:
+        if profile_json.exists():
+            run_cmd(f'gzip "{profile_json}"')
+        run_cmd(f'find "{output_dir}" -name "*.svg" -exec gzip {{}} +')
+        run_cmd(f'find "{output_dir}" -name "*.ll" -exec gzip {{}} +')
+
+    print("Nightly script completed successfully!")
 
 def main():
     parser = argparse.ArgumentParser(
@@ -107,48 +169,21 @@ def main():
 
     os.chdir(top_dir)
 
-    # Run profiler
-    if args.update:
-        print("Skipping profile.py, updating front end")
-    else:
-        if not is_local:
-            os.environ["LLVM_SYS_180_PREFIX"] = "/usr/lib/llvm-18/"
-            run_cmd("make runtime")
-        
-        print(f"Running profile with data_dir={data_dir}, bril_dir={args.benchmark_dir}, parallel={args.parallel}")
-        run_profile(str(data_dir), args.benchmark_dir, config, parallel=args.parallel)
+    # Set up logging to both console and file
+    log_file_handle = open(log_file, 'w')
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    sys.stdout = TeeWriter(log_file_handle, original_stdout)
+    sys.stderr = TeeWriter(log_file_handle, original_stderr)
 
-    # Generate the plots
-    print("Generating graphs...")
-    make_graphs(str(output_dir), str(paper_dir), str(profile_json), "benchmarks/passing", config)
-
-    # Generate latex after running the profiler (depends on profile.json)
-    print("Generating line counts...")
-    generate_latex(str(data_dir))
-
-    os.chdir(script_dir)
-
-    # Update HTML index page
-    if resource_dir.exists():
-        for item in resource_dir.iterdir():
-            dest = output_dir / item.name
-            if item.is_dir():
-                shutil.copytree(item, dest, dirs_exist_ok=True)
-            else:
-                shutil.copy2(item, dest)
-
-    # Copy data over to output
-    if data_dir.exists():
-        shutil.copytree(data_dir, output_data_dir, dirs_exist_ok=True)
-
-    # Gzip all JSON and SVGs in the nightly dir (only in non-local mode)
-    if not is_local:
-        if profile_json.exists():
-            run_cmd(f'gzip "{profile_json}"')
-        run_cmd(f'find "{output_dir}" -name "*.svg" -exec gzip {{}} +')
-        run_cmd(f'find "{output_dir}" -name "*.ll" -exec gzip {{}} +')
-
-    print("Nightly script completed successfully!")
+    try:
+        run_nightly(args, config, top_dir, script_dir, resource_dir, nightly_dir, 
+                    output_dir, paper_dir, data_dir, output_data_dir, profile_json, is_local)
+    finally:
+        # Restore original stdout/stderr and close log file
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+        log_file_handle.close()
 
 if __name__ == "__main__":
     main()

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -34,7 +34,7 @@ class TeeWriter:
 def run_cmd(cmd, cwd=None):
     """Run a command and exit on failure."""
     print(f"+ {cmd}")
-    result = subprocess.run(['bash', '-l', '-c', cmd], cwd=cwd)
+    result = subprocess.run(cmd, shell=True, cwd=cwd, shell=True)
     if result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
         sys.exit(result.returncode)

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -12,12 +12,4 @@ while [ -L "$src" ]; do
 done
 MYDIR="$(cd -P "$(dirname "$src")" && pwd)"
 
-
-# locally, skip rustup and tokei install
-# todo idk why this doesn't work from python
-if [ "$LOCAL" == "" ]; then
-  rustup update
-  cargo install tokei
-fi
-
 "$MYDIR/nightly.py" "$@"

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -12,4 +12,12 @@ while [ -L "$src" ]; do
 done
 MYDIR="$(cd -P "$(dirname "$src")" && pwd)"
 
+
+# locally, skip rustup and tokei install
+# todo idk why this doesn't work from python
+if [ "$LOCAL" == "" ]; then
+  rustup update
+  cargo install tokei
+fi
+
 "$MYDIR/nightly.py" "$@"

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -12,4 +12,4 @@ while [ -L "$src" ]; do
 done
 MYDIR="$(cd -P "$(dirname "$src")" && pwd)"
 
-exec "$MYDIR/nightly.py" "$@"
+"$MYDIR/nightly.py" "$@"

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -1,26 +1,7 @@
 #!/bin/bash
-# The primary purpose of this script is to run all the tests and upload 
-# the results to the nightly-results server. It also generates some HTML
-# to display the equiderivability tests in a nicely-formatted way.
-
-# Takes no arguments, unless in LOCAL mode
-# see infra/localnightly.sh for an example of how to run this script locally
-
-echo "Beginning eggcc nightly script..."
-
-# -x: before executing each command, print it
-# -e: exit immediately upon first error
-set -x -e
-# if anything in a pipeline fails, fail the whole pipeline
-set -o pipefail
-
-export PATH=~/.cargo/bin:$PATH
-
-# locally, skip rustup and tokei install
-if [ "$LOCAL" == "" ]; then
-  rustup update
-  cargo install tokei
-fi
+# Thin wrapper that passes all arguments to nightly.py
+# See nightly.py for the actual implementation
+# Do not edit
 
 # determine physical directory of this script
 src="${BASH_SOURCE[0]}"
@@ -31,78 +12,4 @@ while [ -L "$src" ]; do
 done
 MYDIR="$(cd -P "$(dirname "$src")" && pwd)"
 
-# eggcc paths
-TOP_DIR="$MYDIR/.."
-RESOURCE_DIR="$MYDIR/nightly-resources"
-
-# Nightly run directories. OUTPUT_DIR is where results go. Other temporary files can go in NIGHTLY_DIR.
-NIGHTLY_DIR="$TOP_DIR/nightly"
-# Output generated from data, such as graphs and the resulting report
-OUTPUT_DIR="$NIGHTLY_DIR/output"
-# Output for paper figures, macros
-PAPER_DIR="$NIGHTLY_DIR/output/paper"
-# data_dir stays even when regenerating output with --update
-DATA_DIR="$TOP_DIR/nightly/data" # data from the run stored here
-# we copy the data to output for archiving
-OUTPUT_DATA_DIR="$OUTPUT_DIR/data" # copy the data to output
-# stores llvm svgs for the website
-LLVM_DIR="$DATA_DIR/llvm"
-LOG_FILE="$OUTPUT_DIR/log.txt"
-PROFILE_JSON="$DATA_DIR/profile.json"
-
-# Make sure we're in the right place
-cd $MYDIR
-echo "Switching to nighly script directory: $MYDIR"
-
-# Clean previous nightly run
-# CAREFUL using -f
-if [ "$1" == "--update" ]; then
-  echo "updating front end only (output folder) due to --update flag"
-  rm -rf $OUTPUT_DIR
-  mkdir -p "$OUTPUT_DIR" "$PAPER_DIR"
-else
-  rm -rf $NIGHTLY_DIR
-  # Prepare output directories
-  mkdir -p "$NIGHTLY_DIR" "$NIGHTLY_DIR" "$OUTPUT_DIR" "$DATA_DIR" "$LLVM_DIR" "$PAPER_DIR"
-fi
-
-
-
-pushd $TOP_DIR
-
-# Run profiler.
-# locally, run on argument
-if [ "$1" == "--update" ]; then
-  echo "skipping profile.py, updating front end"
-elif [ "$LOCAL" != "" ]; then
-  ./infra/profile.py "$DATA_DIR" "$@" 2>&1 | tee "$LOG_FILE"
-else
-  export LLVM_SYS_180_PREFIX="/usr/lib/llvm-18/"
-  make runtime
-  # run on all benchmarks in nightly
-  ./infra/profile.py "$DATA_DIR" benchmarks/passing  2>&1 | tee "$LOG_FILE"
-fi
-
-# CFGs now generated inside profile.py (removed separate generate_cfgs.py call)
-
-# generate the plots
-# needs to know what the benchmark suites are
-./infra/graphs.py  "$OUTPUT_DIR" "$PAPER_DIR" "$PROFILE_JSON" benchmarks/passing 2>&1 | tee "$LOG_FILE"
-
-# Generate latex after running the profiler (depends on profile.json)
-./infra/generate_line_counts.py "$DATA_DIR" 2>&1 | tee "$LOG_FILE"
-
-popd
-
-# Update HTML index page.
-cp "$RESOURCE_DIR"/* "$OUTPUT_DIR"
-
-# copy data over to output
-cp -r "$DATA_DIR" "$OUTPUT_DATA_DIR"
-
-# gzip all JSON and svgs in the nightly dir
-if [ "$LOCAL" == "" ]; then
-  gzip "$PROFILE_JSON"
-  find "$OUTPUT_DIR" -name '*.svg' -exec gzip {} +
-  find "$OUTPUT_DIR" -name '*.ll' -exec gzip {} +
-fi
+exec "$MYDIR/nightly.py" "$@"

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -76,7 +76,7 @@ _base_treatments = [
   "eggcc-WITHCTX-O0-O0",
 ]
 
-# Treatments that require Gurobi (only run in paper mode)
+# Treatments that require Gurobi (when --use-gurobi or --paper is passed)
 _gurobi_treatments = [
   "eggcc-tiger-ILP-O0-O0",
   "eggcc-tiger-ILP-NOMIN-O0-O0",

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -12,33 +12,39 @@ import resource
 import concurrent.futures
 import time
 from generate_cfgs import make_cfgs
+from dataclasses import dataclass
 
 
-# testing mode takes much fewer samples than the real eval in the paper
-IS_TESTING_MODE = True
-# whether to include Gurobi treatments (requires Gurobi to be installed)
-USE_GUROBI = False
-
-def eggcc_timeout_secs():
-  if IS_TESTING_MODE:
-    return 10 * 60 # 10 minutes
-  else:
-    return 6 * 60 * 60 # 6 hours (ILP can take a long time, timing out on lots of regions after 5 min)
-
-def num_warmup_samples():
-  if IS_TESTING_MODE:
-    return 2
-  return 10
+@dataclass
+class NightlyConfig:
+  """Configuration for nightly runs."""
+  paper_mode: bool = False
+  use_gurobi: bool = False
   
-def num_samples():
-  if IS_TESTING_MODE:
-    return 100
-  return 200
+  @property
+  def eggcc_timeout_secs(self):
+    if not self.paper_mode:
+      return 10 * 60 # 10 minutes
+    else:
+      return 6 * 60 * 60 # 6 hours (ILP can take a long time, timing out on lots of regions after 5 min)
 
-def percent_regions():
-  if IS_TESTING_MODE:
-    return 1.0
-  return 100.0
+  @property
+  def num_warmup_samples(self):
+    if not self.paper_mode:
+      return 2
+    return 10
+  
+  @property
+  def num_samples(self):
+    if not self.paper_mode:
+      return 100
+    return 200
+
+  @property
+  def percent_regions(self):
+    if not self.paper_mode:
+      return 1.0
+    return 100.0
 
 
 def average(lst):
@@ -78,9 +84,9 @@ _gurobi_treatments = [
   "eggcc-tiger-ILP-COMPARISON", 
 ]
 
-def get_treatments():
-  """Returns the list of treatments to run based on the current mode.
-  When USE_GUROBI is True, includes Gurobi treatments; otherwise only base treatments."""
+def get_treatments(config: NightlyConfig):
+  """Returns the list of treatments to run based on the config.
+  When config.use_gurobi is True, includes Gurobi treatments; otherwise only base treatments."""
   result = _base_treatments.copy()
   if TO_ABLATE != "":
     result.extend([
@@ -88,7 +94,7 @@ def get_treatments():
       "eggcc-ablation-O3-O0",
       "eggcc-ablation-O3-O3",
     ])
-  if USE_GUROBI:
+  if config.use_gurobi:
     result.extend(_gurobi_treatments)
   return result
 
@@ -213,7 +219,7 @@ def get_eggcc_options(benchmark):
     case "eggcc-tiger-O0-O0":
       return (f'optimize --use-tiger --non-weakly-linear', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
     case "eggcc-tiger-ILP-COMPARISON":
-      return (f'optimize --use-tiger --non-weakly-linear --time-ilp --percent-regions {percent_regions()}', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
+      return (f'optimize --use-tiger --non-weakly-linear --time-ilp --percent-regions {benchmark.config.percent_regions}', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
     case "eggcc-tiger-ILP-O0-O0":
       return (f'optimize --use-tiger --tiger-ilp --non-weakly-linear', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
     case "eggcc-tiger-ILP-CBC-O0-O0":
@@ -231,7 +237,7 @@ def get_eggcc_options(benchmark):
     
 
 class Benchmark:
-  def __init__(self, path, treatment, index, total):
+  def __init__(self, path, treatment, index, total, config: NightlyConfig):
     self.path = path
     # assert the file doesn't have any dots in the name besides the last
     if path.split("/")[-1].count(".") != 1:
@@ -244,6 +250,7 @@ class Benchmark:
     # total number of benchmarks being run
     self.total = total
     self.is_last_before_ilp = False
+    self.config = config
 
 def benchmark_profile_dir(name):
   return f'{TMP_DIR}/{name}'
@@ -286,16 +293,17 @@ def optimize(benchmark):
     }
 
   enforce_memory_limit = _should_enforce_memory_limit(benchmark.treatment)
+  timeout_secs = benchmark.config.eggcc_timeout_secs
   try:
     process = run_with_timeout_killing_tree(
       cmd1,
-      eggcc_timeout_secs(),
+      timeout_secs,
       apply_memory_limits=enforce_memory_limit,
     )
   except subprocess.TimeoutExpired:
     # Timeouts are failures
-    print(f'[{benchmark.index}/{benchmark.total}] Timeout running {cmd1} after {eggcc_timeout_secs()} seconds', flush=True)
-    failure_data["error"] = f'Timeout running {cmd1} after {eggcc_timeout_secs()} seconds'
+    print(f'[{benchmark.index}/{benchmark.total}] Timeout running {cmd1} after {timeout_secs} seconds', flush=True)
+    failure_data["error"] = f'Timeout running {cmd1} after {timeout_secs} seconds'
     return failure_data
 
   if _memory_limit_exceeded(process.returncode):
@@ -414,10 +422,10 @@ def bench(benchmark):
       resulting_num_cycles = []
 
       # take some warmup cycles
-      while len(warmup_cycles) < num_warmup_samples():
+      while len(warmup_cycles) < benchmark.config.num_warmup_samples:
         warmup_cycles.append(take_sample(cmd, benchmark))
 
-      num_to_run = num_samples()
+      num_to_run = benchmark.config.num_samples
 
       while True:
         resulting_num_cycles.append(take_sample(cmd, benchmark))
@@ -499,38 +507,21 @@ def build_eggcc():
     print("Failed to build eggcc")
     exit(1)
 
-if __name__ == '__main__':
+def run_profile(data_dir, bril_dir, config: NightlyConfig, parallel=False):
+  """Main entry point for running the profiler as a library."""
+  global DATA_DIR
+  DATA_DIR = data_dir
+  
   start_time = time.perf_counter()
-  # expect two arguments
-  if len(os.sys.argv) < 3:
-    print("Usage: profile.py <output_directory> <bril_directory> <--parallel> <--paper> <--use-gurobi>")
-    exit(1)
 
-  # check for paper flag
-  for arg in os.sys.argv:
-    if arg == "--paper":
-      IS_TESTING_MODE = False
-      USE_GUROBI = True  # paper mode enables Gurobi by default
-
-  # check for use-gurobi flag (can be used independently of paper mode)
-  for arg in os.sys.argv:
-    if arg == "--use-gurobi":
-      USE_GUROBI = True
-
-  # Get treatments based on mode
-  treatments = get_treatments()
-  if IS_TESTING_MODE:
+  # Get treatments based on config
+  treatments = get_treatments(config)
+  if not config.paper_mode:
     print("WARNING: Running in testing mode with reduced samples. Pass the --paper flag for the final paper results.")
-  if not USE_GUROBI:
+  if not config.use_gurobi:
     print("INFO: Gurobi treatments disabled. Pass --use-gurobi or --paper to enable them.")
 
-  # running benchmarks sequentially for more reliable results
-  # can set this to true for testing
-  isParallelBenchmark = False
-  # detect parallel flag
-  for arg in os.sys.argv:
-    if arg == "--parallel":
-      isParallelBenchmark = True
+  isParallelBenchmark = parallel
 
   # Create tmp directory for intermediate files
   try:
@@ -543,9 +534,6 @@ if __name__ == '__main__':
   # build eggcc
   build_eggcc()
 
-
-
-  DATA_DIR, bril_dir  = os.sys.argv[1:3]
   profiles = []
   # if it is a directory get all files
   if os.path.isdir(bril_dir):
@@ -567,7 +555,7 @@ if __name__ == '__main__':
   total = len(profiles) * len(treatments)
   for treatment in treatments:
     for benchmark_path in profiles:
-      to_run.append(Benchmark(benchmark_path, treatment, index, total))
+      to_run.append(Benchmark(benchmark_path, treatment, index, total, config))
       index += 1
 
   benchmark_names = set([benchmark.name for benchmark in to_run])
@@ -638,8 +626,8 @@ if __name__ == '__main__':
       bench_data[path] = _bench_data
 
   nightly_data = aggregate(compile_data, bench_data, paths)
-  with open(f"{DATA_DIR}/profile.json", "w") as profile:
-    json.dump(nightly_data, profile, indent=2)
+  with open(f"{DATA_DIR}/profile.json", "w") as profile_file:
+    json.dump(nightly_data, profile_file, indent=2)
 
   # Parallel CFG generation only for successful
   with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -16,6 +16,8 @@ from generate_cfgs import make_cfgs
 
 # testing mode takes much fewer samples than the real eval in the paper
 IS_TESTING_MODE = True
+# whether to include Gurobi treatments (requires Gurobi to be installed)
+USE_GUROBI = False
 
 def eggcc_timeout_secs():
   if IS_TESTING_MODE:
@@ -48,7 +50,9 @@ TO_ABLATE = "" # change to a ruleset to ablate
 # use for running a subset of the treatments
 # disables checks that ensure the data is complete
 UNSAFE_TREATMENTS = False
-treatments = [
+
+# Base treatments that don't require Gurobi
+_base_treatments = [
   "rvsdg-round-trip-to-executable",
   "llvm-O0-O0",
   "llvm-O1-O0",
@@ -61,14 +65,32 @@ treatments = [
   "eggcc-O3-O3",
   "eggcc-tiger-WL-O0-O0",
   "eggcc-tiger-O0-O0",
-  "eggcc-tiger-ILP-O0-O0",
   "eggcc-tiger-ILP-CBC-O0-O0",
-  "eggcc-tiger-ILP-NOMIN-O0-O0",
   #"eggcc-tiger-ILP-WITHCTX-O0-O0", #disabled for now
   "eggcc-WITHCTX-O0-O0",
+]
+
+# Treatments that require Gurobi (only run in paper mode)
+_gurobi_treatments = [
+  "eggcc-tiger-ILP-O0-O0",
+  "eggcc-tiger-ILP-NOMIN-O0-O0",
   # run both tiger and ILP on the same egraphs, keep this last in the list
   "eggcc-tiger-ILP-COMPARISON", 
 ]
+
+def get_treatments():
+  """Returns the list of treatments to run based on the current mode.
+  When USE_GUROBI is True, includes Gurobi treatments; otherwise only base treatments."""
+  result = _base_treatments.copy()
+  if TO_ABLATE != "":
+    result.extend([
+      "eggcc-ablation-O0-O0",
+      "eggcc-ablation-O3-O0",
+      "eggcc-ablation-O3-O3",
+    ])
+  if USE_GUROBI:
+    result.extend(_gurobi_treatments)
+  return result
 
 example_subset_treatments = [
   "llvm-O0-O0",
@@ -78,13 +100,6 @@ example_subset_treatments = [
   "eggcc-tiger-O0-O0"
 ]
 
-
-if TO_ABLATE != "":
-  treatments.extend([
-    "eggcc-ablation-O0-O0",
-    "eggcc-ablation-O3-O0",
-    "eggcc-ablation-O3-O3",
-  ])
 
 # Where to output files that are needed for nightly report
 DATA_DIR = None
@@ -488,16 +503,26 @@ if __name__ == '__main__':
   start_time = time.perf_counter()
   # expect two arguments
   if len(os.sys.argv) < 3:
-    print("Usage: profile.py <output_directory> <bril_directory> <--parallel> <--paper>")
+    print("Usage: profile.py <output_directory> <bril_directory> <--parallel> <--paper> <--use-gurobi>")
     exit(1)
 
   # check for paper flag
   for arg in os.sys.argv:
     if arg == "--paper":
       IS_TESTING_MODE = False
+      USE_GUROBI = True  # paper mode enables Gurobi by default
 
+  # check for use-gurobi flag (can be used independently of paper mode)
+  for arg in os.sys.argv:
+    if arg == "--use-gurobi":
+      USE_GUROBI = True
+
+  # Get treatments based on mode
+  treatments = get_treatments()
   if IS_TESTING_MODE:
     print("WARNING: Running in testing mode with reduced samples. Pass the --paper flag for the final paper results.")
+  if not USE_GUROBI:
+    print("INFO: Gurobi treatments disabled. Pass --use-gurobi or --paper to enable them.")
 
   # running benchmarks sequentially for more reliable results
   # can set this to true for testing

--- a/infra/profile.py
+++ b/infra/profile.py
@@ -33,6 +33,11 @@ def num_samples():
     return 100
   return 200
 
+def percent_regions():
+  if IS_TESTING_MODE:
+    return 1.0
+  return 100.0
+
 
 def average(lst):
   return sum(lst) / len(lst)
@@ -193,7 +198,7 @@ def get_eggcc_options(benchmark):
     case "eggcc-tiger-O0-O0":
       return (f'optimize --use-tiger --non-weakly-linear', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
     case "eggcc-tiger-ILP-COMPARISON":
-      return (f'optimize --use-tiger --non-weakly-linear --time-ilp', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
+      return (f'optimize --use-tiger --non-weakly-linear --time-ilp --percent-regions {percent_regions()}', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
     case "eggcc-tiger-ILP-O0-O0":
       return (f'optimize --use-tiger --tiger-ilp --non-weakly-linear', f'--run-mode llvm --optimize-egglog false --optimize-bril-llvm O0_O0')
     case "eggcc-tiger-ILP-CBC-O0-O0":

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,10 @@ fn parse_percent_regions(s: &str) -> Result<f64, String> {
         return Err(format!("Value must be finite, got: {}", s));
     }
     if !(0.0..=100.0).contains(&value) {
-        return Err(format!("Value must be between 0.0 and 100.0, got: {}", value));
+        return Err(format!(
+            "Value must be between 0.0 and 100.0, got: {}",
+            value
+        ));
     }
     Ok(value)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,17 @@ use dag_in_context::{EggccConfig, IlpSolver, Schedule};
 use eggcc::util::{visualize, InterpMode, LLVMOptLevel, Run, RunMode, TestProgram};
 use std::{ffi::OsStr, iter::once, path::PathBuf};
 
+fn parse_percent_regions(s: &str) -> Result<f64, String> {
+    let value: f64 = s.parse().map_err(|_| format!("Invalid number: {}", s))?;
+    if !value.is_finite() {
+        return Err(format!("Value must be finite, got: {}", s));
+    }
+    if !(0.0..=100.0).contains(&value) {
+        return Err(format!("Value must be between 0.0 and 100.0, got: {}", value));
+    }
+    Ok(value)
+}
+
 #[derive(Debug, Parser)]
 struct Args {
     /// A directory for debug output, including
@@ -88,7 +99,7 @@ struct Args {
     #[clap(long)]
     time_ilp: bool,
     /// Percentage of regions to run ILP timing on (0.0 to 100.0). Defaults to 100.0.
-    #[clap(long, default_value_t = 100.0)]
+    #[clap(long, default_value_t = 100.0, value_parser = parse_percent_regions)]
     percent_regions: f64,
     /// When provided, dump each e-graph we extract from into this directory.
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,9 @@ struct Args {
     tiger_ilp: bool,
     #[clap(long)]
     time_ilp: bool,
+    /// Percentage of regions to run ILP timing on (0.0 to 100.0). Defaults to 100.0.
+    #[clap(long, default_value_t = 100.0)]
+    percent_regions: f64,
     /// When provided, dump each e-graph we extract from into this directory.
     #[clap(long)]
     egraph_out_dir: Option<PathBuf>,
@@ -157,6 +160,7 @@ fn main() {
             use_tiger: args.use_tiger,
             tiger_ilp: args.tiger_ilp,
             time_ilp: args.time_ilp,
+            percent_regions: args.percent_regions,
             use_context: args.with_context,
             ilp_minimize_objective: !args.ilp_no_minimize,
             ilp_solver: args.ilp_solver,


### PR DESCRIPTION
This PR refactors the nightly.sh script, rewriting it in python so we can parse arguments nicely. 
It adds --use-gurobi as a flag that allows you to enable gurobi use. The existing `--paper` flag enables this by default so you can reproduce the paper. 

It also adds --percent-regions to specify how many regions to run on, set to 100 percent for the `--paper` flag. This is necessary because the nightly is too long without it. 