### PR TITLE
Move the artifact VM to Ubuntu 24.04 (and trim disk to 40 GB)

### DIFF
--- a/artifact/README.md
+++ b/artifact/README.md
@@ -24,7 +24,7 @@ infeasibility (CBC also times out on every PolyBench benchmark).
 
 - **Host:** VirtualBox 7.2+ (free; macOS/ARM and Windows/ARM supported). Import
   `eggcc-artifact.ova` and start it.
-- **Guest:** Ubuntu 22.04 Desktop, 4 vCPUs / 8 GB RAM. Login `eggcc` / `eggcc`.
+- **Guest:** Ubuntu 24.04 Desktop, 4 vCPUs / 8 GB RAM. Login `eggcc` / `eggcc`.
 - **Your home folder is the workspace.** It holds only: `README.md` (a short quick start),
   `reproduce.sh`, the source in `eggcc/`, and the **figures** — already generated, so you
   can open them right away.

--- a/infra/BUILDING.md
+++ b/infra/BUILDING.md
@@ -21,7 +21,7 @@ cd infra
 ```
 
 `--pregenerate smoke` keeps the build fast — it skips the ~3–4 h CBC full run you'd just
-overwrite with the Gurobi run in step 2. `build_vm.sh` downloads the Ubuntu 22.04 **Server**
+overwrite with the Gurobi run in step 2. `build_vm.sh` downloads the Ubuntu 24.04 **Server**
 ISO (~2 GB) and unattended-installs it (VirtualBox drives the server installer reliably; the
 desktop ISO's newer installer fails at VBox's "prepare" step). It then provisions over SSH:
 `provision.sh` adds a minimal GNOME desktop so the VM is graphical, installs the deps, builds
@@ -71,7 +71,7 @@ Then submit `eggcc-artifact.ova` (e.g. upload to Zenodo for a DOI, then the AE H
 environment had no VirtualBox). If a `VBoxManage` step fails on your host, build the VM by
 hand instead:
 
-1. Create an Ubuntu 22.04 Desktop VM in the VirtualBox GUI (4 vCPUs, 8 GB RAM, 60 GB disk;
+1. Create an Ubuntu 24.04 Desktop VM in the VirtualBox GUI (4 vCPUs, 8 GB RAM, 40 GB disk;
    user `eggcc`).
 2. Inside the VM:
    ```bash

--- a/infra/build_vm.sh
+++ b/infra/build_vm.sh
@@ -7,7 +7,7 @@
 #                 [--iso-url URL] [--workdir DIR]
 #
 # It creates a VirtualBox VM (4 vCPUs / 8 GB RAM by default) and unattended-installs the
-# Ubuntu 22.04 *Server* ISO -- VirtualBox drives the server installer's autoinstall reliably,
+# Ubuntu 24.04 *Server* ISO -- VirtualBox drives the server installer's autoinstall reliably,
 # whereas the desktop ISO's newer installer often fails at VBoxManage's "prepare" step. It
 # then runs infra/provision.sh inside over SSH, which adds a minimal GNOME desktop (so the
 # VM is graphical for viewing PDFs), installs every dependency, builds eggcc, and
@@ -30,10 +30,10 @@ VM_NAME="eggcc-artifact"
 EGGCC_REF="oflatt-gurobi-optional"
 CPUS=4
 RAM_MB=8192
-DISK_MB=61440
+DISK_MB=40960
 SSH_PORT=2222
 PREGENERATE="full"
-ISO_URL="https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso"
+ISO_URL="https://releases.ubuntu.com/24.04/ubuntu-24.04.4-live-server-amd64.iso"
 WORKDIR="$HOME/eggcc-artifact-build"
 VM_USER="eggcc"
 VM_PASS="eggcc"
@@ -67,7 +67,7 @@ PUBKEY="$(cat "$KEY.pub")"
 
 # 2. Create + configure the VM -----------------------------------------------------------
 if ! VBoxManage showvminfo "$VM_NAME" >/dev/null 2>&1; then
-  VBoxManage createvm --name "$VM_NAME" --ostype Ubuntu22_LTS_64 --register
+  VBoxManage createvm --name "$VM_NAME" --ostype Ubuntu24_LTS_64 --register
   VBoxManage createhd --filename "$WORKDIR/$VM_NAME.vdi" --size "$DISK_MB"
   VBoxManage storagectl "$VM_NAME" --name SATA --add sata --controller IntelAhci
   VBoxManage storageattach "$VM_NAME" --storagectl SATA --port 0 --device 0 --type hdd \

--- a/infra/provision.sh
+++ b/infra/provision.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Provision a fresh Ubuntu 22.04 (jammy) machine into the eggcc artifact:
+# Provision a fresh Ubuntu 24.04 (noble) or 22.04 (jammy) machine into the eggcc artifact:
 # installs every dependency, clones eggcc, builds it, and pre-generates the figures.
 # Designed to run unattended (all apt installs use -y). Safe to re-run.
 #
 # This is what infra/build_vm.sh runs inside the guest. You can also run it by hand on
-# any fresh Ubuntu 22.04 machine or VM:
+# any fresh Ubuntu 24.04 / 22.04 machine or VM:
 #
 #   bash provision.sh [--ref REF] [--repo URL] [--dir DIR] [--pregenerate full|smoke|none]
 #
@@ -58,7 +58,9 @@ fi
 # Mirrors install_ubuntu.sh but non-interactively, using a modern signed keyring.
 curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
   | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
-echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
+# Match the LLVM repo to this machine's Ubuntu release (jammy=22.04, noble=24.04).
+LLVM_CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME:-jammy}")"
+echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/${LLVM_CODENAME}/ llvm-toolchain-${LLVM_CODENAME}-18 main" \
   | sudo tee /etc/apt/sources.list.d/llvm-18.list >/dev/null
 sudo apt-get update -y
 sudo apt-get install -y \


### PR DESCRIPTION
Moves the artifact VM to Ubuntu 24.04 and trims the default disk.

Follows up on #800 (which restored the VM). You built VirtualBox with Ubuntu 24.04, but the scripts targeted 22.04 (jammy) — most importantly `provision.sh` pinned the LLVM 18 apt repo to `jammy`, which is wrong on a 24.04 (noble) guest.

### Changes
- **`provision.sh`** — detect the codename from `/etc/os-release` and point the LLVM 18 repo at it (`http://apt.llvm.org/${LLVM_CODENAME}/`), instead of hardcoding `jammy`. Works on **both** 22.04 and 24.04 now. (Verified apt.llvm.org serves `noble` clang-18/llvm-18.)
- **`build_vm.sh`** — default ISO → `ubuntu-24.04.4-live-server-amd64.iso`; `--ostype Ubuntu24_LTS_64`.
- **Docs** — guest bumped to Ubuntu 24.04.
- **Disk** — default shrunk from **60 GB → 40 GB**. The VDI is dynamically allocated, so 60 GB was only a ceiling (the `.vdi`/`.ova` grow to actual use); a full build + run uses ~25–30 GB, so 40 GB is a comfortable cap.

### Notes
- Not build-tested here (this environment can't run the VM); `provision.sh`'s dependency steps are unchanged apart from the codename, and CBC/Rust/Python are release-agnostic.
- To confirm real disk use in your VM after provisioning: `df -h /` (and `du -sh ~/eggcc/target ~/.rustup ~/.cargo ~/.eggcc-venv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
